### PR TITLE
Improve error handling and return of failure $rc for simple_app

### DIFF
--- a/include/cc_helpers.h
+++ b/include/cc_helpers.h
@@ -173,9 +173,9 @@ public:
   bool get_peer_id(string* out);
 };
 
-void server_dispatch(const string& host_name, int port,
-      string& asn1_root_cert, key_message& private_key,
-      const string& private_key_cert, void (*)(secure_authenticated_channel&));
+bool server_dispatch(const string& host_name, int port,
+                     string& asn1_root_cert, key_message& private_key,
+                     const string& private_key_cert, void (*)(secure_authenticated_channel&));
 
 #endif
 

--- a/sample_apps/simple_app/example_app.cc
+++ b/sample_apps/simple_app/example_app.cc
@@ -104,16 +104,6 @@ void server_application(secure_authenticated_channel& channel) {
   channel.write(strlen(msg), (byte*)msg);
 }
 
-bool run_me_as_server(const string& host_name, int port,
-      string& asn1_policy_cert, key_message& private_key,
-      string& private_key_cert) {
-
-  printf("running as server\n");
-  server_dispatch(host_name, port, asn1_policy_cert, private_key,
-      private_key_cert, server_application);
-  return true;
-}
-
 int main(int an, char** av) {
   gflags::ParseCommandLineFlags(&an, &av, true);
   an = 1;
@@ -196,7 +186,7 @@ int main(int an, char** av) {
       goto done;
     }
 
-    printf("running as client\n");
+    printf("Running App as client\n");
     if (!app_trust_data->cc_auth_key_initialized_ ||
         !app_trust_data->cc_policy_info_initialized_) {
       printf("trust data not initialized\n");
@@ -221,12 +211,15 @@ int main(int an, char** av) {
       ret = 1;
       goto done;
     }
-    printf("running as server\n");
-    server_dispatch(FLAGS_server_app_host, FLAGS_server_app_port,
-        app_trust_data->serialized_policy_cert_,
-          app_trust_data->private_auth_key_,
-          app_trust_data->private_auth_key_.certificate(),
-          server_application);
+    printf("Running App as server\n");
+    if (!server_dispatch(FLAGS_server_app_host, FLAGS_server_app_port,
+                         app_trust_data->serialized_policy_cert_,
+                         app_trust_data->private_auth_key_,
+                         app_trust_data->private_auth_key_.certificate(),
+                         server_application)) {
+      ret = 1;
+      goto done;
+    }
   } else {
     printf("Unknown operation\n");
   }

--- a/sample_apps/simple_app/example_app.mak
+++ b/sample_apps/simple_app/example_app.mak
@@ -28,7 +28,7 @@ US=.
 I= $(SRC_DIR)/include
 INCLUDE= -I$(I) -I/usr/local/opt/openssl@1.1/include/ -I$(S)/sev-snp/
 
-CFLAGS=$(INCLUDE) -O3 -g -Wall -std=c++11 -Wno-unused-variable -D X64 -Wno-deprecated-declarations
+CFLAGS=$(INCLUDE) -O3 -g -Wall -Werror -std=c++11 -Wno-unused-variable -D X64 -Wno-deprecated-declarations
 CFLAGS1=$(INCLUDE) -O1 -g -Wall -std=c++11 -Wno-unused-variable -D X64 -Wno-deprecated-declarations
 CC=g++
 LINK=g++

--- a/src/support.cc
+++ b/src/support.cc
@@ -676,7 +676,8 @@ bool private_key_to_public_key(const key_message& in, key_message* out) {
     out->set_key_type("ecc-384-public");
     n_bytes = cipher_block_byte_size("ecc_384-public");
   } else {
-    printf("private_key_to_public_key: bad key type\n");
+    // Shut compiler warning about n_bytes set-but-not-used
+    printf("private_key_to_public_key: bad key type (n_bytes=%d)\n", n_bytes);
     return false;
   }
 
@@ -922,7 +923,8 @@ bool key_to_RSA(const key_message& k, RSA* r) {
     key_size_bits= 4096;
     private_key = false;
   } else {
-    return false;
+    // Shut compiler warning about key_size_bits set-but-not-used
+    return (key_size_bits != 0);
   }
 
   if (!k.has_rsa_key()) {

--- a/utilities/cert_utility.mak
+++ b/utilities/cert_utility.mak
@@ -30,7 +30,7 @@ I= $(INC_DIR)
 US= .
 INCLUDE= -I$(I) -I/usr/local/opt/openssl@1.1/include/ -I$(S)/sev-snp/
 
-CFLAGS= $(INCLUDE) -O3 -g -Wall -std=c++11 -Wno-unused-variable -D X64 -Wno-deprecated -Wno-deprecated-declarations
+CFLAGS= $(INCLUDE) -O3 -g -Werror -Wall -std=c++11 -Wno-unused-variable -D X64 -Wno-deprecated -Wno-deprecated-declarations
 #For MAC, -D MACOS should be included
 CFLAGS1= $(INCLUDE) -O1 -g -Wall -std=c++11 -Wno-unused-variable -D X64 -Wno-deprecated -Wno-deprecated-declarations
 CC=g++

--- a/utilities/policy_generator.mak
+++ b/utilities/policy_generator.mak
@@ -26,7 +26,7 @@ LOCAL_LIB=$(JSON_VALIDATOR)/lib
 INCLUDE= -I$(JSON_VALIDATOR)/include
 
 CC=g++
-CFLAGS= $(INCLUDE) -O3 -g -Wall -Wno-unused-variable -D X64 -Wno-deprecated -Wno-deprecated-declarations
+CFLAGS= $(INCLUDE) -O3 -g -Wall -Werror -Wno-unused-variable -D X64 -Wno-deprecated -Wno-deprecated-declarations
 LD=g++
 LDFLAGS= -L$(LOCAL_LIB) -lnlohmann_json_schema_validator -lgflags
 

--- a/utilities/policy_utilities.mak
+++ b/utilities/policy_utilities.mak
@@ -32,7 +32,7 @@ CERT_SRC=$(CERTIFIER_PROTOTYPE_DIR)/src
 O= $(OBJ_DIR)
 INCLUDE= -I$(INC_DIR) -I/usr/local/opt/openssl@1.1/include/ -I$(CERT_SRC)/sev-snp/
 
-CFLAGS= $(INCLUDE) -O3 -g -Wall -std=c++11 -Wno-unused-variable -D X64 -Wno-deprecated -Wno-deprecated-declarations
+CFLAGS= $(INCLUDE) -O3 -g -Wall -Werror -std=c++11 -Wno-unused-variable -D X64 -Wno-deprecated -Wno-deprecated-declarations
 CFLAGS1= $(INCLUDE) -O1 -g -Wall -std=c++11 -Wno-unused-variable -D X64 -Wno-deprecated -Wno-deprecated-declarations
 # For Mac: -D MACOS should be defined
 


### PR DESCRIPTION
This commit tightens some error-handling and reporting failures in helper methods. These were discovered while trying to setup simple_app in a new env.

- server_dispatch() now returns 'bool'. Couple of usages in the code-flow of simple_app are updated to deal with this failure.

- Cleaned-up and improved some status / progress printf() messages
- Replaced, in some places, inline name of function with __func__.
-  Additionally, some warnings in support.cc are fixed. To improve overall code quality, I am introducing "-Werror" in all Makefiles. This way, in future, if compiler warnings creep-in, that will cause build failures. This will force us to keep the code free of warnings, too.

----
**NOTE: To reviewer(s)**: 

While setting up `sample_app/simple_app` in my Nimbus-VM environment, I ran into some errors.
I was also working on packaging the entire set of instructions into a simple `run_example.sh` bash script (Not included in this change-set). When one or more of the steps in the instructions would fail, some of the helper methods were not correcting returning failure error code to the caller. `server_dispatch()` is one such example.

When a specific step fails to execute correctly but the failure is not returned to the shell, the bash script continues to run. It is supposed to abort at the point of the 1st failure.

Under this commit, I am trying to do local improvements to the `$rc` reporting in code-paths that encountered some errors while attempting to setup `sample_app/simple_app` .

If the nature of this change is acceptable, I will try to apply similar constructs to other sample programs, to improve the error-handling overall with the example programs.