### PR TITLE
Allow specification of authenticated encryption algorithm for Protect

### DIFF
--- a/src/support.cc
+++ b/src/support.cc
@@ -32,6 +32,9 @@
 #include <string>
 using std::string;
 
+string authenticated_encryption_algorithm("aes-256-cbc-hmac-sha256");
+
+
 // -----------------------------------------------------------------------
 
 class name_size {


### PR DESCRIPTION
This small change lets us specify the authenticated encryption algorithm for Protect_Blob.  The default is "aes-256-cbc-hmac-sha256" but you can also specify "aes-256-gcm"."  This  keeps us in conformance with CNSA 2.0.