### PR TITLE
Relocate copyright notice to be at top of the file. Other minor edits.

### DIFF
--- a/include/cc_helpers.h
+++ b/include/cc_helpers.h
@@ -1,19 +1,3 @@
-#include "support.h"
-#include "certifier.h"
-#include "simulated_enclave.h"
-
-#include <sys/socket.h>
-#include <arpa/inet.h>
-#include <netinet/in.h>
-#include <netdb.h>
-#include <openssl/ssl.h>
-#include <openssl/rsa.h>
-#include <openssl/x509.h>
-#include <openssl/evp.h>
-#include <openssl/rand.h>
-#include <openssl/hmac.h>
-#include <openssl/err.h>
-
 //  Copyright (c) 2021-22, VMware Inc, and the Certifier Authors.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,6 +11,22 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+#include <sys/socket.h>
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <netdb.h>
+#include <openssl/ssl.h>
+#include <openssl/rsa.h>
+#include <openssl/x509.h>
+#include <openssl/evp.h>
+#include <openssl/rand.h>
+#include <openssl/hmac.h>
+#include <openssl/err.h>
+
+#include "support.h"
+#include "certifier.h"
+#include "simulated_enclave.h"
 
 #ifndef _CC_HELPERS_CC_
 #define _CC_HELPERS_CC_

--- a/include/certifier.h
+++ b/include/certifier.h
@@ -1,3 +1,17 @@
+//  Copyright (c) 2021-22, VMware Inc, and the Certifier Authors.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef _CERTIFIER_H__
 #define _CERTIFIER_H__
 
@@ -27,20 +41,6 @@ typedef unsigned char byte;
 #endif
 
 using std::string;
-
-//  Copyright (c) 2021-22, VMware Inc, and the Certifier Authors.  All rights reserved.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 
 
 // Some Data and access functions

--- a/sample_apps/att_systemd_service/attsvc.cc
+++ b/sample_apps/att_systemd_service/attsvc.cc
@@ -1,3 +1,17 @@
+//  Copyright (c) 2021-22, VMware Inc, and the Certifier Authors.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -24,20 +38,6 @@
 #include <openssl/rand.h>
 #include <openssl/hmac.h>
 #include <openssl/err.h>
-
-//  Copyright (c) 2021-22, VMware Inc, and the Certifier Authors.  All rights reserved.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 
 #ifdef ATT_DEBUG
 #define ATT_LOG(priority, format, ...)  printf(format"\n", ##__VA_ARGS__)

--- a/sample_apps/simple_app/example_app.cc
+++ b/sample_apps/simple_app/example_app.cc
@@ -1,23 +1,3 @@
-#include <gtest/gtest.h>
-#include <gflags/gflags.h>
-
-#include "support.h"
-#include "certifier.h"
-#include "simulated_enclave.h"
-#include "cc_helpers.h"
-
-#include <sys/socket.h>
-#include <arpa/inet.h>
-#include <netinet/in.h>
-#include  <netdb.h>
-#include <openssl/ssl.h>
-#include <openssl/rsa.h>
-#include <openssl/x509.h>
-#include <openssl/evp.h>
-#include <openssl/rand.h>
-#include <openssl/hmac.h>
-#include <openssl/err.h>
-
 //  Copyright (c) 2021-22, VMware Inc, and the Certifier Authors.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -31,6 +11,26 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+#include <gtest/gtest.h>
+#include <gflags/gflags.h>
+
+#include <sys/socket.h>
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include  <netdb.h>
+#include <openssl/ssl.h>
+#include <openssl/rsa.h>
+#include <openssl/x509.h>
+#include <openssl/evp.h>
+#include <openssl/rand.h>
+#include <openssl/hmac.h>
+#include <openssl/err.h>
+
+#include "support.h"
+#include "certifier.h"
+#include "simulated_enclave.h"
+#include "cc_helpers.h"
 
 
 // operations are: cold-init, warm-restart, get-certifier, run-app-as-client, run-app-as-server

