### PR TITLE
Fix the file_size() return value

### DIFF
--- a/src/cc_helpers.cc
+++ b/src/cc_helpers.cc
@@ -343,6 +343,9 @@ bool cc_trust_data::save_store() {
 bool cc_trust_data::fetch_store() {
 
   int size_protected_blob = file_size(store_file_name_);
+  if (size_protected_blob < 0) {
+    return false;
+  }
   byte protected_blob[size_protected_blob];
   int size_unprotected_blob = size_protected_blob;
   byte unprotected_blob[size_unprotected_blob];

--- a/src/simulated_enclave.cc
+++ b/src/simulated_enclave.cc
@@ -79,6 +79,9 @@ bool simulated_Init(const string& asn1_policy_cert, const string& attest_key_fil
 
   // get attest key
   int at_size = file_size(attest_key_file);
+  if (at_size < 0) {
+    return false;
+  }
   byte at[at_size];
   if (!read_file(attest_key_file, &at_size, at)) {
     return false;
@@ -97,6 +100,9 @@ bool simulated_Init(const string& asn1_policy_cert, const string& attest_key_fil
   }
 
   int a_size = file_size(attest_key_signed_claim_file);
+  if (a_size < 0) {
+      return false;
+  }
   byte a_buf[a_size];
   if (!read_file(attest_key_signed_claim_file, &a_size, a_buf)) {
     printf("Can't read attest claim\n");

--- a/src/support.cc
+++ b/src/support.cc
@@ -143,9 +143,9 @@ int file_size(const string& file_name) {
   struct stat file_info;
 
   if (stat(file_name.c_str(), &file_info) != 0)
-    return false;
+    return -1;
   if (!S_ISREG(file_info.st_mode))
-    return false;
+    return -1;
   return (int)file_info.st_size;
 }
 

--- a/src/test_channel.cc
+++ b/src/test_channel.cc
@@ -148,6 +148,10 @@ int main(int an, char** av) {
   string policy_cert_file(FLAGS_data_dir);
   policy_cert_file.append(FLAGS_policy_cert_file);
   int sz = file_size(policy_cert_file);
+  if (sz < 0) {
+    printf("Can't find policy cert\n");
+    return 1;
+  }
   byte policy_cert_buf[sz];
   if (!read_file(policy_cert_file, &sz, policy_cert_buf)) {
     printf("Can't read policy cert\n");
@@ -160,6 +164,10 @@ int main(int an, char** av) {
   string policy_key_file(FLAGS_data_dir);
   policy_key_file.append(FLAGS_policy_key_file);
   sz = file_size(policy_key_file);
+  if (sz < 0) {
+    printf("Can't find policy key %s\n", policy_key_file.c_str());
+    return 1;
+  }
   byte policy_key_buf[sz];
   if (!read_file(policy_key_file, &sz, policy_key_buf)) {
     printf("Can't read policy key %s\n", policy_key_file.c_str());
@@ -172,6 +180,10 @@ int main(int an, char** av) {
   string auth_key_file(FLAGS_data_dir);
   auth_key_file.append(FLAGS_auth_key_file);
   sz = file_size(auth_key_file);
+  if (sz < 0) {
+    printf("Can't find auth key\n");
+    return 1;
+  }
   byte auth_key_buf[sz];
   if (!read_file(auth_key_file, &sz, auth_key_buf)) {
     printf("Can't read auth key\n");

--- a/src/test_support.cc
+++ b/src/test_support.cc
@@ -21,6 +21,9 @@ bool read_trusted_binary_measurements_and_sign(string& file_name, key_message& p
         signed_claim_sequence* list) {
 
   int size = file_size(file_name);
+  if (size < 0) {
+    return false;
+  }
   byte file_contents[size];
 
   if (!read_file(file_name, &size, file_contents)) {


### PR DESCRIPTION
The file_size() function should return negative values when the specified file is missing.