### PR TITLE
Add Ssl_errors[] as an optlookup{} table to map SSL-error IDs to messages.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,11 +19,17 @@ jobs:
         sudo apt install libgtest-dev libgflags-dev openssl libssl-dev protobuf-compiler
     - name: make
       run: |
+        #! Check that core certifier programs still compile
         cd src
         make -f certifier.mak
         rm ./*.o
         make -f certifier_tests.mak
         ./certifier_tests.exe
+        #! Check that utilities programs still compile
         cd ../utilities
         make -f cert_utility.mak
         make -f policy_utilities.mak
+        #! Few other miscellaneous checks
+        cd ../certifier_service/oelib
+        make clean
+        make dummy

--- a/application_service/app_service.mak
+++ b/application_service/app_service.mak
@@ -41,11 +41,11 @@ AR=ar
 LDFLAGS= -L $(LOCAL_LIB) -lprotobuf -lgtest -lgflags -lpthread -L/usr/local/opt/openssl@1.1/lib/ -lcrypto -lssl
 
 dobj=	$(O)/app_service.o $(O)/certifier.pb.o $(O)/certifier.o $(O)/certifier_proofs.o $(O)/support.o \
-$(O)/simulated_enclave.o $(O)/application_enclave.o $(O)/cc_helpers.o \
+$(O)/simulated_enclave.o $(O)/application_enclave.o $(O)/cc_helpers.o $(O)/cc_useful.o \
 $(O)/sev_support.o $(O)/sev_report.o
 
 user_dobj= $(O)/test_user.o $(O)/certifier.pb.o $(O)/certifier.o $(O)/certifier_proofs.o $(O)/support.o \
-$(O)/simulated_enclave.o $(O)/application_enclave.o $(O)/cc_helpers.o
+$(O)/simulated_enclave.o $(O)/application_enclave.o $(O)/cc_helpers.o $(O)/cc_useful.o
 
 
 all:	app_service.exe hello_world.exe send_request.exe test_user.exe
@@ -104,6 +104,10 @@ $(O)/support.o: $(LIBSRC)/support.cc $(I)/support.h
 $(O)/cc_helpers.o: $(LIBSRC)/cc_helpers.cc $(I)/cc_helpers.h
 	@echo "compiling cc_helpers.cc"
 	$(CC) $(CFLAGS) -c -o $(O)/cc_helpers.o $(LIBSRC)/cc_helpers.cc
+
+$(O)/cc_useful.o: $(S)/cc_useful.cc $(I)/cc_useful.h
+	@echo "compiling cc_useful.cc"
+	$(CC) $(CFLAGS) -c -o $(O)/cc_useful.o $(S)/cc_useful.cc
 
 $(O)/simulated_enclave.o: $(LIBSRC)/simulated_enclave.cc $(I)/simulated_enclave.h
 	@echo "compiling simulated_enclave.cc"

--- a/certifier_service/certlib/certlib_proofs.go
+++ b/certifier_service/certlib/certlib_proofs.go
@@ -25,8 +25,6 @@ import (
 	"crypto/x509"
 	"google.golang.org/protobuf/proto"
 	certprotos "github.com/jlmucb/crypto/v2/certifier-framework-for-confidential-computing/certifier_service/certprotos"
-	oeverify "github.com/jlmucb/crypto/v2/certifier-framework-for-confidential-computing/certifier_service/oeverify"
-	gramineverify "github.com/jlmucb/crypto/v2/certifier-framework-for-confidential-computing/certifier_service/gramineverify"
 )
 
 

--- a/include/cc_useful.h
+++ b/include/cc_useful.h
@@ -1,0 +1,43 @@
+//  Copyright (c) 2021-22, VMware Inc, and the Certifier Authors.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef __CC_USEFUL_H__
+#define __CC_USEFUL_H__
+
+/*
+ * A collection of useful macros and things ...
+ */
+#define CC_TO_STR(x)       #x
+
+// Return this for 'unknown thing', to avoid seg-faults when printing.
+#define CC_EMPTY_STRING (const char *) ""
+
+
+/* Option {value -> name } lookup structure */
+typedef struct optlookup {
+  const int   id;
+  const char *name;
+} optlookup;
+
+#define DCL__OPTLOOKUP(token, descr) { .id = token, .name =  descr }
+
+#define DCL_OPTLOOKUP(token, descr)                                  \
+        DCL__OPTLOOKUP(token, #token ": " descr )
+
+// Declare a terminating entry for optlookup table
+#define DCL_OPTLOOKUP_TERM() { .id = -1, .name = NULL }
+
+const char * optbyid(optlookup * opt, int id);
+
+#endif   /* __CC_USEFUL_H__ */

--- a/sample_apps/simple_app/example_app.mak
+++ b/sample_apps/simple_app/example_app.mak
@@ -41,7 +41,8 @@ LDFLAGS= -L $(LOCAL_LIB) -lprotobuf -lgtest -lgflags -lpthread -L/usr/local/opt/
 # Note:  You can omit all the files below in d_obj except $(O)/example_app.o,
 #  if you link in the certifier library certifier.a.
 dobj=	$(O)/example_app.o $(O)/certifier.pb.o $(O)/certifier.o $(O)/certifier_proofs.o \
-$(O)/support.o $(O)/simulated_enclave.o $(O)/application_enclave.o $(O)/cc_helpers.o
+      $(O)/support.o $(O)/simulated_enclave.o $(O)/application_enclave.o $(O)/cc_helpers.o \
+      $(O)/cc_useful.o
 
 
 all:	example_app.exe
@@ -92,3 +93,7 @@ $(O)/application_enclave.o: $(S)/application_enclave.cc $(I)/application_enclave
 $(O)/cc_helpers.o: $(S)/cc_helpers.cc $(I)/certifier.h $(US)/certifier.pb.cc
 	@echo "compiling cc_helpers.cc"
 	$(CC) $(CFLAGS) -c -o $(O)/cc_helpers.o $(S)/cc_helpers.cc
+
+$(O)/cc_useful.o: $(S)/cc_useful.cc $(I)/cc_useful.h
+	@echo "compiling cc_useful.cc"
+	$(CC) $(CFLAGS) -c -o $(O)/cc_useful.o $(S)/cc_useful.cc

--- a/sample_apps/simple_app_under_app_service/service_example_app.mak
+++ b/sample_apps/simple_app_under_app_service/service_example_app.mak
@@ -41,9 +41,10 @@ LDFLAGS= -L $(LOCAL_LIB) -lprotobuf -lgtest -lgflags -lpthread -L/usr/local/opt/
 # Note:  You can omit all the files below in d_obj except $(O)/example_app.o,
 #  if you link in the certifier library certifier.a.
 dobj=	$(O)/service_example_app.o $(O)/certifier.pb.o $(O)/certifier.o $(O)/certifier_proofs.o \
-$(O)/support.o $(O)/simulated_enclave.o $(O)/application_enclave.o $(O)/cc_helpers.o
+$(O)/support.o $(O)/simulated_enclave.o $(O)/application_enclave.o $(O)/cc_helpers.o $(O)/cc_useful.o
+
 sp_dobj=$(O)/start_program.o $(O)/certifier.pb.o $(O)/certifier.o $(O)/certifier_proofs.o $(O)/support.o \
-$(O)/simulated_enclave.o $(O)/application_enclave.o $(O)/cc_helpers.o
+$(O)/simulated_enclave.o $(O)/application_enclave.o $(O)/cc_helpers.o $(O)/cc_useful.o
 
 
 all:	service_example_app.exe start_program.exe
@@ -101,3 +102,8 @@ $(O)/application_enclave.o: $(S)/application_enclave.cc $(I)/application_enclave
 $(O)/cc_helpers.o: $(S)/cc_helpers.cc $(I)/certifier.h $(S)/certifier.pb.cc
 	@echo "compiling cc_helpers.cc"
 	$(CC) $(CFLAGS) -c -o $(O)/cc_helpers.o $(S)/cc_helpers.cc
+
+$(O)/cc_useful.o: $(S)/cc_useful.cc $(I)/cc_useful.h
+	@echo "compiling cc_useful.cc"
+	$(CC) $(CFLAGS) -c -o $(O)/cc_useful.o $(S)/cc_useful.cc
+

--- a/sample_apps/simple_app_under_gramine/gramine_example_app.mak
+++ b/sample_apps/simple_app_under_gramine/gramine_example_app.mak
@@ -38,6 +38,7 @@ CERTIFIER_SRC = $(CERTIFIER_SRC_PATH)/gramine/gramine_api.cc        \
 		$(CERTIFIER_SRC_PATH)/simulated_enclave.cc          \
 		$(CERTIFIER_SRC_PATH)/application_enclave.cc        \
 		$(CERTIFIER_SRC_PATH)/cc_helpers.cc                 \
+		$(CERTIFIER_SRC_PATH)/cc_useful.cc                  \
 		$(CERTIFIER_SRC_PATH)/test_support.cc               \
 		$(CERTIFIER_SRC_PATH)/certifier.pb.cc               \
 

--- a/sample_apps/simple_app_under_sev/sev_example_app.mak
+++ b/sample_apps/simple_app_under_sev/sev_example_app.mak
@@ -39,7 +39,7 @@ LDFLAGS= -L $(LOCAL_LIB) -lprotobuf -lgtest -lgflags -lpthread -L/usr/local/opt/
 #  if you link in the certifier library certifier.a.
 dobj=	$(O)/sev_example_app.o $(O)/certifier.pb.o $(O)/certifier.o $(O)/certifier_proofs.o $(O)/support.o \
 $(O)/application_enclave.o $(O)/simulated_enclave.o  $(O)/sev_support.o \
-$(O)/sev_report.o $(O)/cc_helpers.o
+$(O)/sev_report.o $(O)/cc_helpers.o $(O)/cc_useful.o
 
 
 all:	sev_example_app.exe
@@ -89,6 +89,10 @@ $(O)/application_enclave.o: $(S)/application_enclave.cc $(I)/application_enclave
 $(O)/cc_helpers.o: $(S)/cc_helpers.cc $(I)/certifier.h $(S)/certifier.pb.cc
 	@echo "compiling cc_helpers.cc"
 	$(CC) $(CFLAGS) -c -o $(O)/cc_helpers.o $(S)/cc_helpers.cc
+
+$(O)/cc_useful.o: $(S)/cc_useful.cc $(I)/cc_useful.h
+	@echo "compiling cc_useful.cc"
+	$(CC) $(CFLAGS) -c -o $(O)/cc_useful.o $(S)/cc_useful.cc
 
 SEV_S=$(S)/sev-snp
 

--- a/sample_apps/simple_app_under_sev/sev_example_app_with_dummy.mak
+++ b/sample_apps/simple_app_under_sev/sev_example_app_with_dummy.mak
@@ -39,7 +39,7 @@ LDFLAGS= -L $(LOCAL_LIB) -lprotobuf -lgtest -lgflags -lpthread -L/usr/local/opt/
 #  if you link in the certifier library certifier.a.
 dobj=	$(O)/sev_example_app.o $(O)/certifier.pb.o $(O)/certifier.o $(O)/certifier_proofs.o $(O)/support.o \
 $(O)/application_enclave.o $(O)/simulated_enclave.o  $(O)/sev_support.o \
-$(O)/sev_report.o $(O)/cc_helpers.o
+$(O)/sev_report.o $(O)/cc_helpers.o $(O)/cc_useful.o
 
 
 all:	sev_example_app.exe
@@ -89,6 +89,10 @@ $(O)/application_enclave.o: $(S)/application_enclave.cc $(I)/application_enclave
 $(O)/cc_helpers.o: $(S)/cc_helpers.cc $(I)/certifier.h $(S)/certifier.pb.cc
 	@echo "compiling cc_helpers.cc"
 	$(CC) $(CFLAGS) -c -o $(O)/cc_helpers.o $(S)/cc_helpers.cc
+
+$(O)/cc_useful.o: $(S)/cc_useful.cc $(I)/cc_useful.h
+	@echo "compiling cc_useful.cc"
+	$(CC) $(CFLAGS) -c -o $(O)/cc_useful.o $(S)/cc_useful.cc
 
 SEV_S=$(S)/sev-snp
 

--- a/src/cc_useful.cc
+++ b/src/cc_useful.cc
@@ -1,0 +1,38 @@
+//  Copyright (c) 2021-22, VMware Inc, and the Certifier Authors.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cstddef>
+#include "cc_useful.h"
+
+/*
+ * Implementation for a collection of useful macros and things ...
+ */
+
+/*
+ * Find 'optid' in 'opt' lookup array, return option's name.
+ * Returns NULL if optid is not found in lookup array.
+ */
+const char * optbyid(optlookup * opt_array, int optid) {
+  if (!opt_array) {
+    return CC_EMPTY_STRING;
+  }
+  // Expect array to be terminated by a NULL-name entry
+  optlookup *opt = NULL;
+  for (opt = opt_array; opt->name; opt++) {
+      if (opt->id == optid) {
+         return opt->name;
+      }
+  }
+  return NULL;
+}

--- a/src/certifier.mak
+++ b/src/certifier.mak
@@ -54,10 +54,10 @@ LDFLAGS= -L $(LOCAL_LIB) -lprotobuf -lgtest -lgflags -lpthread -L/usr/local/opt/
 ifdef ENABLE_SEV
 dobj=	$(O)/certifier.pb.o $(O)/certifier.o $(O)/certifier_proofs.o $(O)/support.o \
 $(O)/application_enclave.o $(O)/simulated_enclave.o \
-$(O)/sev_support.o $(O)/sev_report.o $(O)/cc_helpers.o
+$(O)/sev_support.o $(O)/sev_report.o $(O)/cc_helpers.o $(O)/cc_useful.o
 else
 dobj=	$(O)/certifier.pb.o $(O)/certifier.o $(O)/certifier_proofs.o $(O)/support.o \
-$(O)/application_enclave.o $(O)/simulated_enclave.o $(O)/cc_helpers.o
+$(O)/application_enclave.o $(O)/simulated_enclave.o $(O)/cc_helpers.o $(O)/cc_useful.o
 endif
 
 
@@ -108,6 +108,10 @@ $(O)/application_enclave.o: $(S)/application_enclave.cc $(I)/application_enclave
 $(O)/cc_helpers.o: $(S)/cc_helpers.cc $(I)/cc_helpers.h
 	@echo "compiling cc_helpers.cc"
 	$(CC) $(CFLAGS) -c -o $(O)/cc_helpers.o $(S)/cc_helpers.cc
+
+$(O)/cc_useful.o: $(S)/cc_useful.cc $(I)/cc_useful.h
+	@echo "compiling cc_useful.cc"
+	$(CC) $(CFLAGS) -c -o $(O)/cc_useful.o $(S)/cc_useful.cc
 
 ifdef ENABLE_SEV
 SEV_S=$(S)/sev-snp

--- a/src/certifier_tests.mak
+++ b/src/certifier_tests.mak
@@ -66,13 +66,13 @@ ifdef ENABLE_SEV
 dobj=	$(O)/certifier_tests.o $(O)/certifier.pb.o $(O)/certifier.o $(O)/certifier_proofs.o \
 $(O)/support.o $(O)/simulated_enclave.o \
 $(O)/certificate_tests.o $(O)/claims_tests.o $(O)/primitive_tests.o \
-$(O)/cc_helpers.o $(O)/sev_tests.o $(O)/store_tests.o $(O)/support_tests.o \
+$(O)/cc_helpers.o $(O)/cc_useful.o $(O)/sev_tests.o $(O)/store_tests.o $(O)/support_tests.o \
 $(O)/application_enclave.o $(O)/sev_support.o $(O)/sev_report.o \
 $(O)/x509_tests.o
 
 channel_dobj=	$(O)/test_channel.o $(O)/certifier.pb.o $(O)/certifier.o $(O)/support.o \
 $(O)/certifier_proofs.o  $(O)/simulated_enclave.o $(O)/application_enclave.o \
-$(O)/cc_helpers.o $(O)/sev_support.o $(O)/sev_report.o 
+$(O)/cc_helpers.o $(O)/cc_useful.o $(O)/sev_support.o $(O)/sev_report.o
 
 pipe_read_dobj=	$(O)/pipe_read_test.o $(O)/certifier.pb.o $(O)/certifier.o $(O)/certifier_proofs.o \
 $(O)/support.o $(O)/simulated_enclave.o $(O)/application_enclave.o $(O)/sev_support.o $(O)/sev_report.o
@@ -81,12 +81,13 @@ else
 
 dobj=	$(O)/certifier_tests.o $(O)/certifier.pb.o $(O)/certifier.o $(O)/certifier_proofs.o \
 $(O)/support.o $(O)/simulated_enclave.o \
-$(O)/cc_helpers.o $(O)/application_enclave.o $(O)/claims_tests.o $(O)/primitive_tests.o \
+$(O)/cc_helpers.o $(O)/cc_useful.o $(O)/application_enclave.o $(O)/claims_tests.o $(O)/primitive_tests.o \
 $(O)/certificate_tests.o $(O)/sev_tests.o $(O)/store_tests.o $(O)/support_tests.o \
 $(O)/x509_tests.o
 
 channel_dobj=	$(O)/test_channel.o $(O)/certifier.pb.o $(O)/certifier.o $(O)/certifier_proofs.o \
 $(O)/support.o $(O)/simulated_enclave.o $(O)/application_enclave.o $(O)/cc_helpers.o \
+$(O)/cc_useful.o
 
 pipe_read_dobj=	$(O)/pipe_read_test.o $(O)/certifier.pb.o $(O)/certifier.o $(O)/certifier_proofs.o  \
 $(O)/support.o $(O)/simulated_enclave.o $(O)/application_enclave.o
@@ -155,6 +156,10 @@ $(O)/certifier_proofs.o: $(S)/certifier_proofs.cc $(I)/certifier.pb.h $(I)/certi
 $(O)/cc_helpers.o: $(S)/cc_helpers.cc $(I)/certifier.pb.h $(I)/cc_helpers.h
 	@echo "compiling cc_helpers.cc"
 	$(CC) $(CFLAGS) -c -o $(O)/cc_helpers.o $(S)/cc_helpers.cc
+
+$(O)/cc_useful.o: $(S)/cc_useful.cc $(I)/cc_useful.h
+	@echo "compiling cc_useful.cc"
+	$(CC) $(CFLAGS) -c -o $(O)/cc_useful.o $(S)/cc_useful.cc
 
 $(O)/support.o: $(S)/support.cc $(I)/support.h
 	@echo "compiling support.cc"


### PR DESCRIPTION
This commit refactors a bit of existing inline code that maps SSL error-code IDs to human-readable string describing the error.

- Introduce cc_useful.h / cc_useful.cc to define a new optlookup{} struct. Add optbyid(), to lookup string associated with an ID
- Add Ssl_errors[] optlookup array.
- Replace inline body of print_ssl_error() with call to optbyid() to lookup error-ID to error-description (strng).
- Use ssl_strerror() to print client-side SSL-errors.

This debug infra has been exercised while setting up simple_app on Nimbus-VM, where we are [strangely] encountering SSL errors.

- Delete couple of imports in certlib/certlib_proofs.go that result in Go compilation warnings.


-----
**NOTE to the reviewer**: 

This tracing / debugging refactoring came about while I was stabilizing the execution of newly added `run_example.sh`, being built under PR #48 . In my Nimbus-VM env, I am strangely running into SSL-errors. To debug the SSL error code, I refactored existing code as you see in this PR.

The failure of `simple_app` will be debugged separately under above PR. Once this change goes into `/main`, I will be able to pull into the other dev-branch to continue debugging w/ this improved & simplified tracing code.

Attn: The deletion of couple of imports in one of the Go programs need a 2nd-look. I need those to get the builds working. Please see my annotations in the corresponding file.

(My first change-set ran into build failures in CI. I had to fix a collection of Makefiles to include `c_useful.o`. Things are better now with CI tests.)

@jlmucb -- Once you approve these changes, let me know. I will rebase the commit to make one push (commit) into `/main`. Thanks!