--- a/sample_apps/simple_app_under_app_service/service_example_app.cc
+++ b/sample_apps/simple_app_under_app_service/service_example_app.cc
@@ -1,24 +1,3 @@
-#include <gtest/gtest.h>
-#include <gflags/gflags.h>
-
-#include "support.h"
-#include "certifier.h"
-#include "simulated_enclave.h"
-#include "application_enclave.h"
-#include "cc_helpers.h"
-
-#include <sys/socket.h>
-#include <arpa/inet.h>
-#include <netinet/in.h>
-#include  <netdb.h>
-#include <openssl/ssl.h>
-#include <openssl/rsa.h>
-#include <openssl/x509.h>
-#include <openssl/evp.h>
-#include <openssl/rand.h>
-#include <openssl/hmac.h>
-#include <openssl/err.h>
-
 //  Copyright (c) 2021-22, VMware Inc, and the Certifier Authors.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -33,6 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <gtest/gtest.h>
+#include <gflags/gflags.h>
+
+#include <sys/socket.h>
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include  <netdb.h>
+#include <openssl/ssl.h>
+#include <openssl/rsa.h>
+#include <openssl/x509.h>
+#include <openssl/evp.h>
+#include <openssl/rand.h>
+#include <openssl/hmac.h>
+#include <openssl/err.h>
+
+#include "support.h"
+#include "certifier.h"
+#include "simulated_enclave.h"
+#include "application_enclave.h"
+#include "cc_helpers.h"
 
 // operations are: cold-init, warm-restart, get-certifier, run-app-as-client, run-app-as-server
 DEFINE_bool(print_all, false,  "verbose");

--- a/sample_apps/simple_app_under_sev/sev_example_app.cc
+++ b/sample_apps/simple_app_under_sev/sev_example_app.cc
@@ -1,23 +1,3 @@
-#include <gtest/gtest.h>
-#include <gflags/gflags.h>
-
-#include "support.h"
-#include "certifier.h"
-#include "simulated_enclave.h"
-#include "cc_helpers.h"
-
-#include <sys/socket.h>
-#include <arpa/inet.h>
-#include <netinet/in.h>
-#include  <netdb.h>
-#include <openssl/ssl.h>
-#include <openssl/rsa.h>
-#include <openssl/x509.h>
-#include <openssl/evp.h>
-#include <openssl/rand.h>
-#include <openssl/hmac.h>
-#include <openssl/err.h>
-
 //  Copyright (c) 2021-22, VMware Inc, and the Certifier Authors.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -32,6 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <gtest/gtest.h>
+#include <gflags/gflags.h>
+
+#include <sys/socket.h>
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include  <netdb.h>
+#include <openssl/ssl.h>
+#include <openssl/rsa.h>
+#include <openssl/x509.h>
+#include <openssl/evp.h>
+#include <openssl/rand.h>
+#include <openssl/hmac.h>
+#include <openssl/err.h>
+
+#include "support.h"
+#include "certifier.h"
+#include "simulated_enclave.h"
+#include "cc_helpers.h"
 
 // operations are: cold-init, warm-restart, get-certifier, run-app-as-client, run-app-as-server
 DEFINE_bool(print_all, false,  "verbose");

--- a/src/cc_helpers.cc
+++ b/src/cc_helpers.cc
@@ -1,24 +1,3 @@
-#include "support.h"
-#include "certifier.h"
-#include "simulated_enclave.h"
-#include "application_enclave.h"
-#include "cc_helpers.h"
-#ifdef GRAMINE_CERTIFIER
-#include "gramine_api.h"
-#endif
-
-#include <sys/socket.h>
-#include <arpa/inet.h>
-#include <netinet/in.h>
-#include <netdb.h>
-#include <openssl/ssl.h>
-#include <openssl/rsa.h>
-#include <openssl/x509.h>
-#include <openssl/evp.h>
-#include <openssl/rand.h>
-#include <openssl/hmac.h>
-#include <openssl/err.h>
-
 //  Copyright (c) 2021-22, VMware Inc, and the Certifier Authors.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -32,6 +11,27 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+#include <sys/socket.h>
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <netdb.h>
+#include <openssl/ssl.h>
+#include <openssl/rsa.h>
+#include <openssl/x509.h>
+#include <openssl/evp.h>
+#include <openssl/rand.h>
+#include <openssl/hmac.h>
+#include <openssl/err.h>
+
+#include "support.h"
+#include "certifier.h"
+#include "simulated_enclave.h"
+#include "application_enclave.h"
+#include "cc_helpers.h"
+#ifdef GRAMINE_CERTIFIER
+#include "gramine_api.h"
+#endif
 
 
 //  This is a collection of functions that accomplish almost all the

