### PR TITLE
OE SGX Real Hardware Updates

### DIFF
--- a/certifier_service/certlib/certlib_proofs.go
+++ b/certifier_service/certlib/certlib_proofs.go
@@ -226,8 +226,11 @@ func InitProvedStatements(pk certprotos.KeyMessage, evidenceList []*certprotos.E
 				fmt.Printf("InitProvedStatements: missing cert chain in oe evidence\n")
 				return false
 			}
+			// Ignore SGX TCB level check for now
 			serializedUD, m, err  := oeverify.OEHostVerifyEvidence(evidenceList[i].SerializedEvidence,
-				evidenceList[i-1].SerializedEvidence)
+				nil, false)
+			//serializedUD, m, err  := oeverify.OEHostVerifyEvidence(evidenceList[i].SerializedEvidence,
+			//	evidenceList[i-1].SerializedEvidence, false)
 			if err != nil || serializedUD == nil || m == nil {
 				return false
 			}

--- a/certifier_service/oelib/oeverify.h
+++ b/certifier_service/oelib/oeverify.h
@@ -13,4 +13,5 @@ bool oe_host_verify_evidence(
     uint8_t* custom_claim_out,
     size_t* custom_claim_size,
     uint8_t* measurement_out,
-    size_t* measurement_size);
+    size_t* measurement_size,
+    bool check_tcb);

