### PR TITLE
Fix 'clean' recipe  to avoid getting noisy messasges. Update .gitignore rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,14 @@
 *.o
 *.swp
 *.swo
+*.pb.h
+*.pb.cc
+*.pb.go
+*.so
+*.cmd
+*.exe
+*.bin
+app1_data/
+app2_data/
+simpleserver
+provisioning/

--- a/application_service/app_service.mak
+++ b/application_service/app_service.mak
@@ -52,9 +52,9 @@ all:	app_service.exe hello_world.exe send_request.exe test_user.exe
 
 clean:
 	@echo "removing object files"
-	rm $(O)/*.o
+	rm -rf $(O)/*.o
 	@echo "removing executable file"
-	rm $(EXE_DIR)/app_service.exe
+	rm -rf $(EXE_DIR)/app_service.exe
 
 hello_world.exe: hello_world.cc
 	@echo "hello_world.cc"

--- a/openenclave_test/enclave/oe_certifier.mak
+++ b/openenclave_test/enclave/oe_certifier.mak
@@ -41,9 +41,9 @@ dobj=	$(O)/oe_certifier.o $(O)/certifier.pb.o $(O)/certifier.o $(O)/support.o
 all:	oe_certifier.exe
 clean:
 	@echo "removing object files"
-	rm $(O)/*.o
+	rm -rf $(O)/*.o
 	@echo "removing executable file"
-	rm $(EXE_DIR)/oe_certifier.exe
+	rm -rf $(EXE_DIR)/oe_certifier.exe
 
 oe_certifier.exe: $(dobj) 
 	@echo "linking executable files"

--- a/sample_apps/analytics_example/enclave/oe_certifier.mak
+++ b/sample_apps/analytics_example/enclave/oe_certifier.mak
@@ -41,9 +41,9 @@ dobj=	$(O)/oe_certifier.o $(O)/certifier.pb.o $(O)/certifier.o $(O)/support.o
 all:	oe_certifier.exe
 clean:
 	@echo "removing object files"
-	rm $(O)/*.o
+	rm -rf $(O)/*.o
 	@echo "removing executable file"
-	rm $(EXE_DIR)/oe_certifier.exe
+	rm -rf $(EXE_DIR)/oe_certifier.exe
 
 oe_certifier.exe: $(dobj) 
 	@echo "linking executable files"

--- a/sample_apps/simple_app/example_app.mak
+++ b/sample_apps/simple_app/example_app.mak
@@ -47,9 +47,9 @@ $(O)/support.o $(O)/simulated_enclave.o $(O)/application_enclave.o $(O)/cc_helpe
 all:	example_app.exe
 clean:
 	@echo "removing object files"
-	rm $(O)/*.o
+	rm -rf $(O)/*.o
 	@echo "removing executable file"
-	rm $(EXE_DIR)/example_app.exe
+	rm -rf $(EXE_DIR)/example_app.exe
 
 example_app.exe: $(dobj) 
 	@echo "linking executable files"

--- a/sample_apps/simple_app_under_app_service/service_example_app.mak
+++ b/sample_apps/simple_app_under_app_service/service_example_app.mak
@@ -49,9 +49,9 @@ $(O)/simulated_enclave.o $(O)/application_enclave.o $(O)/cc_helpers.o
 all:	service_example_app.exe start_program.exe
 clean:
 	@echo "removing object files"
-	rm $(O)/*.o
+	rm -rf $(O)/*.o
 	@echo "removing executable file"
-	rm $(EXE_DIR)/service_example_app.exe
+	rm -rf $(EXE_DIR)/service_example_app.exe
 
 service_example_app.exe: $(dobj) 
 	@echo "linking executable files"

--- a/sample_apps/simple_app_under_sev/sev_example_app.mak
+++ b/sample_apps/simple_app_under_sev/sev_example_app.mak
@@ -45,9 +45,9 @@ $(O)/sev_report.o $(O)/cc_helpers.o
 all:	sev_example_app.exe
 clean:
 	@echo "removing object files"
-	rm $(O)/*.o
+	rm -rf $(O)/*.o
 	@echo "removing executable file"
-	rm $(EXE_DIR)/sev_example_app.exe
+	rm -rf $(EXE_DIR)/sev_example_app.exe
 
 sev_example_app.exe: $(dobj) 
 	@echo "linking executable files"

--- a/sample_apps/simple_app_under_sev/sev_example_app_with_dummy.mak
+++ b/sample_apps/simple_app_under_sev/sev_example_app_with_dummy.mak
@@ -45,9 +45,9 @@ $(O)/sev_report.o $(O)/cc_helpers.o
 all:	sev_example_app.exe
 clean:
 	@echo "removing object files"
-	rm $(O)/*.o
+	rm -rf $(O)/*.o
 	@echo "removing executable file"
-	rm $(EXE_DIR)/sev_example_app.exe
+	rm -rf $(EXE_DIR)/sev_example_app.exe
 
 sev_example_app.exe: $(dobj) 
 	@echo "linking executable files"

--- a/src/certifier.mak
+++ b/src/certifier.mak
@@ -64,9 +64,9 @@ endif
 all:	$(CL)/certifier.a
 clean:
 	@echo "removing object files"
-	rm $(O)/*.o
+	rm -rf $(O)/*.o
 	@echo "removing executable file"
-	rm $(CL)/certifier.a
+	rm -rf $(CL)/certifier.a
 
 $(CL)/certifier.a: $(dobj)
 	@echo "linking certifier library"

--- a/src/certifier_tests.mak
+++ b/src/certifier_tests.mak
@@ -96,9 +96,9 @@ all:	certifier_tests.exe test_channel.exe pipe_read_test.exe
 
 clean:
 	@echo "removing object files"
-	rm $(O)/*.o
+	rm -rf $(O)/*.o
 	@echo "removing executable file"
-	rm $(EXE_DIR)/certifier_tests.exe $(EXE_DIR)/pipe_read_test.exe $(EXE_DIR)/test_channel.exe
+	rm -rf $(EXE_DIR)/certifier_tests.exe $(EXE_DIR)/pipe_read_test.exe $(EXE_DIR)/test_channel.exe
 
 certifier_tests.exe: $(dobj) 
 	@echo "linking executable files"

--- a/utilities/cert_utility.mak
+++ b/utilities/cert_utility.mak
@@ -56,9 +56,9 @@ $(O)/certifier_proofs.o $(O)/simulated_enclave.o $(O)/application_enclave.o
 all:	cert_utility.exe measurement_init.exe key_utility.exe
 clean:
 	@echo "removing object files"
-	rm $(O)/*.o
+	rm -rf $(O)/*.o
 	@echo "removing executable file"
-	rm $(EXE_DIR)/cert_utility.exe
+	rm -rf $(EXE_DIR)/cert_utility.exe
 
 cert_utility.exe: $(dobj) 
 	@echo "linking executable files"

--- a/utilities/policy_generator.mak
+++ b/utilities/policy_generator.mak
@@ -33,8 +33,8 @@ LDFLAGS= -L$(LOCAL_LIB) -lnlohmann_json_schema_validator -lgflags
 all:	$(EXE_DIR)/policy_generator.exe
 
 clean:
-	rm $(O)/policy_generator.o
-	rm $(EXE_DIR)/policy_generator.exe
+	rm -rf $(O)/policy_generator.o
+	rm -rf $(EXE_DIR)/policy_generator.exe
 
 $(EXE_DIR)/policy_generator.exe: $(EXE_DIR)/policy_generator.o
 	$(LD) -o $(EXE_DIR)/policy_generator.exe policy_generator.o $(LDFLAGS)

--- a/utilities/policy_utilities.mak
+++ b/utilities/policy_utilities.mak
@@ -95,9 +95,9 @@ all:	$(EXE_DIR)/measurement_utility.exe $(EXE_DIR)/make_indirect_vse_clause.exe 
 
 clean:
 	@echo "removing object files"
-	rm $(O)/*.o
+	rm -rf $(O)/*.o
 	@echo "removing executable file"
-	rm $(EXE_DIR)/*.exe
+	rm -rf $(EXE_DIR)/*.exe
 
 $(EXE_DIR)/measurement_utility.exe: $(measurement_utility_obj) 
 	@echo "linking executable files"


### PR DESCRIPTION
Fix diff Makefile's 'clean' recipe to use "rm -rf" on *.o's so that we don't get noisy messages reporting that *.o is not found. These occur when someone attempts 'clean' on a new branch, before making any executables.

Add more patterns to .gitignore rules.

----

**NOTE**: To reviewers: This change-set is mostly a cleanup-type changes to reduce noisy messages when running `clean` in a new code branch. I ran into these while going thru diff steps / instructions for sample programs.

As part of the build(s), we seem to produce many artifacts in the code line itself. So this commit enhances existing rules in `.gitignore` to exclude some of the generated files. 

Please see my annotations to `.gitignore` before we finalize this change. We don't want to accidentally ignore a file that should be tracked under git.
