### PR TITLE
Add rm_non_git_files() that only does 'git ls-files' for now.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,8 @@ jobs:
         cd ../sample_apps/simple_app
         ./cleanup.sh
         ./run_example.sh
+        ./cleanup.sh
+
         #! ---------------------------------------------------------------------
         #! Few other miscellaneous checks
         cd ../../certifier_service/oelib

--- a/sample_apps/simple_app/README.md
+++ b/sample_apps/simple_app/README.md
@@ -20,14 +20,17 @@ You can use this script to Build and run example program simple_app.
    - Run individual step in sequence.
 
 Usage: run_example.sh [--help | --list]
-  To run the example program          : ./run_example.sh
-  To setup the example program        : ./run_example.sh setup
-  To run and test the example program : ./run_example.sh run_test
-  To list the individual steps        : ./run_example.sh --list
-  To run an individual step           : ./run_example.sh <step name>
+  To setup and run the example program, end-to-end : ./run_example.sh
+  To setup the example program                     : ./run_example.sh setup
+  To run and test the example program              : ./run_example.sh run_test
+  To list the individual steps                     : ./run_example.sh --list
+  To run an individual step                        : ./run_example.sh <step name>
 ```
 
 - To setup and run the simple_app: `$ run_example.sh`
+  In this mode, any artifacts produced by previous steps will be deleted, so
+  you can exercise a clean end-to-end run of this script.
+
 - In case there is any cleanup needed, issue: `$ cleanup.sh`
 - You can perform the setup once, and execute the test multiple times as follows:
 

--- a/sample_apps/simple_app/cleanup.sh
+++ b/sample_apps/simple_app/cleanup.sh
@@ -12,6 +12,8 @@ Me=$(basename "$0")
 parent_pid=-99999
 if [ $# -eq 1 ]; then parent_pid="$1"; fi
 
+Killed_some_procs=0
+
 # ##############################################################################
 function cleanup_stale_procs() {
 
@@ -34,6 +36,7 @@ function cleanup_stale_procs() {
             # kill -9 ${pid}
             kill -s SIGKILL ${pid} || :
             set +x
+            Killed_some_procs=1
         fi
     done
 }
@@ -43,4 +46,9 @@ if [ ${parent_pid} -gt 0 ]; then
    echo "${Me}: Cleanup stale processes (parent_pid=${parent_pid}) ..."
 fi
 cleanup_stale_procs
+
+# To let open sockets be drained etc ... Empirical fix to get stuff running on CI
+if [ "${Killed_some_procs}" = "1" ]; then
+   echo "${Me}: $(TZ="America/Los_Angeles" date) Completed."
+fi
 exit 0

--- a/utilities/policy_utilities.mak
+++ b/utilities/policy_utilities.mak
@@ -28,8 +28,11 @@ TARGET_MACHINE_TYPE= x64
 endif
 
 S= $(SRC_DIR)
-CERT_SRC=$(CERTIFIER_PROTOTYPE_DIR)/src
 O= $(OBJ_DIR)
+I= $(INC_DIR)
+US= .
+CERT_SRC=$(CERTIFIER_PROTOTYPE_DIR)/src
+
 INCLUDE= -I$(INC_DIR) -I/usr/local/opt/openssl@1.1/include/ -I$(CERT_SRC)/sev-snp/
 
 CFLAGS= $(INCLUDE) -O3 -g -Wall -Werror -std=c++11 -Wno-unused-variable -D X64 -Wno-deprecated -Wno-deprecated-declarations
@@ -116,9 +119,9 @@ $(O)/key_utility.o: $(US)/key_utility.cc $(INC_DIR)/support.h $(INC_DIR)/certifi
 	@echo "compiling key_utility.cc"
 	$(CC) $(CFLAGS) -c -o $(O)/key_utility.o $(US)/key_utility.cc
 
-#$(US)/certifier.pb.cc $(I)/certifier.pb.h: $(CERT_SRC)/certifier.proto
-#	$(PROTO) -I$(S) --cpp_out=$(US) $(CERT_SRC)/certifier.proto
-#	mv certifier.pb.h $(I)
+$(CERT_SRC)/certifier.pb.cc $(I)/certifier.pb.h: $(CERT_SRC)/certifier.proto
+	$(PROTO) -I$(S) --proto_path=$(CERT_SRC) --cpp_out=$(CERT_SRC) $(CERT_SRC)/certifier.proto
+	mv $(CERT_SRC)/certifier.pb.h $(I)
 
 $(O)/certifier.pb.o: $(CERT_SRC)/certifier.pb.cc $(INC_DIR)/certifier.pb.h
 	@echo "compiling certifier.pb.cc"


### PR DESCRIPTION
Remove dependency of simple_app/run_example.sh on existence of src/certifier.pb.cc

This commit cleanses some logic in simple_app/run_example.sh to clean-up all non-git-tracked artifacts (.o's, .exe's, .cc/.h files etc.) from the dev area where steps to build-and-run simple_app are executed.

Previously, (in CI), other steps would have run 'make -f certifier.mak' in src/ sub-dir, that produces the required src/certifier.pb.cc file.

Rework the rules in utilities/policy_utilities.mak to correctly compile the protobuf file (from src/) to generate *.pb.cc/*.pb.h in the required sub-dirs.
Fix shellcheck errors in shell script.