### PR TITLE
Fix checking the return value of SSL_connect()

### DIFF
--- a/src/cc_helpers.cc
+++ b/src/cc_helpers.cc
@@ -1619,8 +1619,10 @@ printf("ADDING\n");
   }
 
   // SSL_connect - initiate the TLS/SSL handshake with an TLS/SSL server
-  if (SSL_connect(ssl_) == 0) {
-    printf("ssl_connect failed\n");
+  int ret = SSL_connect(ssl_);
+  if (ret <= 0) {
+    int err = SSL_get_error(ssl_, ret);
+    printf("ssl_connect failed, err: %d\n", err);
     return false;
   }
 


### PR DESCRIPTION
SSL_connect returns 1 on sucess and <= 0 on failure. If the peer ceritifate is missing or invalid, SSL_connect returns -1.