### PR TITLE
DRAFT: Governance Documentation

### DIFF
--- a/CONTRIBUTOR_LADDER.md
+++ b/CONTRIBUTOR_LADDER.md
@@ -1,0 +1,86 @@
+# Contributor Ladder for Certifier Framework for Confidential Computing
+
+Hello! We are excited that you want to learn more about our project contributor ladder! This contributor ladder outlines the different contributor roles within the project, along with the responsibilities and privileges that come with them. Community members generally start at the first levels of the "ladder" and advance up it as their involvement in the project grows.  Our project members are happy to help you advance along the contributor ladder.
+
+Each of the contributor roles below is organized into lists of three types of things. "Responsibilities" are things that contributor is expected to do. "Requirements" are qualifications a person needs to meet to be in that role, and "Privileges" are things contributors on that level are entitled to.
+
+
+### Community Participant
+Description: A Community Participant engages with the project and its community, contributing their time, thoughts, etc. Community participants are usually users who have stopped being anonymous and started being active in project discussions.
+
+* Responsibilities:
+    * Must follow the Code of Conduct
+* How users can get involved with the community:
+    * Participating in community discussions
+    * Helping other users
+    * Submitting bug reports
+    * Commenting on issues
+    * Trying out new releases
+
+### Contributor
+Description: A Contributor contributes directly to the project and adds value to it. Contributions need not be code. People at the Contributor level may be new contributors, or they may only contribute occasionally.
+
+* Responsibilities include:
+    * Follow the Code of Conduct
+    * Follow the project contributing guide
+* Requirements (one or several of the below):
+    * Report and sometimes resolve issues
+    * Occasionally submit PRs
+    * Contribute to the documentation
+    * Answer questions from other community members
+    * Submit feedback on issues and PRs
+    * Test releases and patches and submit reviews
+    * Promote the project in public
+* Privileges:
+    * May be assigned Issues and Reviews
+    * Can recommend other community members to become Contributors
+
+
+### Maintainer
+Description: Maintainers are very established contributors who are responsible for the entire project. As such, they have the ability to approve PRs against any area of the project, and are expected to participate in making decisions about the strategy and priorities of the project.
+
+A Maintainer must meet the responsibilities and requirements of a Contributor, plus:
+
+* Responsibilities include:
+    * Reviewing PRs, especially PRs that involve multiple parts of the project
+    * Mentoring and onboarding Contributors and community members
+    * Writing refactoring PRs
+    * Determining strategy and policy for the project
+* Requirements
+    * Demonstrates a broad knowledge of the project across multiple areas
+    * Is able to exercise judgement for the good of the project, independent of their employer, friends, or team
+    * Mentors other contributors
+    * Can commit to contributing on a regular basis
+* Additional privileges:
+    * Approve PRs to any area of the project
+    * Represent the project in public as a Maintainer
+    * Have a vote in Maintainer decision-making
+    
+
+Process of becoming a maintainer:
+1. Any current Maintainer may nominate a current Contributor to become a new Maintainer, by opening a PR adding the nominee as an Approver in the MAINTAINERS.md file
+2. The nominee will add a comment to the PR testifying that they agree to all requirements of becoming a Maintainer.
+3. A majority of the current Maintainers must then approve the PR.
+
+
+## Inactivity
+It is important for contributors to be and stay active to set an example and show commitment to the project. Inactivity is harmful to the project as it may lead to unexpected delays, contributor attrition, and a lost of trust in the project.
+
+* Inactivity is measured by:
+    * Periods of no contributions for longer than 3 months
+    * Periods of no communication for longer than 3 months
+* Consequences of being inactive include:
+    * Involuntary removal or demotion
+    * Being asked to move to Emeritus status
+
+## Involuntary Removal or Demotion
+
+Involuntary removal/demotion of a contributor happens when responsibilities and requirements aren't being met. This may include repeated patterns of inactivity, extended period of inactivity, a period of failing to meet the requirements of your role, and/or a violation of the Code of Conduct. This process is important because it protects the community and its deliverables while also opens up opportunities for new contributors to step in.
+
+Involuntary removal or demotion is handled by a majority vote of the maintainers.
+
+## Stepping Down/Emeritus Process
+If and when contributors' commitment levels change, contributors can consider stepping down (moving down the contributor ladder) vs moving to emeritus status (completely stepping away from the project).
+
+Contact the Maintainers about changing to Emeritus status, or reducing your contributor level.
+

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,66 @@
+# Certifier Framework for Confidential Computing Governance
+
+## Values
+
+The Certifier Framework for Confidential Computing and its leadership embrace the following values:
+
+* Openness: Communication and decision-making happens in the open and is discoverable for future
+  reference. As much as possible, all discussions and work take place in public
+  forums and open repositories.
+
+* Fairness: All stakeholders have the opportunity to provide feedback and submit
+  contributions, which will be considered on their merits.
+
+* Inclusivity: We innovate through different perspectives and skill sets, which
+  can only be accomplished in a welcoming and respectful environment.
+
+* Participation: Responsibilities within the project are earned through
+  participation, and there is a clear path up the contributor ladder into leadership
+  positions.
+
+## Maintainers
+
+Maintainers have write access to the project GitHub repository.
+They can merge their own patches or patches from others. The current maintainers
+can be found in [MAINTAINERS.md](./MAINTAINERS.md).  Maintainers collectively manage the project's
+resources and contributors.
+
+This privilege is granted with some expectation of responsibility: maintainers
+are people who care about the project and want to help it grow and
+improve. A maintainer is not just someone who can make changes, but someone who
+has demonstrated their ability to collaborate with the team, get the most
+knowledgeable people to review code and docs, contribute high-quality code, and
+follow through to fix issues (in code or tests).
+
+A maintainer is a contributor to the project's success and a citizen helping
+the project succeed.
+
+## Becoming a Maintainer
+
+To become a Maintainer you need to demonstrate the following:
+
+  * commitment to the project:
+    * participate in discussions, contributions, code and documentation reviews,
+    * perform reviews for pull requests,
+    * contribute non-trivial pull requests and have them merged,
+  * ability to write quality code and/or documentation,
+  * ability to collaborate with the team,
+  * understanding of how the team works (policies, processes for testing and code review, etc),
+  * understanding of the project's code base and coding and documentation style.
+
+A new Maintainer must be proposed by an existing maintainer. A simple majority vote of existing Maintainers
+approves the application.
+
+## Code of Conduct
+
+Maintainers agree to uphold the [Code of Conduct](./CODE_OF_CONDUCT.md) and role model
+appropriate and inclusive behavior within the community.
+
+## Voting
+
+While most business is conducted by "lazy consensus", periodically
+the Maintainers may need to vote on specific actions or changes.
+
+Most votes require a simple majority of all Maintainers to succeed. Maintainers
+can be removed by a 2/3 majority vote of all Maintainers, and changes to this
+Governance require a 2/3 vote of all Maintainers.


### PR DESCRIPTION
Adding draft governance and contributor ladder documentation after discussing the need to have these docs in a meeting with @jlmucb.

I suspect that we will need to iterate on this PR, since I guessed at a few things and made arbitrary choices :) 

None of this is decided at this point, and we can change things as much as we need to, so please review and provide feedback so that we can improve on these docs and make sure that they meet your needs for the project.