--- a/src/support.cc
+++ b/src/support.cc
@@ -1,23 +1,3 @@
-#include <openssl/ssl.h>
-#include <openssl/rsa.h>
-#include <openssl/x509.h>
-#include <openssl/evp.h>
-#include <openssl/rand.h>
-#include <openssl/hmac.h>
-#include <openssl/x509v3.h>
-#include <openssl/ecdsa.h>
- #include <openssl/bn.h>
- #include <openssl/evp.h>
- #include <openssl/ec.h>
-
-#include "support.h" 
-#include "certifier.pb.h" 
-
-#include <sys/ioctl.h>
-#include <sys/socket.h>
-#include <string>
-using std::string;
-
 //  Copyright (c) 2021-22, VMware Inc, and the Certifier Authors.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -31,6 +11,26 @@ using std::string;
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+#include <openssl/ssl.h>
+#include <openssl/rsa.h>
+#include <openssl/x509.h>
+#include <openssl/evp.h>
+#include <openssl/rand.h>
+#include <openssl/hmac.h>
+#include <openssl/x509v3.h>
+#include <openssl/ecdsa.h>
+#include <openssl/bn.h>
+#include <openssl/evp.h>
+#include <openssl/ec.h>
+
+#include "support.h" 
+#include "certifier.pb.h" 
+
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <string>
+using std::string;
 
 // -----------------------------------------------------------------------
 

--- a/utilities/appoint_platform.cc
+++ b/utilities/appoint_platform.cc
@@ -1,7 +1,3 @@
-#include <gflags/gflags.h>
-#include "certifier.h"
-#include "support.h"
-
 //  Copyright (c) 2021-22, VMware Inc, and the Certifier Authors.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,6 +13,10 @@
 // limitations under the License.
 
 // appoint_platform.exe --policy_key=file --cert_file=ark_cert.bin --output=output-file-name
+
+#include <gflags/gflags.h>
+#include "certifier.h"
+#include "support.h"
 
 DEFINE_bool(print_all, false,  "verbose");
 DEFINE_string(output, "simple_clause.bin",  "output file");

--- a/utilities/cert_utility.cc
+++ b/utilities/cert_utility.cc
@@ -1,6 +1,3 @@
-#include <gflags/gflags.h>
-#include "support.h"
-
 //  Copyright (c) 2021-22, VMware Inc, and the Certifier Authors.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <gflags/gflags.h>
+#include "support.h"
 
 DEFINE_bool(print_all, false,  "verbose");
 // "generate-policy-key-and-test-keys" is the other option

--- a/utilities/combine_properties.cc
+++ b/utilities/combine_properties.cc
@@ -1,7 +1,3 @@
-#include <gflags/gflags.h>
-#include "certifier.h"
-#include "support.h"
-
 //  Copyright (c) 2021-22, VMware Inc, and the Certifier Authors.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,6 +13,10 @@
 // limitations under the License.
 
 // combine_properties.exe --in=file1,file2,...,filen --output=out
+
+#include <gflags/gflags.h>
+#include "certifier.h"
+#include "support.h"
 
 DEFINE_bool(print_all, false,  "verbose");
 DEFINE_string(in, "",  "input files");

--- a/utilities/embed_policy_key.cc
+++ b/utilities/embed_policy_key.cc
@@ -1,3 +1,17 @@
+//  Copyright (c) 2021-22, VMware Inc, and the Certifier Authors.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <gflags/gflags.h>
 #include <stdio.h>
 #include <stdint.h>
@@ -18,20 +32,6 @@ typedef unsigned char byte;
 #endif
 
 using std::string;
-
-//  Copyright (c) 2021-22, VMware Inc, and the Certifier Authors.  All rights reserved.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 
 
 DEFINE_bool(print_all, false,  "verbose");

--- a/utilities/key_utility.cc
+++ b/utilities/key_utility.cc
@@ -1,6 +1,3 @@
-#include <gflags/gflags.h>
-#include "support.h"
-
 //  Copyright (c) 2021-22, VMware Inc, and the Certifier Authors.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <gflags/gflags.h>
