### PR TITLE
(#58) Fix build failures for utilities on SGX platform.

### DIFF
--- a/utilities/cert_utility.mak
+++ b/utilities/cert_utility.mak
@@ -16,9 +16,12 @@ endif
 #ifndef GOOGLE_INCLUDE
 #GOOGLE_INCLUDE=/usr/local/include/g
 #endif
+
+# Allows user to over-ride libs path externally depending on machine's install
 ifndef LOCAL_LIB
 LOCAL_LIB=/usr/local/lib
 endif
+
 ifndef TARGET_MACHINE_TYPE
 TARGET_MACHINE_TYPE= x64
 endif
@@ -30,7 +33,11 @@ I= $(INC_DIR)
 US= .
 INCLUDE= -I$(I) -I/usr/local/opt/openssl@1.1/include/ -I$(S)/sev-snp/
 
-CFLAGS= $(INCLUDE) -O3 -g -Werror -Wall -std=c++11 -Wno-unused-variable -D X64 -Wno-deprecated -Wno-deprecated-declarations
+# Compilation of protobuf files could run into some errors, so avoid using
+# -Werror for those targets
+CFLAGS_NOERROR = $(INCLUDE) -O3 -g -Wall -std=c++11 -Wno-unused-variable -D X64 -Wno-deprecated -Wno-deprecated-declarations
+CFLAGS = $(CFLAGS_NOERROR) -Werror
+
 #For MAC, -D MACOS should be included
 CFLAGS1= $(INCLUDE) -O1 -g -Wall -std=c++11 -Wno-unused-variable -D X64 -Wno-deprecated -Wno-deprecated-declarations
 CC=g++
@@ -90,7 +97,7 @@ $(US)/certifier.pb.cc $(I)/certifier.pb.h: $(S)/certifier.proto
 
 $(O)/certifier.pb.o: $(US)/certifier.pb.cc $(I)/certifier.pb.h
 	@echo "compiling certifier.pb.cc"
-	$(CC) $(CFLAGS) -c  -o $(O)/certifier.pb.o $(US)/certifier.pb.cc
+	$(CC) $(CFLAGS_NOERROR) -c  -o $(O)/certifier.pb.o $(US)/certifier.pb.cc
 
 $(O)/support.o: $(S)/support.cc $(I)/support.h $(I)/certifier.pb.h
 	@echo "compiling support.cc"

--- a/utilities/policy_utilities.mak
+++ b/utilities/policy_utilities.mak
@@ -21,7 +21,11 @@ endif
 #GOOGLE_INCLUDE=/usr/local/include/google
 #endif
 
+# Allows user to over-ride libs path externally depending on machine's install
+ifndef LOCAL_LIB
 LOCAL_LIB=/usr/local/lib
+endif
+
 
 ifndef TARGET_MACHINE_TYPE
 TARGET_MACHINE_TYPE= x64
@@ -35,7 +39,8 @@ CERT_SRC=$(CERTIFIER_PROTOTYPE_DIR)/src
 
 INCLUDE= -I$(INC_DIR) -I/usr/local/opt/openssl@1.1/include/ -I$(CERT_SRC)/sev-snp/
 
-CFLAGS= $(INCLUDE) -O3 -g -Wall -Werror -std=c++11 -Wno-unused-variable -D X64 -Wno-deprecated -Wno-deprecated-declarations
+CFLAGS_NOERROR = $(INCLUDE) -O3 -g -Wall -std=c++11 -Wno-unused-variable -D X64 -Wno-deprecated -Wno-deprecated-declarations
+CFLAGS = $(CFLAGS_NOERROR) -Werror
 CFLAGS1= $(INCLUDE) -O1 -g -Wall -std=c++11 -Wno-unused-variable -D X64 -Wno-deprecated -Wno-deprecated-declarations
 # For Mac: -D MACOS should be defined
 
@@ -125,7 +130,7 @@ $(CERT_SRC)/certifier.pb.cc $(I)/certifier.pb.h: $(CERT_SRC)/certifier.proto
 
 $(O)/certifier.pb.o: $(CERT_SRC)/certifier.pb.cc $(INC_DIR)/certifier.pb.h
 	@echo "compiling certifier.pb.cc"
-	$(CC) $(CFLAGS) -c  -o $(O)/certifier.pb.o $(CERT_SRC)/certifier.pb.cc
+	$(CC) $(CFLAGS_NOERROR) -c  -o $(O)/certifier.pb.o $(CERT_SRC)/certifier.pb.cc
 
 $(O)/support.o: $(CERT_SRC)/support.cc $(INC_DIR)/support.h $(INC_DIR)/certifier.pb.h
 	@echo "compiling support.cc"


### PR DESCRIPTION
Previous commit (@ SHA c7963d9) added -Werror to several Makefiles. This causes builds of utility programs to fail on SGX platforms while compiling protobuf-generated files. This commit resolves those failures by relaxing this flag specifically while compiling these generated files. One other fix is needed to pick-up right version of OpenSSL libs while building policy-utilities exes.

With these fixes, the following should work cleanly on SGX platform:

# Ensure your build area is clean, rm'ing all previously generated files.

$ make -f cert_utility.mak clean
$ LOCAL_LIB=/usr/local/lib64 make -f cert_utility.mak $ LOCAL_LIB=/usr/local/lib64 make -f policy_utilities.mak

----

**NOTE**: To reviewer(s). These build failures have been fixed in my current dev-branch (under upcoming fixes for issue #67).
I am peeling those off that in-flight work to push separately to `/main` to unblock @rgerganov 