--- a/certifier_service/oelib/oeverify_dummy.c
+++ b/certifier_service/oelib/oeverify_dummy.c
@@ -8,7 +8,8 @@ bool oe_host_verify_evidence(
     uint8_t* custom_claim_out,
     size_t* custom_claim_size,
     uint8_t* measurement_out,
-    size_t* measurement_size)
+    size_t* measurement_size,
+    bool check_tcb)
 {
     fprintf(stderr, "Dummy oe_host_verify_evidence call.\n");
     return false;

--- a/sample_apps/simple_app_under_oe/README.md
+++ b/sample_apps/simple_app_under_oe/README.md
@@ -79,10 +79,10 @@ make
 
 Step 6: Obtain the measurement of the trusted application for the security domain.
 ```bash
-cd $EXAMPLE_DIR/provisioning
-$CERTIFIER_PROTOTYPE/utilities/measurement_utility.exe --type=hash --input=../enclave/enclave.signed \
-      --output=example_app.measurement
+cd $EXAMPLE_DIR
+make dump_mrenclave
 ```
+Follow the instructions at the bottom of the output to generate binary_trusted_measurements_file.bin
 
 Step 7: Author the policy for the security domain and produce the signed claims the apps need.
 ```bash
@@ -90,7 +90,7 @@ cd $EXAMPLE_DIR/provisioning
 
 # a. Construct statement "policy-key says example_app-measurement is-trusted"
 $CERTIFIER_PROTOTYPE/utilities/make_unary_vse_clause.exe --key_subject="" \
-   --measurement_subject=example_app.measurement --verb="is-trusted" \
+   --measurement_subject=binary_trusted_measurements_file.bin --verb="is-trusted" \
    --output=ts1.bin
 $CERTIFIER_PROTOTYPE/utilities/make_indirect_vse_clause.exe --key_subject=policy_key_file.bin \
    --verb="says" --clause=ts1.bin --output=vse_policy1.bin

--- a/sample_apps/simple_app_under_oe/enclave/ecalls.cc
+++ b/sample_apps/simple_app_under_oe/enclave/ecalls.cc
@@ -173,7 +173,8 @@ bool certifier_init(char* usr_data_dir, size_t usr_data_dir_size) {
       return false;
     }
 
-    string cert(FLAGS_certificate_file);
+    string cert(data_dir);
+    cert.append(FLAGS_certificate_file);
     if (!app_trust_data->initialize_oe_enclave_data(cert)) {
       printf("Can't init OE enclave\n");
       return false;

--- a/sample_apps/simple_app_under_oe/enclave/enc.conf
+++ b/sample_apps/simple_app_under_oe/enclave/enc.conf
@@ -3,8 +3,8 @@
 
 # Enclave settings:
 Debug=1
-NumHeapPages=4096
-NumStackPages=4096
-NumTCS=1
+NumHeapPages=2048
+NumStackPages=2048
+NumTCS=2
 ProductID=1
 SecurityVersion=1

--- a/sample_apps/simple_app_under_oe/instructions.txt
+++ b/sample_apps/simple_app_under_oe/instructions.txt
@@ -5,8 +5,10 @@ Instructions for building and running the sample application under oe and genera
 
 The structure of an OE application is diferent from other applications in sample_apps because
 of the partitioning of the application into "trusted" and "untrusted" portions.  So, unlike
-other applications there is not a single "example_app.cc" that gets built.  Todo:  Ye should
-say a littl emore about the structure of the application.
+other applications there is not a single "example_app.cc" that gets built. Instead, the simple
+application is split into the host and enclave parts. The normal Certifier interfaces used by
+other simple apps are now wrapped as ECALLs that can be called by the host application into the
+enclave.
 
 $CERTIFIER_PROTOTYPE is the top level directory for the certifier repository.  On my
 computer, it is in =~/src/github.com/jlmucb/crypto/v2/certifier-framework-for-confidential-computing.
@@ -51,10 +53,10 @@ Step 5: Compile example_app with the embedded policy_key
     make
     make dump_mrenclave
 
-Step 6: In addition to making the binary, make will produce a file, binary_trusted_measurements_file.bin
-containing the application measurement.  The platform key should have been provisioned in a pem file called
-vse.crt which you should copy into the provisioning directory.  Translate vse.crt, which is in pem format,
-into der by:
+Step 6: In addition to making the binary, make will provide instructions to produce
+binary_trusted_measurements_file.bin containing the application measurement. The platform key should
+have been provisioned in a pem file called vse.crt which you should copy into the provisioning directory.
+Translate vse.crt, which is in pem format, into der by:
     cd $EXAMPLE_DIR/provisioning
     openssl x509 -in vse.crt -inform pem -out vse.crt.der -outform der
 
@@ -146,13 +148,13 @@ Step 14:  Run the apps and get admission certificates from Certifier Service
 
   In app as a client terminal run the following:
     cd $EXAMPLE_DIR
-    ./host/host enclave/enclave cold-init app1_data
-    ./host/host enclave/enclave get-certifier app1_data
+    ./host/host enclave/enclave.signed cold-init $EXAMPLE_DIR/app1_data
+    ./host/host enclave/enclave.signed get-certifier $EXAMPLE_DIR/app1_data
 
   In app as a server terminal run the following:
     cd $EXAMPLE_DIR
-    ./host/host enclave/enclave cold-init app2_data
-    ./host/host enclave/enclave get-certifier app2_data
+    ./host/host enclave/enclave.signed cold-init $EXAMPLE_DIR/app2_data
+    ./host/host enclave/enclave.signed get-certifier $EXAMPLE_DIR/app2_data
 
 At this point, both versions of the app have their admission certificates.  You can look at
 the output of the terminal running simpleserver for output.  Now all we have to do is have
@@ -165,11 +167,11 @@ Step 15:  Run the apps to test trusted services
 
   In app as a server terminal run the following:
     cd $EXAMPLE_DIR
-    ./host/host enclave/enclave run-app-as-server app2_data
+    ./host/host enclave/enclave.signed run-app-as-server $EXAMPLE_DIR/app2_data
 
   In app as a client terminal run the following:
     cd $EXAMPLE_DIR
-    ./host/host enclave/enclave run-app-as-client app1_data
+    ./host/host enclave/enclave.signed run-app-as-client $EXAMPLE_DIR/app1_data
 
 You should see the message "Hi from your secret server" in the client terminal window and
 "Hi from your secret client".   If so, your first Confidential Computing program worked!

--- a/sample_apps/simple_app_under_oe/script
+++ b/sample_apps/simple_app_under_oe/script
@@ -31,7 +31,7 @@ make dump_mrenclave
 cd $EXAMPLE_DIR/provisioning
 
 
-$CERTIFIER_PROTOTYPE/utilities/make_unary_vse_clause.exe --cert_subject=vse.cer.der \
+$CERTIFIER_PROTOTYPE/utilities/make_unary_vse_clause.exe --cert_subject=vse.crt.der \
   --verb="is-trusted-for-attestation" --output=ts1.bin
 $CERTIFIER_PROTOTYPE/utilities/make_indirect_vse_clause.exe --key_subject=policy_key_file.bin \
   --verb="says" --clause=ts1.bin --output=vse_policy1.bin
@@ -76,18 +76,18 @@ $CERTIFIER_PROTOTYPE/certifier_service/simpleserver \
 
 # initialize client app
 cd $EXAMPLE_DIR
-./host/host enclave/enclave cold-init app1_data
+./host/host enclave/enclave.signed cold-init $EXAMPLE_DIR/app1_data
 # get client app certified
-./host/host enclave/enclave get-certifier app1_data
+./host/host enclave/enclave.signed get-certifier $EXAMPLE_DIR/app1_data
 
 # initialize server app
-./host/host enclave/enclave cold-init app2_data
+./host/host enclave/enclave.signed cold-init $EXAMPLE_DIR/app2_data
 # get server app certified
-./host/host enclave/enclave get-certifier app2_data
+./host/host enclave/enclave.signed get-certifier $EXAMPLE_DIR/app2_data
 
 #run the app
 cd $EXAMPLE_DIR
-./host/host enclave/enclave run-app-as-server app2_data
+./host/host enclave/enclave.signed run-app-as-server $EXAMPLE_DIR/app2_data
 cd $EXAMPLE_DIR
-./host/host enclave/enclave run-app-as-client app1_data
+./host/host enclave/enclave.signed run-app-as-client $EXAMPLE_DIR/app1_data
 

--- a/src/cc_helpers.cc
+++ b/src/cc_helpers.cc
@@ -311,7 +311,7 @@ void cc_trust_data::print_trust_data() {
   }
 }
 
-const int max_pad_size_for_store = 512;
+const int max_pad_size_for_store = 1024;
 
 bool cc_trust_data::save_store() {
 

--- a/src/cc_helpers.cc
+++ b/src/cc_helpers.cc
@@ -800,13 +800,15 @@ bool cc_trust_data::certify_me(const string& host_name, int port) {
       printf("cc_trust_data::certify_me: Can't get pem-chain\n");
       return false;
     }
-    evidence* ev = platform_evidence.add_assertion();
-    if (ev ==nullptr) {
-      printf("cc_trust_data::certify_me: Can't add to platform evidence\n");
-      return false;
+    if (pem_cert_chain != "") {
+      evidence* ev = platform_evidence.add_assertion();
+      if (ev ==nullptr) {
+        printf("cc_trust_data::certify_me: Can't add to platform evidence\n");
+        return false;
+      }
+      ev->set_evidence_type("pem-cert-chain");
+      ev->set_serialized_evidence(pem_cert_chain);
     }
-    ev->set_evidence_type("pem-cert-chain");
-    ev->set_serialized_evidence(pem_cert_chain);
 #endif
   } else {
     printf("cc_trust_data::certify_me: Unknown enclave type\n");

--- a/src/certifier.cc
+++ b/src/certifier.cc
@@ -758,7 +758,7 @@ bool GetParentEnclaveType(string* type) {
 // -------------------------------------------------------------------
 
 // the padding size includes an IV and possibly 3 additional blocks
-const int max_key_seal_pad = 512;
+const int max_key_seal_pad = 1024;
 const int protect_key_size = 64;
 
 bool Protect_Blob(const string& enclave_type, key_message& key,

--- a/src/openenclave/attestation.cc
+++ b/src/openenclave/attestation.cc
@@ -6,9 +6,8 @@
 #include <openenclave/attestation/sgx/evidence.h>
 #include <openenclave/bits/report.h>
 
-// VSE Attestation Format UUID. Use local attestation for efficiency.
-// Change to OE_FORMAT_UUID_VSE_REMOTE_ATTESTATION for remote attestation.
-static oe_uuid_t vse_format_uuid = {OE_FORMAT_UUID_SGX_LOCAL_ATTESTATION};
+// SGX Attestation Format UUID.
+static oe_uuid_t vse_format_uuid = {OE_FORMAT_UUID_SGX_ECDSA};
 
 bool
 oe_Attest(int what_to_say_size, byte* what_to_say,

--- a/src/openenclave/oe_support.cc
+++ b/src/openenclave/oe_support.cc
@@ -14,8 +14,8 @@ bool oe_Init(const string& pem_cert_chain_file) {
   extern bool certifier_parent_enclave_type_intitalized;
   extern string certifier_parent_enclave_type; 
    if (!read_file_into_string(pem_cert_chain_file, &pem_cert_chain)) {
-    printf("oe_Init: Can't read pem cert chain file\n");
-    return false;
+    printf("oe_Init: No pem cert chain file. Assume empty endorsement.\n");
+    pem_cert_chain = "";
   }
 
   pem_cert_chain_initialized = true;

--- a/src/openenclave/sealing.cc
+++ b/src/openenclave/sealing.cc
@@ -15,6 +15,10 @@ oe_Seal (int seal_policy, int in_size, byte* in, int opt_size, byte* opt,
   size_t blob_size;
   uint64_t host_addr = 0;
 
+  if (!size_out || !out) {
+    return result;
+  }
+
   const oe_seal_setting_t settings[] = {OE_SEAL_SET_POLICY(seal_policy)};
   ret = oe_seal(
     NULL,
@@ -34,6 +38,12 @@ oe_Seal (int seal_policy, int in_size, byte* in, int opt_size, byte* opt,
   if (blob_size > UINT32_MAX)
   {
     OE_DEBUG_PRINTF("blob_size is too large\n");
+    goto exit;
+  }
+
+  if (*size_out < (int) blob_size) {
+    OE_DEBUG_PRINTF("Output buffer is too small\n");
+    *size_out = (int) blob_size;
     goto exit;
   }
 


### PR DESCRIPTION
Contains two patches. The first is a fix that ignores the VSE plaftorm certificate. This one is generic. The second patch updates the proof and evidence for OE so that we can have a policy without VSE cert (endorsement).