+#include "support.h"
 
 DEFINE_bool(print_all, false,  "verbose");
 

--- a/utilities/make_environment.cc
+++ b/utilities/make_environment.cc
@@ -1,7 +1,3 @@
-#include <gflags/gflags.h>
-#include "certifier.h"
-#include "support.h"
-
 //  Copyright (c) 2021-22, VMware Inc, and the Certifier Authors.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,6 +13,10 @@
 // limitations under the License.
 
 // make_environment.exe  --platform_file=file --measurement_file=file --output=file
+
+#include <gflags/gflags.h>
+#include "certifier.h"
+#include "support.h"
 
 DEFINE_bool(print_all, false,  "verbose");
 DEFINE_string(platform_file, "",  "platform file");

--- a/utilities/make_indirect_vse_clause.cc
+++ b/utilities/make_indirect_vse_clause.cc
@@ -1,7 +1,3 @@
-#include <gflags/gflags.h>
-#include "certifier.h"
-#include "support.h"
-
 //  Copyright (c) 2021-22, VMware Inc, and the Certifier Authors.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,6 +13,10 @@
 // limitations under the License.
 
 // make_indirect_vse_clause.exe --key_subject=file --verb="says" --clause=file --output=output-file-name
+
+#include <gflags/gflags.h>
+#include "certifier.h"
+#include "support.h"
 
 DEFINE_bool(print_all, false,  "verbose");
 DEFINE_string(output, "simple_clause.bin",  "output file");

--- a/utilities/make_platform.cc
+++ b/utilities/make_platform.cc
@@ -1,7 +1,3 @@
-#include <gflags/gflags.h>
-#include "certifier.h"
-#include "support.h"
-
 //  Copyright (c) 2021-22, VMware Inc, and the Certifier Authors.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,6 +13,10 @@
 // limitations under the License.
 
 // make_platform.exe 
+
+#include <gflags/gflags.h>
+#include "certifier.h"
+#include "support.h"
 
 DEFINE_bool(print_all, false,  "verbose");
 DEFINE_string(platform_type, "",  "platform type");

--- a/utilities/make_property.cc
+++ b/utilities/make_property.cc
@@ -1,7 +1,3 @@
-#include <gflags/gflags.h>
-#include "certifier.h"
-#include "support.h"
-
 //  Copyright (c) 2021-22, VMware Inc, and the Certifier Authors.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,6 +14,10 @@
 
 // make_property.exe --property_name=name --type=type --comparator="X"
 //      --int=int-value --string_value=value
+
+#include <gflags/gflags.h>
+#include "certifier.h"
+#include "support.h"
 
 DEFINE_bool(print_all, false,  "verbose");
 DEFINE_string(property_name, "",  "property name");

--- a/utilities/make_signed_claim_from_vse_clause.cc
+++ b/utilities/make_signed_claim_from_vse_clause.cc
@@ -1,7 +1,3 @@
-#include <gflags/gflags.h>
-#include "certifier.h"
-#include "support.h"
-
 //  Copyright (c) 2021-22, VMware Inc, and the Certifier Authors.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,6 +13,10 @@
 // limitations under the License.
 
 // make_signed_claim_from_vse_clause.exe --vse_file=file --duration=hours --private_key_file=key=key-file --output=output-file-name
+
+#include <gflags/gflags.h>
+#include "certifier.h"
+#include "support.h"
 
 DEFINE_bool(print_all, false,  "verbose");
 DEFINE_string(vse_file, "vse_claim.bin",  "clause file");

--- a/utilities/make_simple_vse_clause.cc
+++ b/utilities/make_simple_vse_clause.cc
@@ -1,7 +1,3 @@
-#include <gflags/gflags.h>
-#include "certifier.h"
-#include "support.h"
-
 //  Copyright (c) 2021-22, VMware Inc, and the Certifier Authors.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,6 +16,10 @@
 //  --platform_subject=file --environment_subject=file --verb="speaks-for"
 //  --key_object=file --measurement_object=file --platform_object=file --environment_object=file
 //  --output=output-file-name
