### PR TITLE
Remove unused include in cc_helpers.cc

### DIFF
--- a/src/cc_helpers.cc
+++ b/src/cc_helpers.cc
@@ -1,5 +1,3 @@
-#include <gtest/gtest.h>
-
 #include "support.h"
 #include "certifier.h"
 #include "simulated_enclave.h"


### PR DESCRIPTION
cc_helpers.cc doesn't contain tests and shouldn't include gtest.h. This patch allows building the Certifier in contstrained environments (like enclaves) where gtest is not available.