### PR TITLE
Remove 'path' parameter of simpleserver

### DIFF
--- a/application_service/instructions.txt
+++ b/application_service/instructions.txt
@@ -136,7 +136,6 @@ Step 9: Provision the service files
 Step 10: Start certifier service
     cd $APP_SERVICE_DIR/service
     $CERTIFIER_PROTOTYPE/certifier_service/simpleserver \
-      --path=$APP_SERVICE_DIR/service \
       --policyFile=policy.bin --readPolicy=true
 
 

--- a/application_service/script
+++ b/application_service/script
@@ -62,7 +62,6 @@ cp policy_key_file.bin policy_cert_file.bin policy.bin attest_key_file.bin platf
 # run certifier_service
 cd $APP_SERVICE_DIR/service
 $CERTIFIER_PROTOTYPE/certifier_service/simpleserver \
-  --path=$APP_SERVICE_DIR/service \
   --policyFile=policy.bin --readPolicy=true
 
 # run app service

--- a/certifier_service/simpleserver.go
+++ b/certifier_service/simpleserver.go
@@ -35,8 +35,6 @@ import (
         certlib "github.com/jlmucb/crypto/v2/certifier-framework-for-confidential-computing/certifier_service/certlib"
 )
 
-var simpleServerPath = flag.String("path", "./SimpleServerFiles",
-        "path to Server files")
 var serverHost = flag.String("host", "localhost", "address for client/server")
 var serverPort = flag.String("port", "8123", "port for client/server")
 

--- a/sample_apps/analytics_example/README.md
+++ b/sample_apps/analytics_example/README.md
@@ -137,7 +137,6 @@ Step 9: Start the Certifier Service
 ```bash
 cd $EXAMPLE_DIR/service
 $CERTIFIER_PROTOTYPE/certifier_service/simpleserver \
---path=$EXAMPLE_DIR/service \
 --policyFile=policy.bin --readPolicy=true
 ```
 

--- a/sample_apps/asylo_secure_grpc/README.md
+++ b/sample_apps/asylo_secure_grpc/README.md
@@ -161,7 +161,6 @@ Run certifier service (in 1st window)
 ```
 cd $EXAMPLE_DIR/service
 $CERTIFIER_PROTOTYPE/certifier_service/simpleserver \
-      --path=$EXAMPLE_DIR/service \
       --policyFile=policy.bin --readPolicy=true
 ```
 

--- a/sample_apps/asylo_secure_grpc/script
+++ b/sample_apps/asylo_secure_grpc/script
@@ -94,7 +94,6 @@ go build simpleserver.go
 # Run certifier service (in 1st window)
 cd $EXAMPLE_DIR/service
 $CERTIFIER_PROTOTYPE/certifier_service/simpleserver \
-      --path=$EXAMPLE_DIR/service \
       --policyFile=policy.bin --readPolicy=true
 
 # Run GRPC Server (in 2nd window)

--- a/sample_apps/simple_app/instructions.txt
+++ b/sample_apps/simple_app/instructions.txt
@@ -153,7 +153,6 @@ Step 13: Start the Certifier Service
   In a new terminal window:
     cd $EXAMPLE_DIR/service
     $CERTIFIER_PROTOTYPE/certifier_service/simpleserver \
-      --path=$EXAMPLE_DIR/service \
       --policyFile=policy.bin --readPolicy=true
 
 

--- a/sample_apps/simple_app/script
+++ b/sample_apps/simple_app/script
@@ -79,7 +79,6 @@ go build simpleserver.go
 #run server
 cd $EXAMPLE_DIR/service
 $CERTIFIER_PROTOTYPE/certifier_service/simpleserver \
-      --path=$EXAMPLE_DIR/service \
       --policyFile=policy.bin --readPolicy=true
 
 # initialize client app

--- a/sample_apps/simple_app_under_app_service/instructions.txt
+++ b/sample_apps/simple_app_under_app_service/instructions.txt
@@ -155,7 +155,6 @@ Step 14: Start the Certifier Service for the built application service
   In a new terminal window:
     cd $APP_SERVICE_DIR/service
     $CERTIFIER_PROTOTYPE/certifier_service/simpleserver \
-      --path=$SERVICE_EXAMPLE_DIR/service \
       --policyFile=policy.bin --readPolicy=true
 
 
@@ -189,7 +188,6 @@ Under the sev enclave:
 Step 16: In a new window, run the Certifier Service for simple_app_under_app_service
     cd $SERVICE_EXAMPLE_DIR/service
     $CERTIFIER_PROTOTYPE/certifier_service/simpleserver \
-      --path=$SERVICE_EXAMPLE_DIR/service \
       --policyFile=policy.bin --readPolicy=true
 
 

--- a/sample_apps/simple_app_under_app_service/script
+++ b/sample_apps/simple_app_under_app_service/script
@@ -102,7 +102,6 @@ $CERTIFIER_PROTOTYPE/utilities/make_signed_claim_from_vse_clause.exe --vse_file=
 $CERTIFIER_PROTOTYPE/utilities/print_signed_claim.exe --input=platform_attest_endorsement.bin
 cp policy_key_file.bin policy_cert_file.bin policy.bin attest_key_file.bin platform_attest_endorsement.bin platform_key_file.bin app_service.measurement $APP_SERVICE_DIR/service
 $CERTIFIER_PROTOTYPE/certifier_service/simpleserver \
-  --path=$APP_SERVICE_DIR/service \
   --policyFile=policy.bin --readPolicy=true
 cd $APP_SERVICE_DIR
 $APP_SERVICE_DIR/app_service.exe \
@@ -120,7 +119,6 @@ $APP_SERVICE_DIR/app_service.exe \
 #run certifier service server
 cd $SERVICE_EXAMPLE_DIR/service
 $CERTIFIER_PROTOTYPE/certifier_service/simpleserver \
-      --path=$SERVICE_EXAMPLE_DIR/service \
       --policyFile=policy.bin --readPolicy=true
 
 # Run the apps

--- a/sample_apps/simple_app_under_sev/instructions.txt
+++ b/sample_apps/simple_app_under_sev/instructions.txt
@@ -341,7 +341,6 @@ Step 13: Start the Certifier Service
   In a new terminal window:
     cd $SEV_EXAMPLE_DIR/service
     $CERTIFIER_PROTOTYPE/certifier_service/simpleserver \
-      --path=$SEV_EXAMPLE_DIR/service \
       --policyFile=policy.bin --readPolicy=true
 
 

--- a/sample_apps/simple_app_under_sev/script
+++ b/sample_apps/simple_app_under_sev/script
@@ -73,7 +73,6 @@ go build simpleserver.go
 #run server
 cd $SEV_EXAMPLE_DIR/service
 $CERTIFIER_PROTOTYPE/certifier_service/simpleserver \
-      --path=$SEV_EXAMPLE_DIR/service \
       --policyFile=policy.bin --readPolicy=true
 
 # initialize client app


### PR DESCRIPTION
The 'path' parameter is not used and should be removed.