+
+#include <gflags/gflags.h>
+#include "certifier.h"
+#include "support.h"
 
 DEFINE_bool(print_all, false,  "verbose");
 DEFINE_string(output, "simple_clause.bin",  "output file");

--- a/utilities/make_unary_vse_clause.cc
+++ b/utilities/make_unary_vse_clause.cc
@@ -1,7 +1,3 @@
-#include <gflags/gflags.h>
-#include "certifier.h"
-#include "support.h"
-
 //  Copyright (c) 2021-22, VMware Inc, and the Certifier Authors.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,6 +14,10 @@
 
 // make_unary_vse_clause.exe --key_subject=file --measurement_subject=file --platform_subject=file
 //    --environment_subject=file --verb="is-trusted" --output=output-file-name
+
+#include <gflags/gflags.h>
+#include "certifier.h"
+#include "support.h"
 
 DEFINE_bool(print_all, false,  "verbose");
 DEFINE_string(output, "simple_clause.bin",  "output file");

--- a/utilities/measurement_init.cc
+++ b/utilities/measurement_init.cc
@@ -1,3 +1,17 @@
+//  Copyright (c) 2021-22, VMware Inc, and the Certifier Authors.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <gflags/gflags.h>
 #include <stdio.h>
 #include <stdint.h>
@@ -18,20 +32,6 @@ typedef unsigned char byte;
 #endif
 
 using std::string;
-
-//  Copyright (c) 2021-22, VMware Inc, and the Certifier Authors.  All rights reserved.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 
 
 DEFINE_bool(print_all, false,  "verbose");

--- a/utilities/measurement_utility.cc
+++ b/utilities/measurement_utility.cc
@@ -1,7 +1,3 @@
-#include <gflags/gflags.h>
-#include "certifier.h"
-#include "support.h"
-
 //  Copyright (c) 2021-22, VMware Inc, and the Certifier Authors.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,8 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 // make_measurement.exe --type=hash --input=input-file --output=output-file
+
+#include <gflags/gflags.h>
+#include "certifier.h"
+#include "support.h"
+
 DEFINE_bool(print_all, false,  "verbose");
 DEFINE_string(type, "hash",  "measurement type");
 DEFINE_string(input, "measurement_utility.exe",  "input file");

--- a/utilities/package_claims.cc
+++ b/utilities/package_claims.cc
@@ -1,7 +1,3 @@
-#include <gflags/gflags.h>
-#include "certifier.h"
-#include "support.h"
-
 //  Copyright (c) 2021-22, VMware Inc, and the Certifier Authors.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,6 +13,10 @@
 // limitations under the License.
 
 // package_claims.exe --input=file1,file2,... --output-file=filename
+
+#include <gflags/gflags.h>
+#include "certifier.h"
+#include "support.h"
 
 DEFINE_bool(print_all, false,  "verbose");
 DEFINE_string(input, "input1,input2,...,inputk",  "input file");

--- a/utilities/policy_generator.cc
+++ b/utilities/policy_generator.cc
@@ -1,13 +1,3 @@
-#include <fstream>
-#include <iostream>
-#include <iomanip>
-#include <string>
-#include <vector>
-#include <stdio.h>
-#include <gflags/gflags.h>
-#include <nlohmann/json.hpp>
-#include <nlohmann/json-schema.hpp>
-
 //  Copyright (c) 2021-23, VMware Inc, and the Certifier Authors.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,6 +11,16 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+#include <fstream>
+#include <iostream>
+#include <iomanip>
+#include <string>
+#include <vector>
+#include <stdio.h>
+#include <gflags/gflags.h>
+#include <nlohmann/json.hpp>
+#include <nlohmann/json-schema.hpp>
 
 using namespace std;
 using nlohmann::json;

--- a/utilities/print_packaged_claims.cc
+++ b/utilities/print_packaged_claims.cc
@@ -1,7 +1,3 @@
-#include <gflags/gflags.h>
-#include "certifier.h"
-#include "support.h"
-
 //  Copyright (c) 2021-22, VMware Inc, and the Certifier Authors.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,6 +13,10 @@
 // limitations under the License.
 
 // print_packaged_claims.exe --input=input-file
+
+#include <gflags/gflags.h>
+#include "certifier.h"
+#include "support.h"
 
 DEFINE_bool(print_all, false,  "verbose");
 DEFINE_string(input, "simple_clause.bin",  "input file");

