### PR TITLE
Add SetUsageMessage() and usage_str to set of programs in utilities/

### DIFF
--- a/utilities/appoint_platform.cc
+++ b/utilities/appoint_platform.cc
@@ -67,16 +67,21 @@ bool get_key_from_cert_file(const string& in, key_message* k) {
 }
 
 int main(int an, char** av) {
+  gflags::SetUsageMessage("Sample key-mgmt utility: RESOLVE - Fix message");
   gflags::ParseCommandLineFlags(&an, &av, true);
   an = 1;
 
+  string usage_str("--policy_key=<file> --cert_file=<ark_cert.bin> "
+                   "--output=<output-file-name>";
   if (FLAGS_policy_key_file == "") {
     printf("No policy key\n");
+    printf("%s %s\n", av[0], usage_str.c_str());
     return 1;
   }
 
   if (FLAGS_cert_file == "") {
     printf("No cert\n");
+    printf("%s: %s\n", av[0], usage_str.c_str());
     return 1;
   }
 

--- a/utilities/cert_utility.cc
+++ b/utilities/cert_utility.cc
@@ -252,17 +252,26 @@ bool generate_key(const string& type, const string& name, key_message* k) {
 
 
 int main(int an, char** av) {
+  string usage("Certifier utility to generate policy-keys and test-keys");
+  gflags::SetUsageMessage(usage);
   gflags::ParseCommandLineFlags(&an, &av, true);
 
   if (FLAGS_operation == "") {
-    printf("cert_utility.exe --operation=generate-policy-key --policy_key_output_file=key_file.bin");
-    printf(" --policy_cert_output_file=policy_cert_file.bin\n");
-    printf("cert_utility.exe --operation=generate-policy-key-and-test-keys ");
-    printf(" --policy_key_output_file=key_file.bin --policy_cert_output_file=policy_cert_file.bin ");
-    printf("--platform_key_output_file=key_file.bin --attest_key_output_file=key_file.bin\n");
-    printf("cert_utility.exe --operation=generate-key --key_type=rsa-2048 --key_name=name\n");
-    printf(" --key_output_file=key_file.bin\n");
-    printf(" --cert_output_file=policy_cert_file.bin\n");
+    printf("%s: %s\n", av[0], usage.c_str());
+    printf("\n%s --operation=generate-policy-key "
+           "--policy_key_output_file=<key_file.bin> "
+           "--policy_cert_output_file=<policy_cert_file.bin>\n",
+           av[0]);
+
+    printf("\n%s --operation=generate-policy-key-and-test-keys "
+           "--policy_key_output_file=<key_file.bin> "
+           "--policy_cert_output_file=<policy_cert_file.bin> "
+           "--platform_key_output_file=<key_file.bin> "
+           "--attest_key_output_file=<key_file.bin>\n", av[0]);
+
+    printf("\n%s --operation=generate-key --key_type=rsa-2048 --key_name=name "
+           "--key_output_file=<key_file.bin> "
+           "--cert_output_file=<policy_cert_file.bin>\n", av[0]);
     return 0;
   }  else if (FLAGS_operation == "test-sig") {
     test_sig();

--- a/utilities/combine_properties.cc
+++ b/utilities/combine_properties.cc
@@ -52,12 +52,14 @@ bool get_input_file_names(const string& name, int* num, string* names) {
 }
 
 int main(int an, char** av) {
+  string usage("Combine properties from multiple files into one output file");
+  gflags::SetUsageMessage(usage);
   gflags::ParseCommandLineFlags(&an, &av, true);
   an = 1;
 
   if (FLAGS_in == "") {
-    printf("No input files\n");
-    printf("combine_properties.exe --in=name --output=out_file\n");
+    printf("%s: No input files\n", usage.c_str());
+    printf("%s --in=name --output=<out_file>\n", av[0]);
     return 1;
   }
 

--- a/utilities/embed_policy_key.cc
+++ b/utilities/embed_policy_key.cc
@@ -135,6 +135,8 @@ return true;
 }
 
 int main(int an, char** av) {
+  string usage("Generate policy certificate to embed policy key in sample app");
+  gflags::SetUsageMessage(usage);
   gflags::ParseCommandLineFlags(&an, &av, true);
 
   if (FLAGS_input == "") {

--- a/utilities/key_utility.cc
+++ b/utilities/key_utility.cc
@@ -62,12 +62,17 @@ bool generate_key(const string& name, const string& type,
 }
 
 int main(int an, char** av) {
+  string usage("Generate certificate keys in different formats to output file");
+  gflags::SetUsageMessage(usage);
   gflags::ParseCommandLineFlags(&an, &av, true);
 
-  printf("key_utility.exe --key_type=rsa-2048-private --key_output_file=key_file.bin\n");
-  printf(" --generate_cert=false, --cert_output_file=cert_file.bin\n");
-  printf(" --duration=in-seconds --serial_number=123231--authority_name=authority\n");
-  printf("Key types : rsa-1024-private , rsa-2048-private, rsa-4096-private, ecc-384-private\n");
+  printf("%s: %s\n", av[0], usage.c_str());
+  printf("%s --key_type=<key-type> --key_output_file=<key_file.bin> "
+         "--generate_cert=false --cert_output_file=<cert_file.bin> "
+         "--duration=in-seconds --serial_number=123231 "
+         "--authority_name=authority\n", av[0]);
+  printf("Key types : rsa-1024-private, rsa-2048-private"
+         ", rsa-4096-private, ecc-384-private\n");
 
   key_message priv;
   key_message pub;

--- a/utilities/make_environment.cc
+++ b/utilities/make_environment.cc
@@ -48,10 +48,15 @@ bool calculate_measurement(const string& in, string* out) {
 }
 
 int main(int an, char** av) {
+  string usage("Generate platform measurement to output file");
+  gflags::SetUsageMessage(usage);
   gflags::ParseCommandLineFlags(&an, &av, true);
   an = 1;
 
   if (FLAGS_platform_file == "" && FLAGS_measurement_file == "" && FLAGS_output == "") {
+    printf("%s: %s\n", av[0], usage.c_str());
+    printf("%s --platform_file=<file> --measurement_file=<file> --output=<file>\n",
+           av[0]);
     printf("Too few arguments\n");
     return 1;
   }

--- a/utilities/make_indirect_vse_clause.cc
+++ b/utilities/make_indirect_vse_clause.cc
@@ -113,16 +113,22 @@ bool get_measurement_entity_from_file(const string& in, entity_message* em) {
 }
 
 int main(int an, char** av) {
+  string usage("Generate certificate keys in different formats to output file");
+  gflags::SetUsageMessage(usage);
   gflags::ParseCommandLineFlags(&an, &av, true);
   an = 1;
 
+  string usage_str("--key_subject=<file> --verb=\"says\" --clause=<file> "
+                   "--output=<output-file-name>");
   if (FLAGS_key_subject == "" && FLAGS_measurement_subject == "") {
-    printf("No subject\n");
+    printf("No key or measurement subject\n");
+    printf("%s: %s\n", av[0], usage_str.c_str());
     return 1;
   }
 
   if (FLAGS_clause == "") {
     printf("No clause file\n");
+    printf("%s %s\n", av[0], usage_str.c_str());
     return 1;
   }
 

--- a/utilities/make_platform.cc
+++ b/utilities/make_platform.cc
@@ -24,11 +24,17 @@ DEFINE_string(properties_file, "",  "properties files");
 DEFINE_string(output, "",  "output file");
 
 int main(int an, char** av) {
+  string usage("Generate platform-specific serialization of certificate. RESOLVE: Fix msg");
+  gflags::SetUsageMessage(usage);
   gflags::ParseCommandLineFlags(&an, &av, true);
   an = 1;
 
+  string usage_str("--platform_type=amd-sev-snp "
+                   "--properties_file=<properties.bin> "
+                   "--output=<platform.bin>");
   if (FLAGS_platform_type == "") {
     printf("No platform type\n");
+    printf("%s %s\n", av[0], usage_str.c_str());
     return 1;
   }
 

--- a/utilities/make_platform.cc
+++ b/utilities/make_platform.cc
@@ -24,7 +24,7 @@ DEFINE_string(properties_file, "",  "properties files");
 DEFINE_string(output, "",  "output file");
 
 int main(int an, char** av) {
-  string usage("Generate platform-specific serialization of certificate. RESOLVE: Fix msg");
+  string usage("Construct platform characteristics for platform verification policy");
   gflags::SetUsageMessage(usage);
   gflags::ParseCommandLineFlags(&an, &av, true);
   an = 1;

--- a/utilities/make_property.cc
+++ b/utilities/make_property.cc
@@ -29,7 +29,7 @@ DEFINE_string(string_value, "",  "string value");
 DEFINE_string(output, "prop.bin",  "output file");
 
 int main(int an, char** av) {
-  string usage("Specify the trusted platform policy property RESOLVE: Fix msg");
+  string usage("Specify a platform policy property used in policy.");
   gflags::SetUsageMessage(usage);
   gflags::ParseCommandLineFlags(&an, &av, true);
   an = 1;

--- a/utilities/make_property.cc
+++ b/utilities/make_property.cc
@@ -29,12 +29,17 @@ DEFINE_string(string_value, "",  "string value");
 DEFINE_string(output, "prop.bin",  "output file");
 
 int main(int an, char** av) {
+  string usage("Specify the trusted platform policy property RESOLVE: Fix msg");
+  gflags::SetUsageMessage(usage);
   gflags::ParseCommandLineFlags(&an, &av, true);
   an = 1;
 
+  string usage_str("--property_name=<name> --property_type=<type> "
+                   "--comparator=<cmp> --int_value=3 "
+                   "--string_value=<string> --output=<output_file>");
   if (FLAGS_property_name == "") {
     printf("No property name\n");
-    printf("make_property.exe --property_name=name --property_type=type --comparator=cmp --int_value=3 --string_value=string--output=out_file\n");
+    printf("%s %s\n", av[0], usage_str.c_str());
     return 1;
   }
 


### PR DESCRIPTION
Enhance few programs in utilities/ sub-dir to call gflags::SetUsageMessage(), so that basic description of the program can be seen via --help output. Add, where needed, usage_str(), to report basic usage information.

------
**NOTE: To reviewer(s)**: 

This is just a sample set of changes to add improved help / usage messages to a small collection of programs. I think, by consistently reporting a small one-liner explaining what the purpose of each program is, we can improve the on-boarding experience for new users.

The actual content of the message will need to be hand-crafted for each program. I do not have sufficient familiarity with each program to craft a message. So, the bulk / brunt of the review process will be for the code-author and me to sit down and hash-out a descriptive message for each program.