### PR TITLE
Add the IP address of the remote peer in the admission certificate

### DIFF
--- a/certifier_service/certlib/certlib_support.go
+++ b/certifier_service/certlib/certlib_support.go
@@ -1692,7 +1692,7 @@ func LittleToBigEndian(in []byte) []byte {
 	return out
 }
 
-func ProduceAdmissionCert(issuerKey *certprotos.KeyMessage, issuerCert *x509.Certificate,
+func ProduceAdmissionCert(remoteIP string, issuerKey *certprotos.KeyMessage, issuerCert *x509.Certificate,
 		subjKey *certprotos.KeyMessage, subjName string, subjOrg string,
 		serialNumber uint64, durationSeconds float64) *x509.Certificate {
 
@@ -1709,6 +1709,9 @@ func ProduceAdmissionCert(issuerKey *certprotos.KeyMessage, issuerCert *x509.Cer
 		ExtKeyUsage:	   []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
 		KeyUsage:	      x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
 		BasicConstraintsValid: true,
+	}
+	if remoteIP != "" {
+		cert.IPAddresses = []net.IP{net.ParseIP(remoteIP)}
 	}
 	spK := rsa.PrivateKey{}
 	sPK := rsa.PublicKey{}

--- a/certifier_service/simpleserver.go
+++ b/certifier_service/simpleserver.go
@@ -204,7 +204,7 @@ func logEvent(msg string, req []byte, resp []byte) {
         }
 }
 
-func ValidateRequestAndObtainToken(pubKey *certprotos.KeyMessage, privKey *certprotos.KeyMessage,
+func ValidateRequestAndObtainToken(remoteIP string, pubKey *certprotos.KeyMessage, privKey *certprotos.KeyMessage,
 		evType string, purpose string, ep *certprotos.EvidencePackage) (bool, []byte) {
 
         // evidenceType should be "vse-attestation-package", "gramine-evidence",
@@ -283,7 +283,7 @@ func ValidateRequestAndObtainToken(pubKey *certprotos.KeyMessage, privKey *certp
 		certlib.PrintKey(toProve.Subject.Key);
 		fmt.Printf("\norg: %s, appOrgName: %s\n", org, appOrgName)
 
-		cert := certlib.ProduceAdmissionCert(privKey, policyCert,
+		cert := certlib.ProduceAdmissionCert(remoteIP, privKey, policyCert,
 			toProve.Subject.Key, org, appOrgName, sn, duration)
 		if cert == nil {
 			fmt.Printf("ValidateRequestAndObtainToken: x509 certificate is nil\n")
@@ -348,7 +348,11 @@ func serviceThread(conn net.Conn, client string) {
         response.RequestingEnclaveTag = request.RequestingEnclaveTag
         response.ProvidingEnclaveTag = request.ProvidingEnclaveTag
 
-	outcome, artifact := ValidateRequestAndObtainToken(publicPolicyKey, privatePolicyKey,
+	var remoteIP string
+	if remoteAddr, ok := conn.RemoteAddr().(*net.TCPAddr); ok {
+		remoteIP = remoteAddr.IP.String()
+	}
+	outcome, artifact := ValidateRequestAndObtainToken(remoteIP, publicPolicyKey, privatePolicyKey,
 		request.GetSubmittedEvidenceType(), request.GetPurpose(),
 		request.Support)
 


### PR DESCRIPTION
This allows running HTTPS endpoints with the admission certificate