--- a/utilities/print_signed_claim.cc
+++ b/utilities/print_signed_claim.cc
@@ -1,7 +1,3 @@
-#include <gflags/gflags.h>
-#include "certifier.h"
-#include "support.h"
-
 //  Copyright (c) 2021-22, VMware Inc, and the Certifier Authors.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,6 +13,10 @@
 // limitations under the License.
 
 // package_claims.exe --input=file1,file2,... --output-file=filename
+
+#include <gflags/gflags.h>
+#include "certifier.h"
+#include "support.h"
 
 DEFINE_bool(print_all, false,  "verbose");
 DEFINE_string(input, "",  "input file");

--- a/utilities/print_vse_clause.cc
+++ b/utilities/print_vse_clause.cc
@@ -1,7 +1,3 @@
-#include <gflags/gflags.h>
-#include "certifier.h"
-#include "support.h"
-
 //  Copyright (c) 2021-22, VMware Inc, and the Certifier Authors.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,6 +13,11 @@
 // limitations under the License.
 
 // print_vse_clause.exe --input=filename
+
+#include <gflags/gflags.h>
+#include "certifier.h"
+#include "support.h"
+
 DEFINE_bool(print_all, false,  "verbose");
 DEFINE_string(input, "measurement_utility.exe",  "input file");
 

--- a/utilities/sample_sev_key_generation.cc
+++ b/utilities/sample_sev_key_generation.cc
@@ -1,8 +1,3 @@
-#include <gflags/gflags.h>
-#include "certifier.h"
-#include "support.h"
-#include "attestation.h"
-
 //  Copyright (c) 2021-22, VMware Inc, and the Certifier Authors.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <gflags/gflags.h>
+#include "certifier.h"
+#include "support.h"
+#include "attestation.h"
 
 DEFINE_bool(print_all, false,  "verbose");
 DEFINE_string(ark_der, "sev_ark_cert.der",  "ark cert file");

--- a/utilities/simulated_sev_attest.cc
+++ b/utilities/simulated_sev_attest.cc
@@ -1,8 +1,3 @@
-#include "certifier.h"
-#include "support.h"
-#include "attestation.h"
-#include <gflags/gflags.h>
-
 //  Copyright (c) 2021-22, VMware Inc, and the Certifier Authors.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,6 +11,11 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+#include "certifier.h"
+#include "support.h"
+#include "attestation.h"
+#include <gflags/gflags.h>
 
 
 DEFINE_bool(print_all, false,  "verbose");

--- a/utilities/simulated_sev_key_generation.cc
+++ b/utilities/simulated_sev_key_generation.cc
@@ -1,14 +1,3 @@
-#include <gflags/gflags.h>
-#include "certifier.h"
-#include "support.h"
-#include "attestation.h"
-#include <openssl/evp.h>
-#include <openssl/err.h>
-#include <openssl/bio.h>
-#include <openssl/pem.h>
-#include <openssl/sha.h>
-
-
 //  Copyright (c) 2021-22, VMware Inc, and the Certifier Authors.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,6 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <gflags/gflags.h>
+#include <openssl/evp.h>
+#include <openssl/err.h>
+#include <openssl/bio.h>
+#include <openssl/pem.h>
+#include <openssl/sha.h>
+#include "certifier.h"
+#include "support.h"
+#include "attestation.h"
 
 DEFINE_bool(print_all, false,  "verbose");
 DEFINE_string(ark_der, "sev_ark_cert.der",  "ark cert file");


### PR DESCRIPTION
This commit relocates the Copyright notice to be at the top of the file so it's consistently placed at the very top in all files. In a few files, user #include's are re-arranged so that they follow system .h #includes. 

There are no other code-/logic-changes with this commit.

----
**NOTE: To reviewers**: This change-set is mostly of a cleanup-nature. However, lots of source files are affected.

In principle, by simply rearranging some user-#include's to appear -after- system #include's `.h` files should not regress compilation. We don't quite have a full build-and-test CI. So, what's the way to ensure that these source file edits do not regress compilation? 

I have left this PR in 'draft' - stage just so that we can talk about this change, and to figure out how to test these diffs to ensure that everything still builds cleanly.