### PR TITLE
Import ISLET project for Arm CCA

### DIFF
--- a/src/cca/islet_test/Makefile
+++ b/src/cca/islet_test/Makefile
@@ -1,0 +1,22 @@
+GPP=g++
+ISLET_PATH = ../../../third_party/islet
+ISLET_INCLUDE= -I$(ISLET_PATH)/include
+ISLET_LDFLAGS= -L$(ISLET_PATH)/lib -lislet_sdk
+
+.PHONY: all
+all: attest_seal_test
+
+CFLAGS += $(ISLET_INCLUDE)
+LDFLAGS += $(ISLET_LDFLAGS)
+
+.PHONY: attest_seal_test
+attest_seal_test: attest_seal_test.cc
+	@$(GPP) $< $(CFLAGS) $(LDFLAGS) -o $@
+
+.PHONY: test
+test: attest_seal_test
+	@LD_LIBRARY_PATH=$(ISLET_PATH)/lib ./attest_seal_test
+
+.PHONY: clean
+clean:
+	@rm -rf attest_seal_test

--- a/src/cca/islet_test/README.md
+++ b/src/cca/islet_test/README.md
@@ -1,0 +1,21 @@
+# ISLET tests for Attest/Verify, Seal/Unseal core APIs on Arm CCA platform
+This sample app is towards Arm CCA with [ISLET SDK](https://github.com/Samsung/islet/tree/main/sdk)
+Currently this is running on x86_64 to integrate easily.
+The real app running on Arm CCA simulator (arm64) is coming soon.
+
+## How to test
+### Setup islet sdk
+ISLET SDK is written in Rust but it also supports C/C++.
+```sh
+../../../third_party/islet/setup.sh
+```
+
+### Run tests (simulated version running on x86_64)
+```sh
+make test
+```
+
+## TODO
+- [x] Import ISLET SDK and make the sample app (simulated version on x86_64)
+- [ ] Integrate interface between `ceritifer` and `islet` (x86_64)
+- [ ] Run sample app on Arm CCA simulator

--- a/src/cca/islet_test/attest_seal_test.cc
+++ b/src/cca/islet_test/attest_seal_test.cc
@@ -1,0 +1,104 @@
+/*
+ *  Copyright (c) 2023 Samsung Electronics Co., Ltd All Rights Reserved
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the language governing permissions and
+ *  limitations under the License
+ */
+
+#include <islet.h>
+
+#include <iostream>
+#include <string>
+#include <cstring>
+
+// Some reasonable size to allocate an attestation report on-stack buffers.
+// Typical attestation report size is over 1K.
+#define BUFFER_SIZE 2048
+
+using byte = unsigned char;
+
+static const char CLAIM_TITLE_USER_DATA[] = "User data";
+static const char CLAIM_TITLE_PLATFORM_PROFILE[] = "Profile";
+
+bool attestation_test() {
+  byte report[BUFFER_SIZE];
+  byte claims[BUFFER_SIZE];
+  byte value[BUFFER_SIZE];
+  int report_len = 0;
+  int claims_len = 0;
+  int value_len = 0;
+
+  memset(report, 0, sizeof(report));
+  memset(claims, 0, sizeof(claims));
+  memset(value, 0, sizeof(value));
+
+  // -- Attest -- //
+  std::string user_data("User Custom data");
+  if (islet_attest((const byte*)user_data.c_str(), user_data.size(), report, &report_len))
+    return false;
+
+  // -- Verify -- //
+  if (islet_verify(report, report_len, claims, &claims_len))
+    return false;
+
+  islet_print_claims(claims, claims_len);
+
+  // -- Parse -- //
+  if (islet_parse(CLAIM_TITLE_USER_DATA, claims, claims_len, value, &value_len))
+    return false;
+
+  printf("Claim[User data]: %s\n", (char*) value);
+
+  memset(value, 0, sizeof(value));
+  if (islet_parse(CLAIM_TITLE_PLATFORM_PROFILE, claims, claims_len, value, &value_len))
+    return false;
+
+  printf("Claim[Platform  profile]: %s\n", (char*) value);
+
+  return true;
+}
+
+bool sealing_test() {
+  byte sealed[BUFFER_SIZE];
+  byte unsealed[BUFFER_SIZE];
+
+  int sealed_len = 0;
+  int unsealed_len = 0;
+
+  memset(sealed, 0, sizeof(sealed));
+  memset(unsealed, 0, sizeof(unsealed));
+
+  // -- Seal -- //
+  std::string plaintext("Plaintext");
+  if (islet_seal((const byte*)plaintext.c_str(), plaintext.size(), sealed, &sealed_len))
+    return false;
+
+  // -- Unseal -- //
+  if (islet_unseal(sealed, sealed_len, unsealed, &unsealed_len))
+    return false;
+
+  printf("Success sealing round trip.\n");
+
+  return true;
+}
+
+int main() {
+  bool rv = attestation_test();
+  printf("Attestation test %s.\n", (rv ? "succeeded" : "failed"));
+  if (!rv)
+    return -1;
+
+  rv = sealing_test();
+  printf("Sealing test %s.\n", (rv ? "succeeded" : "failed"));
+
+  return 0;
+}

--- a/third_party/islet/include/islet.h
+++ b/third_party/islet/include/islet.h
@@ -1,0 +1,83 @@
+/*
+ *  Copyright (c) 2023 Samsung Electronics Co., Ltd All Rights Reserved
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the language governing permissions and
+ *  limitations under the License
+ */
+
+#pragma once
+
+#include <cstdarg>
+#include <cstdint>
+#include <cstdlib>
+#include <ostream>
+#include <new>
+
+enum islet_status_t {
+  ISLET_SUCCESS = 0,
+  ISLET_FAILURE = -1,
+  ISLET_ERROR_INPUT = -2,
+  ISLET_ERROR_WRONG_REPORT = -3,
+  ISLET_ERROR_WRONG_CLAIMS = -4,
+  ISLET_ERROR_FEATURE_NOT_SUPPORTED = -5,
+};
+
+extern "C" {
+
+/// Get an attestation report(token).
+///
+/// # Note
+/// This API currently returns hard-coded report to simulate attest operation.
+/// In future, this will be finalized to support reports signed by RMM.
+/// `User data` could be used as nonce to prevent reply attack.
+islet_status_t islet_attest(const unsigned char *user_data,
+                            int user_data_len,
+                            unsigned char *report_out,
+                            int *report_out_len);
+
+/// Verify the attestation report and returns attestation claims if succeeded.
+islet_status_t islet_verify(const unsigned char *report,
+                            int report_len,
+                            unsigned char *claims_out,
+                            int *claims_out_len);
+
+/// Parse the claims with the given title and returns the claim if succeeded.
+islet_status_t islet_parse(const char *title,
+                           const unsigned char *claims,
+                           int claims_len,
+                           unsigned char *value_out,
+                           int *value_out_len);
+
+/// Print all claims including Realm Token and Platform Token.
+void islet_print_claims(const unsigned char *claims, int claims_len);
+
+/// Seals the plaintext given into the binary slice
+///
+/// # Note
+/// This API currently seals with a hard-coded key, to simulate seal operation.
+/// In future, this will be finalized to support keys derived from HES.
+islet_status_t islet_seal(const unsigned char *plaintext,
+                          int plaintext_len,
+                          unsigned char *sealed_out,
+                          int *sealed_out_len);
+
+/// Unseals into plaintext the sealed binary provided.
+///
+/// # Note
+/// This API currently unseals with a hard-coded key, to simulate unseal operation.
+/// In future, this will be finalized to support keys derived from HES.
+islet_status_t islet_unseal(const unsigned char *sealed,
+                            int sealed_len,
+                            unsigned char *plaintext_out,
+                            int *plaintext_out_len);
+
+} // extern "C"

--- a/third_party/islet/setup.sh
+++ b/third_party/islet/setup.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+#  Copyright (c) 2023 Samsung Electronics Co., Ltd All Rights Reserved
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License
+
+# ##############################################################################
+# setup.sh - Setup script to build ISLET SDK
+# ##############################################################################
+
+set -Eeuo pipefail
+
+CC_ROOT=$(git rev-parse --show-toplevel)
+HERE="$CC_ROOT/third_party/islet"
+
+ISLET="$HERE/remote"
+ISLET_SDK="$ISLET/sdk"
+ISLET_INC="$HERE/include"
+ISLET_LIB="$HERE/lib"
+
+TARGET_HDR="$ISLET_SDK/include/islet.h"
+TARGET_LIB="$ISLET/out/x86_64-unknown-linux-gnu/debug/libislet_sdk.so"
+
+# Sync islet
+cd "$HERE"
+wget https://github.com/Samsung/islet/archive/refs/tags/certifier-v1.0.1-beta.tar.gz
+tar xf certifier-v1.0.1-beta.tar.gz
+rm -rf "$ISLET"
+mv islet-certifier-v1.0.1-beta "$ISLET"
+
+# Install rust to build ISLET SDK
+"$ISLET/scripts/deps/rust.sh"
+
+# Build ISLET SDK (simulated version for x86_64)
+cd "$ISLET_SDK" && cargo build
+
+mkdir -p "$ISLET_INC" "$ISLET_LIB"
+cp -p "$TARGET_HDR" "$ISLET_INC"
+cp -p "$TARGET_LIB" "$ISLET_LIB"


### PR DESCRIPTION
First, I am glad to collaborate with `Certifier` :)

This PR imports `ISLET SDK` and adds the sample application.
This version runs on x86_64 to integrate easily.

My plan is like:
1. Import ISLET SDK and make the sample app (simulated version on x86_64) << **This PR**
2. Integrate interfaces between `ceritifer` and `islet` (x86_64) << *I hope that certifier developer could help this!*
3. Run sample app on Arm CCA simulator (arm64)

## ISLET SDK
It is for applications running on Arm CCA. ISLET SDK is written in `rust` but we also support `C/C++`.
We use `cbindgen` which is the powerful tool to create headers for rust libraries which expose public C/C++ APIs.
_So please do not modify header directly._

Please refer [this](https://github.com/Samsung/islet/tree/main/sdk) for details.

```
+--------+                           +---------+
| sdk    | => cbindgen => header  => | app     |
| (rust) | => cdylib   => library => | (c/c++) |
+--------+                           +---------+
```

Feel free to give me feedback and any questions.