### PR TITLE
Pass correct addrlen to accept

### DIFF
--- a/src/cc_helpers.cc
+++ b/src/cc_helpers.cc
@@ -1362,12 +1362,12 @@ void server_dispatch(const string& host_name, int port,
   // For debug: SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER, verify_callback);
   //SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER, nullptr);
 
-  unsigned int len = 0;
   while (1) {
 #ifdef DEBUG
     printf("at accept\n");
 #endif
     struct sockaddr_in addr;
+    unsigned int len = sizeof(sockaddr_in);
     int client = accept(sock, (struct sockaddr*)&addr, &len);
     string my_role("server");
     secure_authenticated_channel nc(my_role);


### PR DESCRIPTION
The addrlen argument of accept() is used for both input and output, see "man 2 accept". It must be initialized to contain the size of the structure pointed by addr. Failing to do so results may result in obscure memory errors, especially with alternative libc implementations like oelibc.