### PR TITLE
Certifier user header refactoring

### DIFF
--- a/application_service/app_service.cc
+++ b/application_service/app_service.cc
@@ -27,6 +27,9 @@
 #include <linux/memfd.h>
 #include <sys/mman.h>
 
+using namespace certifier::framework;
+using namespace certifier::utilities;
+
 //  Copyright (c) 2021-22, VMware Inc, and the Certifier Authors.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/include/cc_helpers.h
+++ b/include/cc_helpers.h
@@ -27,96 +27,10 @@
 #include "support.h"
 #include "certifier.h"
 #include "simulated_enclave.h"
+#include "certifier_framework.h"
 
 #ifndef _CC_HELPERS_CC_
 #define _CC_HELPERS_CC_
-
-const int cc_helper_symmetric_key_size = 64;
-
-class cc_trust_data {
-public:
-  bool cc_basic_data_initialized_;
-  string purpose_;
-  string enclave_type_;
-  string store_file_name_;
-
-  bool cc_policy_info_initialized_;
-  string serialized_policy_cert_;
-  X509* x509_policy_cert_;
-  key_message public_policy_key_;
-
-  bool cc_policy_store_initialized_;
-  policy_store store_;
-
-  bool cc_provider_provisioned_;
-  bool cc_is_certified_;
-
-  // For auth
-  bool cc_auth_key_initialized_;
-  key_message private_auth_key_;
-  key_message public_auth_key_;
-
-  bool cc_symmetric_key_initialized_;
-  byte symmetric_key_bytes_[cc_helper_symmetric_key_size];
-  key_message symmetric_key_;
-
-  // For attest
-  bool cc_service_key_initialized_;
-  key_message private_service_key_;
-  key_message public_service_key_;
-
-  bool cc_service_cert_initialized_;
-  string serialized_service_cert_;
-
-  bool cc_service_platform_rule_initialized_;
-  signed_claim_message platform_rule_;
-
-  // This is the sealing key
-  bool cc_sealing_key_initialized_;
-  byte service_symmetric_key_[cc_helper_symmetric_key_size];
-  key_message service_sealing_key_;
-
-  // For peer-to-peer certification
-  bool peer_data_initialized_;
-  key_message local_policy_key_;
-  string local_policy_cert_;
-
-  cc_trust_data();
-  cc_trust_data(const string& enclave_type, const string& purpose,
-      const string& policy_store_name);
-  ~cc_trust_data();
-
-  // Each of the enclave types have bespoke initialization
-  bool initialize_simulated_enclave_data(const string& attest_key_file_name,
-      const string& measurement_file_name, const string& attest_endorsement_file_name);
-  bool initialize_sev_enclave_data(const string& platform_ark_der_file,
-      const string& platform_ask_der_file,
-      const string& platform_vcek_der_file);
-  bool initialize_gramine_enclave_data(const int size, byte* cert);
-  bool initialize_oe_enclave_data(const string& file);
-  bool initialize_application_enclave_data(const string& parent_enclave_type,
-          int in_fd, int out_fd);
-
-  bool cc_all_initialized();
-  bool init_policy_key(int asn1_cert_size, byte* asn1_cert);
-  bool put_trust_data_in_store();
-  bool get_trust_data_from_store();
-  bool save_store();
-  bool fetch_store();
-  void clear_sensitive_data();
-  bool cold_init(const string& public_key_alg, const string& symmetric_key_alg,
-                 const string& hash_alg, const string& hmac_alg);
-  bool warm_restart();
-  bool certify_me(const string& host_name, int port);
-  bool GetPlatformSaysAttestClaim(signed_claim_message* scm);
-  void print_trust_data();
-
-  // For peer-to-peer certification
-  bool init_peer_certification_data(const string& public_key_alg);
-  bool recover_peer_certification_data();
-  bool get_peer_certification(const string& host_name, int port);
-  bool run_peer_certificationservice(const string& host_name, int port);
-};
 
 bool open_client_socket(const string& host_name, int port, int* soc);
 bool open_server_socket(const string& host_name, int port, int* soc);
@@ -137,45 +51,6 @@ bool init_client_ssl(X509* x509_root_cert, key_message& private_key,
     const string& host_name, int port, int* p_sd, SSL_CTX** p_ctx, SSL** p_ssl);
 void close_client_ssl(int sd, SSL_CTX* ctx, SSL* ssl);
 #endif
-
-class secure_authenticated_channel {
-public:
-  string role_;
-  bool channel_initialized_;
-  key_message private_key_;
-  SSL_CTX* ssl_ctx_;
-  X509_STORE_CTX* store_ctx_;
-  SSL* ssl_;
-  int sock_;
-  string asn1_root_cert_;
-  X509* root_cert_;
-  X509* my_cert_;
-  string asn1_my_cert_;
-  X509* peer_cert_;
-  string peer_id_;
-
-  secure_authenticated_channel(string& role);  // role is client or server
-  ~secure_authenticated_channel();
-
-  bool load_client_certs_and_key();
-
-  bool init_client_ssl(const string& host_name, int port, string& asn1_root_cert,
-      key_message& private_key, const string& private_key_cert);
-  bool init_server_ssl(const string& host_name, int port, string& asn1_root_cert,
-      key_message& private_key, const string& private_key_cert);
-
-  void server_channel_accept_and_auth(void (*func)(secure_authenticated_channel&));
-
-  int read(string* out);
-  int read(int size, byte* b);
-  int write(int size, byte* b);
-  void close();
-  bool get_peer_id(string* out);
-};
-
-bool server_dispatch(const string& host_name, int port,
-                     string& asn1_root_cert, key_message& private_key,
-                     const string& private_key_cert, void (*)(secure_authenticated_channel&));
 
 #endif
 

--- a/include/certifier.h
+++ b/include/certifier.h
@@ -36,12 +36,7 @@
 #include <openssl/evp.h>
 #include "certifier.pb.h"
 
-#ifndef byte
-typedef unsigned char byte;
-#endif
-
-using std::string;
-
+#include "certifier_framework.h"
 
 // Some Data and access functions
 // -------------------------------------------------------------------
@@ -56,104 +51,6 @@ const key_message* GetPublicPolicyKey();
 bool PublicKeyFromCert(const string& cert, key_message* k);
 
 
-// Policy store
-// -------------------------------------------------------------------
-
-class policy_store {
-public:
-  enum {MAX_NUM_ENTRIES = 200};
-  bool policy_key_valid_;
-
-  key_message policy_key_;
-
-  int max_num_ts_;
-  int num_ts_;
-  trusted_service_message** ts_;
-  int max_num_tsc_;
-  int num_tsc_;
-  tagged_signed_claim** tsc_;
-  int max_num_si_;
-  int num_si_;
-  storage_info_message** si_;
-  int max_num_tc_;
-  int num_tc_;
-  tagged_claim** tc_;
-  int max_num_tkm_;
-  int num_tkm_;
-  channel_key_message** tkm_;
-  int max_num_blobs_;
-  int num_blobs_;
-  tagged_blob_message** tagged_blob_;
-
-public:
-
-  policy_store();
-  policy_store(int max_trusted_services, int max_trusted_signed_claims,
-      int max_storage_infos, int max_claims, int max_keys, int max_blobs);
-  ~policy_store();
-
-  bool replace_policy_key(key_message& k);
-  const key_message* get_policy_key();
-
-  int get_num_trusted_services();
-  const trusted_service_message* get_trusted_service_info_by_index(int n);
-  int get_trusted_service_index_by_tag(const string tag);
-  bool add_trusted_service(trusted_service_message& to_add);
-  void delete_trusted_service_by_index(int n);
-
-  int get_num_storage_info();
-  const storage_info_message* get_storage_info_by_index(int n);
-  bool add_storage_info(storage_info_message& to_add);
-  int get_storage_info_index_by_tag(const string& tag);
-  void delete_storage_info_by_index(int n);
-
-  int get_num_claims();
-  const claim_message* get_claim_by_index(int n);
-  bool add_claim(const string& tag, const claim_message& to_add);
-  int get_claim_index_by_tag(const string& tag);
-  void delete_claim_by_index(int n);
-
-  int get_num_signed_claims();
-  const signed_claim_message* get_signed_claim_by_index(int n);
-  int get_signed_claim_index_by_tag(const string& tag);
-  bool add_signed_claim(const string& tag, const signed_claim_message& to_add);
-  void delete_signed_claim_by_index(int n);
-
-  bool add_authentication_key(const string& tag, const key_message& k);
-  const key_message* get_authentication_key_by_tag(const string& tag);
-  const key_message* get_authentication_key_by_index(int index);
-  int get_authentication_key_index_by_tag(const string& tag);
-  void delete_authentication_key_by_index(int index);
-
-  bool add_blob(const string& tag, const string& s);
-  const string* get_blob_by_tag(const string& tag);
-  const string* get_blob_by_index(int index);
-  const tagged_blob_message* get_tagged_blob_info_by_index(int n);
-  int get_blob_index_by_tag(const string& tag);
-  void delete_blob_by_index(int index);
-  int get_num_blobs();
-
-  bool Serialize(string* out);
-  bool Deserialize(string& in);
-
-  void clear_policy_store();
-};
-void print_store(policy_store& ps);
-
-
-// Trusted primitives
-// -------------------------------------------------------------------
-
-bool Seal(const string& enclave_type, const string& enclave_id,
-  int in_size, byte* in, int* size_out, byte* out);
-
-bool Unseal(const string& enclave_type, const string& enclave_id,
-  int in_size, byte* in, int* size_out, byte* out);
-
-bool Attest(const string& enclave_type,
-  int what_to_say_size, byte* what_to_say,
-  int* size_out, byte* out);
-
 bool GetParentEvidence(const string& enclave_type, const string& parent_enclave_type,
       string* out);
 
@@ -161,23 +58,9 @@ bool GetPlatformStatement(const string& enclave_type, const string& enclave_id,
   int* size_out, byte* out);
 
 
-// Protect Support
-// -------------------------------------------------------------------
-
-bool Protect_Blob(const string& enclave_type,
-  key_message& key, int size_unencrypted_data, byte* unencrypted_data,
-  int* size_protected_blob, byte* blob);
-bool Unprotect_Blob(const string& enclave_type,
-  int size_protected_blob, byte* protected_blob,
-  key_message* key, int* size_of_unencrypted_data, byte* data);
-
-// -------------------------------------------------------------------
-
-
 // Claims and proofs
 // -------------------------------------------------------------------
 
-bool check_date_range(const string& nb, const string& na);
 bool make_attestation_user_data(const string& enclave_type,
        const key_message& enclave_key, attestation_user_data* out);
 bool sign_report(const string& type, const string& report, const string& signing_alg,

--- a/include/certifier_framework.h
+++ b/include/certifier_framework.h
@@ -1,0 +1,267 @@
+//  Copyright (c) 2021-23, VMware Inc, and the Certifier Authors.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef _CERTIFIER_FRAMEWORK_H__
+#define _CERTIFIER_FRAMEWORK_H__
+
+#include <string>
+#include <openssl/ssl.h>
+#include <openssl/rsa.h>
+#include <openssl/x509.h>
+#include <openssl/evp.h>
+
+#include "certifier.pb.h"
+
+#ifndef byte
+typedef unsigned char byte;
+#endif
+
+using std::string;
+
+// Policy store
+// -------------------------------------------------------------------
+
+class policy_store {
+public:
+  enum {MAX_NUM_ENTRIES = 200};
+  bool policy_key_valid_;
+
+  key_message policy_key_;
+
+  int max_num_ts_;
+  int num_ts_;
+  trusted_service_message** ts_;
+  int max_num_tsc_;
+  int num_tsc_;
+  tagged_signed_claim** tsc_;
+  int max_num_si_;
+  int num_si_;
+  storage_info_message** si_;
+  int max_num_tc_;
+  int num_tc_;
+  tagged_claim** tc_;
+  int max_num_tkm_;
+  int num_tkm_;
+  channel_key_message** tkm_;
+  int max_num_blobs_;
+  int num_blobs_;
+  tagged_blob_message** tagged_blob_;
+
+public:
+
+  policy_store();
+  policy_store(int max_trusted_services, int max_trusted_signed_claims,
+      int max_storage_infos, int max_claims, int max_keys, int max_blobs);
+  ~policy_store();
+
+  bool replace_policy_key(key_message& k);
+  const key_message* get_policy_key();
+
+  int get_num_trusted_services();
+  const trusted_service_message* get_trusted_service_info_by_index(int n);
+  int get_trusted_service_index_by_tag(const string tag);
+  bool add_trusted_service(trusted_service_message& to_add);
+  void delete_trusted_service_by_index(int n);
+
+  int get_num_storage_info();
+  const storage_info_message* get_storage_info_by_index(int n);
+  bool add_storage_info(storage_info_message& to_add);
+  int get_storage_info_index_by_tag(const string& tag);
+  void delete_storage_info_by_index(int n);
+
+  int get_num_claims();
+  const claim_message* get_claim_by_index(int n);
+  bool add_claim(const string& tag, const claim_message& to_add);
+  int get_claim_index_by_tag(const string& tag);
+  void delete_claim_by_index(int n);
+
+  int get_num_signed_claims();
+  const signed_claim_message* get_signed_claim_by_index(int n);
+  int get_signed_claim_index_by_tag(const string& tag);
+  bool add_signed_claim(const string& tag, const signed_claim_message& to_add);
+  void delete_signed_claim_by_index(int n);
+
+  bool add_authentication_key(const string& tag, const key_message& k);
+  const key_message* get_authentication_key_by_tag(const string& tag);
+  const key_message* get_authentication_key_by_index(int index);
+  int get_authentication_key_index_by_tag(const string& tag);
+  void delete_authentication_key_by_index(int index);
+
+  bool add_blob(const string& tag, const string& s);
+  const string* get_blob_by_tag(const string& tag);
+  const string* get_blob_by_index(int index);
+  const tagged_blob_message* get_tagged_blob_info_by_index(int n);
+  int get_blob_index_by_tag(const string& tag);
+  void delete_blob_by_index(int index);
+  int get_num_blobs();
+
+  bool Serialize(string* out);
+  bool Deserialize(string& in);
+
+  void clear_policy_store();
+};
+void print_store(policy_store& ps);
+
+// Trusted primitives
+// -------------------------------------------------------------------
+
+bool Seal(const string& enclave_type, const string& enclave_id,
+  int in_size, byte* in, int* size_out, byte* out);
+
+bool Unseal(const string& enclave_type, const string& enclave_id,
+  int in_size, byte* in, int* size_out, byte* out);
+
+bool Attest(const string& enclave_type,
+  int what_to_say_size, byte* what_to_say,
+  int* size_out, byte* out);
+
+// Protect Support
+// -------------------------------------------------------------------
+
+bool Protect_Blob(const string& enclave_type,
+  key_message& key, int size_unencrypted_data, byte* unencrypted_data,
+  int* size_protected_blob, byte* blob);
+bool Unprotect_Blob(const string& enclave_type,
+  int size_protected_blob, byte* protected_blob,
+  key_message* key, int* size_of_unencrypted_data, byte* data);
+
+
+class cc_trust_data {
+private:
+  static const int cc_helper_symmetric_key_size = 64;
+
+public:
+  bool cc_basic_data_initialized_;
+  string purpose_;
+  string enclave_type_;
+  string store_file_name_;
+
+  bool cc_policy_info_initialized_;
+  string serialized_policy_cert_;
+  X509* x509_policy_cert_;
+  key_message public_policy_key_;
+
+  bool cc_policy_store_initialized_;
+  policy_store store_;
+
+  bool cc_provider_provisioned_;
+  bool cc_is_certified_;
+
+  // For auth
+  bool cc_auth_key_initialized_;
+  key_message private_auth_key_;
+  key_message public_auth_key_;
+
+  bool cc_symmetric_key_initialized_;
+  byte symmetric_key_bytes_[cc_helper_symmetric_key_size];
+  key_message symmetric_key_;
+
+  // For attest
+  bool cc_service_key_initialized_;
+  key_message private_service_key_;
+  key_message public_service_key_;
+
+  bool cc_service_cert_initialized_;
+  string serialized_service_cert_;
+
+  bool cc_service_platform_rule_initialized_;
+  signed_claim_message platform_rule_;
+
+  // This is the sealing key
+  bool cc_sealing_key_initialized_;
+  byte service_symmetric_key_[cc_helper_symmetric_key_size];
+  key_message service_sealing_key_;
+
+  // For peer-to-peer certification
+  bool peer_data_initialized_;
+  key_message local_policy_key_;
+  string local_policy_cert_;
+
+  cc_trust_data();
+  cc_trust_data(const string& enclave_type, const string& purpose,
+      const string& policy_store_name);
+  ~cc_trust_data();
+
+  // Each of the enclave types have bespoke initialization
+  bool initialize_simulated_enclave_data(const string& attest_key_file_name,
+      const string& measurement_file_name, const string& attest_endorsement_file_name);
+  bool initialize_sev_enclave_data(const string& platform_ark_der_file,
+      const string& platform_ask_der_file,
+      const string& platform_vcek_der_file);
+  bool initialize_gramine_enclave_data(const int size, byte* cert);
+  bool initialize_oe_enclave_data(const string& file);
+  bool initialize_application_enclave_data(const string& parent_enclave_type,
+          int in_fd, int out_fd);
+
+  bool cc_all_initialized();
+  bool init_policy_key(int asn1_cert_size, byte* asn1_cert);
+  bool put_trust_data_in_store();
+  bool get_trust_data_from_store();
+  bool save_store();
+  bool fetch_store();
+  void clear_sensitive_data();
+  bool cold_init(const string& public_key_alg, const string& symmetric_key_alg,
+                 const string& hash_alg, const string& hmac_alg);
+  bool warm_restart();
+  bool certify_me(const string& host_name, int port);
+  bool GetPlatformSaysAttestClaim(signed_claim_message* scm);
+  void print_trust_data();
+
+  // For peer-to-peer certification
+  bool init_peer_certification_data(const string& public_key_alg);
+  bool recover_peer_certification_data();
+  bool get_peer_certification(const string& host_name, int port);
+  bool run_peer_certificationservice(const string& host_name, int port);
+};
+
+class secure_authenticated_channel {
+public:
+  string role_;
+  bool channel_initialized_;
+  key_message private_key_;
+  SSL_CTX* ssl_ctx_;
+  X509_STORE_CTX* store_ctx_;
+  SSL* ssl_;
+  int sock_;
+  string asn1_root_cert_;
+  X509* root_cert_;
+  X509* my_cert_;
+  string asn1_my_cert_;
+  X509* peer_cert_;
+  string peer_id_;
+
+  secure_authenticated_channel(string& role);  // role is client or server
+  ~secure_authenticated_channel();
+
+  bool load_client_certs_and_key();
+
+  bool init_client_ssl(const string& host_name, int port, string& asn1_root_cert,
+      key_message& private_key, const string& private_key_cert);
+  bool init_server_ssl(const string& host_name, int port, string& asn1_root_cert,
+      key_message& private_key, const string& private_key_cert);
+
+  void server_channel_accept_and_auth(void (*func)(secure_authenticated_channel&));
+
+  int read(string* out);
+  int read(int size, byte* b);
+  int write(int size, byte* b);
+  void close();
+  bool get_peer_id(string* out);
+};
+
+bool server_dispatch(const string& host_name, int port,
+                     string& asn1_root_cert, key_message& private_key,
+                     const string& private_key_cert, void (*)(secure_authenticated_channel&));
+
+#endif

--- a/include/certifier_framework.h
+++ b/include/certifier_framework.h
@@ -32,236 +32,240 @@ using std::string;
 // Policy store
 // -------------------------------------------------------------------
 
-class policy_store {
-public:
-  enum {MAX_NUM_ENTRIES = 200};
-  bool policy_key_valid_;
+namespace certifier {
+  namespace framework {
+    class policy_store {
+    public:
+      enum {MAX_NUM_ENTRIES = 200};
+      bool policy_key_valid_;
 
-  key_message policy_key_;
+      key_message policy_key_;
 
-  int max_num_ts_;
-  int num_ts_;
-  trusted_service_message** ts_;
-  int max_num_tsc_;
-  int num_tsc_;
-  tagged_signed_claim** tsc_;
-  int max_num_si_;
-  int num_si_;
-  storage_info_message** si_;
-  int max_num_tc_;
-  int num_tc_;
-  tagged_claim** tc_;
-  int max_num_tkm_;
-  int num_tkm_;
-  channel_key_message** tkm_;
-  int max_num_blobs_;
-  int num_blobs_;
-  tagged_blob_message** tagged_blob_;
+      int max_num_ts_;
+      int num_ts_;
+      trusted_service_message** ts_;
+      int max_num_tsc_;
+      int num_tsc_;
+      tagged_signed_claim** tsc_;
+      int max_num_si_;
+      int num_si_;
+      storage_info_message** si_;
+      int max_num_tc_;
+      int num_tc_;
+      tagged_claim** tc_;
+      int max_num_tkm_;
+      int num_tkm_;
+      channel_key_message** tkm_;
+      int max_num_blobs_;
+      int num_blobs_;
+      tagged_blob_message** tagged_blob_;
 
-public:
+    public:
 
-  policy_store();
-  policy_store(int max_trusted_services, int max_trusted_signed_claims,
-      int max_storage_infos, int max_claims, int max_keys, int max_blobs);
-  ~policy_store();
+      policy_store();
+      policy_store(int max_trusted_services, int max_trusted_signed_claims,
+          int max_storage_infos, int max_claims, int max_keys, int max_blobs);
+      ~policy_store();
 
-  bool replace_policy_key(key_message& k);
-  const key_message* get_policy_key();
+      bool replace_policy_key(key_message& k);
+      const key_message* get_policy_key();
 
-  int get_num_trusted_services();
-  const trusted_service_message* get_trusted_service_info_by_index(int n);
-  int get_trusted_service_index_by_tag(const string tag);
-  bool add_trusted_service(trusted_service_message& to_add);
-  void delete_trusted_service_by_index(int n);
+      int get_num_trusted_services();
+      const trusted_service_message* get_trusted_service_info_by_index(int n);
+      int get_trusted_service_index_by_tag(const string tag);
+      bool add_trusted_service(trusted_service_message& to_add);
+      void delete_trusted_service_by_index(int n);
 
-  int get_num_storage_info();
-  const storage_info_message* get_storage_info_by_index(int n);
-  bool add_storage_info(storage_info_message& to_add);
-  int get_storage_info_index_by_tag(const string& tag);
-  void delete_storage_info_by_index(int n);
+      int get_num_storage_info();
+      const storage_info_message* get_storage_info_by_index(int n);
+      bool add_storage_info(storage_info_message& to_add);
+      int get_storage_info_index_by_tag(const string& tag);
+      void delete_storage_info_by_index(int n);
 
-  int get_num_claims();
-  const claim_message* get_claim_by_index(int n);
-  bool add_claim(const string& tag, const claim_message& to_add);
-  int get_claim_index_by_tag(const string& tag);
-  void delete_claim_by_index(int n);
+      int get_num_claims();
+      const claim_message* get_claim_by_index(int n);
+      bool add_claim(const string& tag, const claim_message& to_add);
+      int get_claim_index_by_tag(const string& tag);
+      void delete_claim_by_index(int n);
 
-  int get_num_signed_claims();
-  const signed_claim_message* get_signed_claim_by_index(int n);
-  int get_signed_claim_index_by_tag(const string& tag);
-  bool add_signed_claim(const string& tag, const signed_claim_message& to_add);
-  void delete_signed_claim_by_index(int n);
+      int get_num_signed_claims();
+      const signed_claim_message* get_signed_claim_by_index(int n);
+      int get_signed_claim_index_by_tag(const string& tag);
+      bool add_signed_claim(const string& tag, const signed_claim_message& to_add);
+      void delete_signed_claim_by_index(int n);
 
-  bool add_authentication_key(const string& tag, const key_message& k);
-  const key_message* get_authentication_key_by_tag(const string& tag);
-  const key_message* get_authentication_key_by_index(int index);
-  int get_authentication_key_index_by_tag(const string& tag);
-  void delete_authentication_key_by_index(int index);
+      bool add_authentication_key(const string& tag, const key_message& k);
+      const key_message* get_authentication_key_by_tag(const string& tag);
+      const key_message* get_authentication_key_by_index(int index);
+      int get_authentication_key_index_by_tag(const string& tag);
+      void delete_authentication_key_by_index(int index);
 
-  bool add_blob(const string& tag, const string& s);
-  const string* get_blob_by_tag(const string& tag);
-  const string* get_blob_by_index(int index);
-  const tagged_blob_message* get_tagged_blob_info_by_index(int n);
-  int get_blob_index_by_tag(const string& tag);
-  void delete_blob_by_index(int index);
-  int get_num_blobs();
+      bool add_blob(const string& tag, const string& s);
+      const string* get_blob_by_tag(const string& tag);
+      const string* get_blob_by_index(int index);
+      const tagged_blob_message* get_tagged_blob_info_by_index(int n);
+      int get_blob_index_by_tag(const string& tag);
+      void delete_blob_by_index(int index);
+      int get_num_blobs();
 
-  bool Serialize(string* out);
-  bool Deserialize(string& in);
+      bool Serialize(string* out);
+      bool Deserialize(string& in);
 
-  void clear_policy_store();
-};
-void print_store(policy_store& ps);
+      void clear_policy_store();
+    };
+    void print_store(policy_store& ps);
 
-// Trusted primitives
-// -------------------------------------------------------------------
+    // Trusted primitives
+    // -------------------------------------------------------------------
 
-bool Seal(const string& enclave_type, const string& enclave_id,
-  int in_size, byte* in, int* size_out, byte* out);
+    bool Seal(const string& enclave_type, const string& enclave_id,
+      int in_size, byte* in, int* size_out, byte* out);
 
-bool Unseal(const string& enclave_type, const string& enclave_id,
-  int in_size, byte* in, int* size_out, byte* out);
+    bool Unseal(const string& enclave_type, const string& enclave_id,
+      int in_size, byte* in, int* size_out, byte* out);
 
-bool Attest(const string& enclave_type,
-  int what_to_say_size, byte* what_to_say,
-  int* size_out, byte* out);
+    bool Attest(const string& enclave_type,
+      int what_to_say_size, byte* what_to_say,
+      int* size_out, byte* out);
 
-// Protect Support
-// -------------------------------------------------------------------
+    // Protect Support
+    // -------------------------------------------------------------------
 
-bool Protect_Blob(const string& enclave_type,
-  key_message& key, int size_unencrypted_data, byte* unencrypted_data,
-  int* size_protected_blob, byte* blob);
-bool Unprotect_Blob(const string& enclave_type,
-  int size_protected_blob, byte* protected_blob,
-  key_message* key, int* size_of_unencrypted_data, byte* data);
+    bool Protect_Blob(const string& enclave_type,
+      key_message& key, int size_unencrypted_data, byte* unencrypted_data,
+      int* size_protected_blob, byte* blob);
+    bool Unprotect_Blob(const string& enclave_type,
+      int size_protected_blob, byte* protected_blob,
+      key_message* key, int* size_of_unencrypted_data, byte* data);
 
 
-class cc_trust_data {
-private:
-  static const int cc_helper_symmetric_key_size = 64;
+    class cc_trust_data {
+    private:
+      static const int cc_helper_symmetric_key_size = 64;
 
-public:
-  bool cc_basic_data_initialized_;
-  string purpose_;
-  string enclave_type_;
-  string store_file_name_;
+    public:
+      bool cc_basic_data_initialized_;
+      string purpose_;
+      string enclave_type_;
+      string store_file_name_;
 
-  bool cc_policy_info_initialized_;
-  string serialized_policy_cert_;
-  X509* x509_policy_cert_;
-  key_message public_policy_key_;
+      bool cc_policy_info_initialized_;
+      string serialized_policy_cert_;
+      X509* x509_policy_cert_;
+      key_message public_policy_key_;
 
-  bool cc_policy_store_initialized_;
-  policy_store store_;
+      bool cc_policy_store_initialized_;
+      policy_store store_;
 
-  bool cc_provider_provisioned_;
-  bool cc_is_certified_;
+      bool cc_provider_provisioned_;
+      bool cc_is_certified_;
 
-  // For auth
-  bool cc_auth_key_initialized_;
-  key_message private_auth_key_;
-  key_message public_auth_key_;
+      // For auth
+      bool cc_auth_key_initialized_;
+      key_message private_auth_key_;
+      key_message public_auth_key_;
 
-  bool cc_symmetric_key_initialized_;
-  byte symmetric_key_bytes_[cc_helper_symmetric_key_size];
-  key_message symmetric_key_;
+      bool cc_symmetric_key_initialized_;
+      byte symmetric_key_bytes_[cc_helper_symmetric_key_size];
+      key_message symmetric_key_;
 
-  // For attest
-  bool cc_service_key_initialized_;
-  key_message private_service_key_;
-  key_message public_service_key_;
+      // For attest
+      bool cc_service_key_initialized_;
+      key_message private_service_key_;
+      key_message public_service_key_;
 
-  bool cc_service_cert_initialized_;
-  string serialized_service_cert_;
+      bool cc_service_cert_initialized_;
+      string serialized_service_cert_;
 
-  bool cc_service_platform_rule_initialized_;
-  signed_claim_message platform_rule_;
+      bool cc_service_platform_rule_initialized_;
+      signed_claim_message platform_rule_;
 
-  // This is the sealing key
-  bool cc_sealing_key_initialized_;
-  byte service_symmetric_key_[cc_helper_symmetric_key_size];
-  key_message service_sealing_key_;
+      // This is the sealing key
+      bool cc_sealing_key_initialized_;
+      byte service_symmetric_key_[cc_helper_symmetric_key_size];
+      key_message service_sealing_key_;
 
-  // For peer-to-peer certification
-  bool peer_data_initialized_;
-  key_message local_policy_key_;
-  string local_policy_cert_;
+      // For peer-to-peer certification
+      bool peer_data_initialized_;
+      key_message local_policy_key_;
+      string local_policy_cert_;
 
-  cc_trust_data();
-  cc_trust_data(const string& enclave_type, const string& purpose,
-      const string& policy_store_name);
-  ~cc_trust_data();
+      cc_trust_data();
+      cc_trust_data(const string& enclave_type, const string& purpose,
+          const string& policy_store_name);
+      ~cc_trust_data();
 
-  // Each of the enclave types have bespoke initialization
-  bool initialize_simulated_enclave_data(const string& attest_key_file_name,
-      const string& measurement_file_name, const string& attest_endorsement_file_name);
-  bool initialize_sev_enclave_data(const string& platform_ark_der_file,
-      const string& platform_ask_der_file,
-      const string& platform_vcek_der_file);
-  bool initialize_gramine_enclave_data(const int size, byte* cert);
-  bool initialize_oe_enclave_data(const string& file);
-  bool initialize_application_enclave_data(const string& parent_enclave_type,
-          int in_fd, int out_fd);
+      // Each of the enclave types have bespoke initialization
+      bool initialize_simulated_enclave_data(const string& attest_key_file_name,
+          const string& measurement_file_name, const string& attest_endorsement_file_name);
+      bool initialize_sev_enclave_data(const string& platform_ark_der_file,
+          const string& platform_ask_der_file,
+          const string& platform_vcek_der_file);
+      bool initialize_gramine_enclave_data(const int size, byte* cert);
+      bool initialize_oe_enclave_data(const string& file);
+      bool initialize_application_enclave_data(const string& parent_enclave_type,
+              int in_fd, int out_fd);
 
-  bool cc_all_initialized();
-  bool init_policy_key(int asn1_cert_size, byte* asn1_cert);
-  bool put_trust_data_in_store();
-  bool get_trust_data_from_store();
-  bool save_store();
-  bool fetch_store();
-  void clear_sensitive_data();
-  bool cold_init(const string& public_key_alg, const string& symmetric_key_alg,
-                 const string& hash_alg, const string& hmac_alg);
-  bool warm_restart();
-  bool certify_me(const string& host_name, int port);
-  bool GetPlatformSaysAttestClaim(signed_claim_message* scm);
-  void print_trust_data();
+      bool cc_all_initialized();
+      bool init_policy_key(int asn1_cert_size, byte* asn1_cert);
+      bool put_trust_data_in_store();
+      bool get_trust_data_from_store();
+      bool save_store();
+      bool fetch_store();
+      void clear_sensitive_data();
+      bool cold_init(const string& public_key_alg, const string& symmetric_key_alg,
+                     const string& hash_alg, const string& hmac_alg);
+      bool warm_restart();
+      bool certify_me(const string& host_name, int port);
+      bool GetPlatformSaysAttestClaim(signed_claim_message* scm);
+      void print_trust_data();
 
-  // For peer-to-peer certification
-  bool init_peer_certification_data(const string& public_key_alg);
-  bool recover_peer_certification_data();
-  bool get_peer_certification(const string& host_name, int port);
-  bool run_peer_certificationservice(const string& host_name, int port);
-};
+      // For peer-to-peer certification
+      bool init_peer_certification_data(const string& public_key_alg);
+      bool recover_peer_certification_data();
+      bool get_peer_certification(const string& host_name, int port);
+      bool run_peer_certificationservice(const string& host_name, int port);
+    };
 
-class secure_authenticated_channel {
-public:
-  string role_;
-  bool channel_initialized_;
-  key_message private_key_;
-  SSL_CTX* ssl_ctx_;
-  X509_STORE_CTX* store_ctx_;
-  SSL* ssl_;
-  int sock_;
-  string asn1_root_cert_;
-  X509* root_cert_;
-  X509* my_cert_;
-  string asn1_my_cert_;
-  X509* peer_cert_;
-  string peer_id_;
+    class secure_authenticated_channel {
+    public:
+      string role_;
+      bool channel_initialized_;
+      key_message private_key_;
+      SSL_CTX* ssl_ctx_;
+      X509_STORE_CTX* store_ctx_;
+      SSL* ssl_;
+      int sock_;
+      string asn1_root_cert_;
+      X509* root_cert_;
+      X509* my_cert_;
+      string asn1_my_cert_;
+      X509* peer_cert_;
+      string peer_id_;
 
-  secure_authenticated_channel(string& role);  // role is client or server
-  ~secure_authenticated_channel();
+      secure_authenticated_channel(string& role);  // role is client or server
+      ~secure_authenticated_channel();
 
-  bool load_client_certs_and_key();
+      bool load_client_certs_and_key();
 
-  bool init_client_ssl(const string& host_name, int port, string& asn1_root_cert,
-      key_message& private_key, const string& private_key_cert);
-  bool init_server_ssl(const string& host_name, int port, string& asn1_root_cert,
-      key_message& private_key, const string& private_key_cert);
+      bool init_client_ssl(const string& host_name, int port, string& asn1_root_cert,
+          key_message& private_key, const string& private_key_cert);
+      bool init_server_ssl(const string& host_name, int port, string& asn1_root_cert,
+          key_message& private_key, const string& private_key_cert);
 
-  void server_channel_accept_and_auth(void (*func)(secure_authenticated_channel&));
+      void server_channel_accept_and_auth(void (*func)(secure_authenticated_channel&));
 
-  int read(string* out);
-  int read(int size, byte* b);
-  int write(int size, byte* b);
-  void close();
-  bool get_peer_id(string* out);
-};
+      int read(string* out);
+      int read(int size, byte* b);
+      int write(int size, byte* b);
+      void close();
+      bool get_peer_id(string* out);
+    };
 
-bool server_dispatch(const string& host_name, int port,
-                     string& asn1_root_cert, key_message& private_key,
-                     const string& private_key_cert, void (*)(secure_authenticated_channel&));
+    bool server_dispatch(const string& host_name, int port,
+                         string& asn1_root_cert, key_message& private_key,
+                         const string& private_key_cert, void (*)(secure_authenticated_channel&));
+  }
+}
 
 #endif

--- a/include/certifier_utilities.h
+++ b/include/certifier_utilities.h
@@ -28,68 +28,72 @@ typedef unsigned char byte;
 
 using std::string;
 
-const int block_size = 16;
-const int num_bits_in_byte = 8;
+namespace certifier {
+  namespace utilities {
+    const int block_size = 16;
+    const int num_bits_in_byte = 8;
 
-bool write_file(const string& file_name, int size, byte* data);
-int file_size(const string& file_name);
-bool read_file(const string& file_name, int* size, byte* data);
-bool read_file_into_string(const string& file_name, string* out);
+    bool write_file(const string& file_name, int size, byte* data);
+    int file_size(const string& file_name);
+    bool read_file(const string& file_name, int* size, byte* data);
+    bool read_file_into_string(const string& file_name, string* out);
 
-bool digest_message(const char* alg, const byte* message, int message_len,
-    byte* digest, unsigned int digest_len);
+    bool digest_message(const char* alg, const byte* message, int message_len,
+        byte* digest, unsigned int digest_len);
 
 
-bool authenticated_encrypt(const char* alg, byte* in, int in_len, byte *key,
-            byte *iv, byte *out, int* out_size);
-bool authenticated_decrypt(const char* alg, byte* in, int in_len, byte *key,
-            byte *out, int* out_size);
+    bool authenticated_encrypt(const char* alg, byte* in, int in_len, byte *key,
+                byte *iv, byte *out, int* out_size);
+    bool authenticated_decrypt(const char* alg, byte* in, int in_len, byte *key,
+                byte *out, int* out_size);
 
-EC_KEY* generate_new_ecc_key(int num_bits);
-EC_KEY* key_to_ECC(const key_message& kr);
-bool ECC_to_key(const EC_KEY* e, key_message* k);
+    EC_KEY* generate_new_ecc_key(int num_bits);
+    EC_KEY* key_to_ECC(const key_message& kr);
+    bool ECC_to_key(const EC_KEY* e, key_message* k);
 
-bool private_key_to_public_key(const key_message& in, key_message* out);
-bool get_random(int num_bits, byte* out);
+    bool private_key_to_public_key(const key_message& in, key_message* out);
+    bool get_random(int num_bits, byte* out);
 
-// Serialized time: YYYY-MM-DDTHH:mm:ss. sssZ
-bool time_now(time_point* t);
-bool time_to_string(time_point& t, string* s);
-bool string_to_time(const string& s, time_point* t);
-bool add_interval_to_time_point(time_point& t_in, double hours, time_point* out);
-int compare_time(time_point& t1, time_point& t2);
-void print_time_point(time_point& t);
-void print_entity(const entity_message& em);
-void print_key(const key_message& k);
-void print_rsa_key(const rsa_message& rsa);
-void print_ecc_key(const ecc_message& rsa);
-void print_platform(const platform& pl);
-void print_environment(const environment& env);
-void print_property(const property& prop);
-void print_bytes(int n, byte* buf);
+    // Serialized time: YYYY-MM-DDTHH:mm:ss. sssZ
+    bool time_now(time_point* t);
+    bool time_to_string(time_point& t, string* s);
+    bool string_to_time(const string& s, time_point* t);
+    bool add_interval_to_time_point(time_point& t_in, double hours, time_point* out);
+    int compare_time(time_point& t1, time_point& t2);
+    void print_time_point(time_point& t);
+    void print_entity(const entity_message& em);
+    void print_key(const key_message& k);
+    void print_rsa_key(const rsa_message& rsa);
+    void print_ecc_key(const ecc_message& rsa);
+    void print_platform(const platform& pl);
+    void print_environment(const environment& env);
+    void print_property(const property& prop);
+    void print_bytes(int n, byte* buf);
 
-// X509 artifact
-bool produce_artifact(key_message& signing_key, string& issuer_name_str,
-      string& issuer_description_str, key_message& subject_key,
-      string& subject_name_str, string& subject_description_str,
-      uint64_t sn, double secs_duration, X509* x509, bool is_root);
-bool verify_artifact(X509& cert, key_message& verify_key,
-    string* issuer_name_str, string* issuer_description_str,
-    key_message* subject_key, string* subject_name_str, string* subject_description_str,
-    uint64_t* sn);
+    // X509 artifact
+    bool produce_artifact(key_message& signing_key, string& issuer_name_str,
+          string& issuer_description_str, key_message& subject_key,
+          string& subject_name_str, string& subject_description_str,
+          uint64_t sn, double secs_duration, X509* x509, bool is_root);
+    bool verify_artifact(X509& cert, key_message& verify_key,
+        string* issuer_name_str, string* issuer_description_str,
+        key_message* subject_key, string* subject_name_str, string* subject_description_str,
+        uint64_t* sn);
 
-int cipher_block_byte_size(const char* alg_name);
-int cipher_key_byte_size(const char* alg_name);
-int digest_output_byte_size(const char* alg_name);
-int mac_output_byte_size(const char* alg_name);
+    int cipher_block_byte_size(const char* alg_name);
+    int cipher_key_byte_size(const char* alg_name);
+    int digest_output_byte_size(const char* alg_name);
+    int mac_output_byte_size(const char* alg_name);
 
-bool asn1_to_x509(const string& in, X509 *x);
-bool x509_to_asn1(X509 *x, string* out);
-bool make_root_key_with_cert(string& type, string& name, string& issuer_name, key_message* k);
+    bool asn1_to_x509(const string& in, X509 *x);
+    bool x509_to_asn1(X509 *x, string* out);
+    bool make_root_key_with_cert(string& type, string& name, string& issuer_name, key_message* k);
 
-bool check_date_range(const string& nb, const string& na);
+    bool check_date_range(const string& nb, const string& na);
 
-int sized_socket_read(int fd, string* out);
-int sized_socket_write(int fd, int size, byte* buf);
+    int sized_socket_read(int fd, string* out);
+    int sized_socket_write(int fd, int size, byte* buf);
+  }
+}
 
 #endif

--- a/include/certifier_utilities.h
+++ b/include/certifier_utilities.h
@@ -1,0 +1,95 @@
+//  Copyright (c) 2021-23, VMware Inc, and the Certifier Authors.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef _CERTIFIER_UTILITIES_H__
+#define _CERTIFIER_UTILITIES_H__
+
+#include <string>
+#include <openssl/ssl.h>
+#include <openssl/rsa.h>
+#include <openssl/x509.h>
+#include <openssl/evp.h>
+#include "certifier.pb.h"
+
+#ifndef byte
+typedef unsigned char byte;
+#endif
+
+using std::string;
+
+const int block_size = 16;
+const int num_bits_in_byte = 8;
+
+bool write_file(const string& file_name, int size, byte* data);
+int file_size(const string& file_name);
+bool read_file(const string& file_name, int* size, byte* data);
+bool read_file_into_string(const string& file_name, string* out);
+
+bool digest_message(const char* alg, const byte* message, int message_len,
+    byte* digest, unsigned int digest_len);
+
+
+bool authenticated_encrypt(const char* alg, byte* in, int in_len, byte *key,
+            byte *iv, byte *out, int* out_size);
+bool authenticated_decrypt(const char* alg, byte* in, int in_len, byte *key,
+            byte *out, int* out_size);
+
+EC_KEY* generate_new_ecc_key(int num_bits);
+EC_KEY* key_to_ECC(const key_message& kr);
+bool ECC_to_key(const EC_KEY* e, key_message* k);
+
+bool private_key_to_public_key(const key_message& in, key_message* out);
+bool get_random(int num_bits, byte* out);
+
+// Serialized time: YYYY-MM-DDTHH:mm:ss. sssZ
+bool time_now(time_point* t);
+bool time_to_string(time_point& t, string* s);
+bool string_to_time(const string& s, time_point* t);
+bool add_interval_to_time_point(time_point& t_in, double hours, time_point* out);
+int compare_time(time_point& t1, time_point& t2);
+void print_time_point(time_point& t);
+void print_entity(const entity_message& em);
+void print_key(const key_message& k);
+void print_rsa_key(const rsa_message& rsa);
+void print_ecc_key(const ecc_message& rsa);
+void print_platform(const platform& pl);
+void print_environment(const environment& env);
+void print_property(const property& prop);
+void print_bytes(int n, byte* buf);
+
+// X509 artifact
+bool produce_artifact(key_message& signing_key, string& issuer_name_str,
+      string& issuer_description_str, key_message& subject_key,
+      string& subject_name_str, string& subject_description_str,
+      uint64_t sn, double secs_duration, X509* x509, bool is_root);
+bool verify_artifact(X509& cert, key_message& verify_key,
+    string* issuer_name_str, string* issuer_description_str,
+    key_message* subject_key, string* subject_name_str, string* subject_description_str,
+    uint64_t* sn);
+
+int cipher_block_byte_size(const char* alg_name);
+int cipher_key_byte_size(const char* alg_name);
+int digest_output_byte_size(const char* alg_name);
+int mac_output_byte_size(const char* alg_name);
+
+bool asn1_to_x509(const string& in, X509 *x);
+bool x509_to_asn1(X509 *x, string* out);
+bool make_root_key_with_cert(string& type, string& name, string& issuer_name, key_message* k);
+
+bool check_date_range(const string& nb, const string& na);
+
+int sized_socket_read(int fd, string* out);
+int sized_socket_write(int fd, int size, byte* buf);
+
+#endif

--- a/sample_apps/analytics_example/enclave/Makefile
+++ b/sample_apps/analytics_example/enclave/Makefile
@@ -47,9 +47,9 @@ build:
 		--search-path $(INCDIR)/openenclave/edl/sgx
 	$(PROTO) -I$(CERT_SRC) --cpp_out=. $(CERT_SRC)/certifier.proto
 	$(PROTO) -I$(CERT_SRC) --cpp_out=$(CERT_SRC) $(CERT_SRC)/certifier.proto
-	$(CXX) -g -Wno-shift-op-parentheses -c $(CXXFLAGS) $(INCLUDES) $(PROTO_INCL) $(CERT_INCL) $(DATAFRAME_INCL) -I. -I.. -std=c++17 -DOE_API_VERSION=2 ecalls.cc $(CERT_SRC)/support.cc $(CERT_SRC)/test_support.cc $(CERT_SRC)/simulated_enclave.cc $(CERT_SRC)/application_enclave.cc $(CERT_SRC)/certifier.cc $(CERT_SRC)/certifier_proofs.cc certifier.pb.cc $(CERT_SRC)/openenclave/attestation.cc $(CERT_SRC)/openenclave/sealing.cc $(CERT_SRC)/cc_helpers.cc
+	$(CXX) -g -Wno-shift-op-parentheses -c $(CXXFLAGS) $(INCLUDES) $(PROTO_INCL) $(CERT_INCL) $(DATAFRAME_INCL) -I. -I.. -std=c++17 -DOE_API_VERSION=2 ecalls.cc $(CERT_SRC)/support.cc $(CERT_SRC)/test_support.cc $(CERT_SRC)/simulated_enclave.cc $(CERT_SRC)/application_enclave.cc $(CERT_SRC)/certifier.cc $(CERT_SRC)/certifier_proofs.cc certifier.pb.cc $(CERT_SRC)/openenclave/attestation.cc $(CERT_SRC)/openenclave/sealing.cc $(CERT_SRC)/cc_helpers.cc $(CERT_SRC)/cc_useful.cc
 	$(CC) -g -c $(CFLAGS) $(CINCLUDES) -I.. -DOE_API_VERSION=2 ./attestation_t.c
-	$(CXX) -o enclave ecalls.o attestation_t.o certifier.pb.o certifier.o certifier_proofs.o support.o test_support.o simulated_enclave.o attestation.o sealing.o application_enclave.o cc_helpers.o $(SEAL_PLUGINS) $(DATAFRAME_LIB) $(LDFLAGS) $(CRYPTO_LDFLAGS) $(PROTO_LIB)  -loehostfs
+	$(CXX) -o enclave ecalls.o attestation_t.o certifier.pb.o certifier.o certifier_proofs.o support.o test_support.o simulated_enclave.o attestation.o sealing.o application_enclave.o cc_helpers.o cc_useful.o $(SEAL_PLUGINS) $(DATAFRAME_LIB) $(LDFLAGS) $(CRYPTO_LDFLAGS) $(PROTO_LIB)  -loehostfs
 	strip enclave
 
 sign:

--- a/sample_apps/analytics_example/enclave/ecalls.cc
+++ b/sample_apps/analytics_example/enclave/ecalls.cc
@@ -7,9 +7,6 @@
 #include <openenclave/attestation/verifier.h>
 #include <openenclave/bits/report.h>
 #include <openenclave/bits/module.h>
-#include "certifier.h"
-#include "support.h"
-#include "simulated_enclave.h"
 
 #include <sys/socket.h>
 #include <arpa/inet.h>
@@ -23,10 +20,8 @@
 #include <openssl/hmac.h>
 #include <openssl/err.h>
 
-#include "certifier.h"
-#include "support.h"
-#include "simulated_enclave.h"
-#include "cc_helpers.h"
+#include "certifier_framework.h"
+#include "certifier_utilities.h"
 #include "../policy_key.cc"
 
 #include "analytics_app.cc"

--- a/sample_apps/analytics_example/enclave/ecalls.cc
+++ b/sample_apps/analytics_example/enclave/ecalls.cc
@@ -26,6 +26,9 @@
 
 #include "analytics_app.cc"
 
+using namespace certifier::framework;
+using namespace certifier::utilities;
+
 #define FLAGS_print_all true
 static string measurement_file("/tmp/binary_trusted_measurements_file.bin");
 #define FLAGS_trusted_measurements_file measurement_file

--- a/sample_apps/att_systemd_service/attsvc.cc
+++ b/sample_apps/att_systemd_service/attsvc.cc
@@ -21,10 +21,6 @@
 #include <string.h>
 #include <sys/types.h>
 #include <filesystem>
-#include <certifier.h>
-#include <support.h>
-#include <simulated_enclave.h>
-#include <cc_helpers.h>
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -38,6 +34,7 @@
 #include <openssl/rand.h>
 #include <openssl/hmac.h>
 #include <openssl/err.h>
+#include <certifier_framework.h>
 
 #ifdef ATT_DEBUG
 #define ATT_LOG(priority, format, ...)  printf(format"\n", ##__VA_ARGS__)

--- a/sample_apps/att_systemd_service/attsvc.cc
+++ b/sample_apps/att_systemd_service/attsvc.cc
@@ -36,6 +36,8 @@
 #include <openssl/err.h>
 #include <certifier_framework.h>
 
+using namespace certifier::framework;
+
 #ifdef ATT_DEBUG
 #define ATT_LOG(priority, format, ...)  printf(format"\n", ##__VA_ARGS__)
 #else

--- a/sample_apps/simple_app/example_app.cc
+++ b/sample_apps/simple_app/example_app.cc
@@ -27,10 +27,7 @@
 #include <openssl/hmac.h>
 #include <openssl/err.h>
 
-#include "support.h"
-#include "certifier.h"
-#include "simulated_enclave.h"
-#include "cc_helpers.h"
+#include "certifier_framework.h"
 
 
 // operations are: cold-init, warm-restart, get-certifier, run-app-as-client, run-app-as-server

--- a/sample_apps/simple_app/example_app.cc
+++ b/sample_apps/simple_app/example_app.cc
@@ -29,6 +29,7 @@
 
 #include "certifier_framework.h"
 
+using namespace certifier::framework;
 
 // operations are: cold-init, warm-restart, get-certifier, run-app-as-client, run-app-as-server
 DEFINE_bool(print_all, false,  "verbose");

--- a/sample_apps/simple_app_under_app_service/service_example_app.cc
+++ b/sample_apps/simple_app_under_app_service/service_example_app.cc
@@ -30,6 +30,9 @@
 #include "certifier_framework.h"
 #include "certifier_utilities.h"
 
+using namespace certifier::framework;
+using namespace certifier::utilities;
+
 // operations are: cold-init, warm-restart, get-certifier, run-app-as-client, run-app-as-server
 DEFINE_bool(print_all, false,  "verbose");
 DEFINE_string(operation, "", "operation");

--- a/sample_apps/simple_app_under_app_service/service_example_app.cc
+++ b/sample_apps/simple_app_under_app_service/service_example_app.cc
@@ -27,11 +27,8 @@
 #include <openssl/hmac.h>
 #include <openssl/err.h>
 
-#include "support.h"
-#include "certifier.h"
-#include "simulated_enclave.h"
-#include "application_enclave.h"
-#include "cc_helpers.h"
+#include "certifier_framework.h"
+#include "certifier_utilities.h"
 
 // operations are: cold-init, warm-restart, get-certifier, run-app-as-client, run-app-as-server
 DEFINE_bool(print_all, false,  "verbose");

--- a/sample_apps/simple_app_under_app_service/start_program.cc
+++ b/sample_apps/simple_app_under_app_service/start_program.cc
@@ -8,6 +8,8 @@
 
 #include "certifier_utilities.h"
 
+using namespace certifier::utilities;
+
 DEFINE_string(server_app_host, "localhost", "address for application requests");
 DEFINE_int32(server_app_port, 8127, "port for application requests");
 DEFINE_string(executable, "service_example_app.exe", "executable to run");

--- a/sample_apps/simple_app_under_app_service/start_program.cc
+++ b/sample_apps/simple_app_under_app_service/start_program.cc
@@ -1,11 +1,12 @@
 #include <gflags/gflags.h>
 
-#include <support.h>
 #include <gflags/gflags.h>
 #include <sys/socket.h>
 #include <arpa/inet.h>
 #include <netinet/in.h>
 #include <netdb.h>
+
+#include "certifier_utilities.h"
 
 DEFINE_string(server_app_host, "localhost", "address for application requests");
 DEFINE_int32(server_app_port, 8127, "port for application requests");

--- a/sample_apps/simple_app_under_gramine/gramine_example_app.cc
+++ b/sample_apps/simple_app_under_gramine/gramine_example_app.cc
@@ -21,10 +21,8 @@
 
 #include "gramine_api.h"
 
-#include "support.h"
-#include "certifier.h"
-#include "simulated_enclave.h"
-#include "cc_helpers.h"
+#include "certifier_framework.h"
+#include "certifier_utilities.h"
 
 // operations are: cold-init, warm-restart, get-certifier, run-app-as-client, run-app-as-server
 DEFINE_bool(print_all, false,  "verbose");

--- a/sample_apps/simple_app_under_gramine/gramine_example_app.cc
+++ b/sample_apps/simple_app_under_gramine/gramine_example_app.cc
@@ -24,6 +24,9 @@
 #include "certifier_framework.h"
 #include "certifier_utilities.h"
 
+using namespace certifier::framework;
+using namespace certifier::utilities;
+
 // operations are: cold-init, warm-restart, get-certifier, run-app-as-client, run-app-as-server
 DEFINE_bool(print_all, false,  "verbose");
 DEFINE_string(operation, "", "operation");

--- a/sample_apps/simple_app_under_oe/enclave/ecalls.cc
+++ b/sample_apps/simple_app_under_oe/enclave/ecalls.cc
@@ -7,8 +7,6 @@
 #include <openenclave/attestation/verifier.h>
 #include <openenclave/bits/report.h>
 #include <openenclave/bits/module.h>
-#include "certifier.h"
-#include "support.h"
 
 #include <sys/socket.h>
 #include <arpa/inet.h>
@@ -22,9 +20,8 @@
 #include <openssl/hmac.h>
 #include <openssl/err.h>
 
-#include "certifier.h"
-#include "support.h"
-#include "cc_helpers.h"
+#include "certifier_framework.h"
+#include "certifier_utilities.h"
 #include "../policy_key.cc"
 
 #define FLAGS_print_all true

--- a/sample_apps/simple_app_under_oe/enclave/ecalls.cc
+++ b/sample_apps/simple_app_under_oe/enclave/ecalls.cc
@@ -24,6 +24,9 @@
 #include "certifier_utilities.h"
 #include "../policy_key.cc"
 
+using namespace certifier::framework;
+using namespace certifier::utilities;
+
 #define FLAGS_print_all true
 #define FLAGS_operation ""
 #define FLAGS_policy_host "localhost"

--- a/sample_apps/simple_app_under_sev/sev_example_app.cc
+++ b/sample_apps/simple_app_under_sev/sev_example_app.cc
@@ -27,10 +27,7 @@
 #include <openssl/hmac.h>
 #include <openssl/err.h>
 
-#include "support.h"
-#include "certifier.h"
-#include "simulated_enclave.h"
-#include "cc_helpers.h"
+#include "certifier_framework.h"
 
 // operations are: cold-init, warm-restart, get-certifier, run-app-as-client, run-app-as-server
 DEFINE_bool(print_all, false,  "verbose");

--- a/sample_apps/simple_app_under_sev/sev_example_app.cc
+++ b/sample_apps/simple_app_under_sev/sev_example_app.cc
@@ -29,6 +29,8 @@
 
 #include "certifier_framework.h"
 
+using namespace certifier::framework;
+
 // operations are: cold-init, warm-restart, get-certifier, run-app-as-client, run-app-as-server
 DEFINE_bool(print_all, false,  "verbose");
 DEFINE_string(operation, "", "operation");

--- a/src/certificate_tests.cc
+++ b/src/certificate_tests.cc
@@ -1,6 +1,8 @@
 #include "certifier.h"
 #include "support.h"
 
+using namespace certifier::utilities;
+
 //  Copyright (c) 2021-22, VMware Inc, and the Certifier Authors.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/certifier.cc
+++ b/src/certifier.cc
@@ -19,13 +19,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using namespace certifier::framework;
+using namespace certifier::utilities;
 
 // Policy store
 // -------------------------------------------------------------------
 
 extern string authenticated_encryption_algorithm;
 
-void print_store(policy_store& ps) {
+void certifier::framework::print_store(policy_store& ps) {
   printf("num_ts: %d\n", ps.num_ts_);
   printf("num_tsc: %d\n", ps.num_tsc_);
   printf("num_si: %d\n", ps.num_si_);
@@ -33,7 +35,7 @@ void print_store(policy_store& ps) {
   printf("num_tkm: %d\n", ps.num_tkm_);
 }
 
-policy_store::policy_store() {
+certifier::framework::policy_store::policy_store() {
   policy_key_valid_ = false;
 
   max_num_ts_ = MAX_NUM_ENTRIES;
@@ -59,7 +61,7 @@ policy_store::policy_store() {
   num_blobs_ = 0;
 }
 
-policy_store::policy_store(int max_trusted_services, int max_trusted_signed_claims,
+certifier::framework::policy_store::policy_store(int max_trusted_services, int max_trusted_signed_claims,
       int max_storage_infos, int max_claims, int max_keys, int max_blobs) {
   policy_key_valid_ = false;
 
@@ -85,38 +87,38 @@ policy_store::policy_store(int max_trusted_services, int max_trusted_signed_clai
   num_blobs_ = 0;
 }
 
-policy_store::~policy_store() {
+certifier::framework::policy_store::~policy_store() {
   // Todo: clean up sensitive values
   //    not necessary on most platfroms
 }
 
-void policy_store::clear_policy_store() {
+void certifier::framework::policy_store::clear_policy_store() {
   // Todo: not necessary on most platfroms
 }
 
-bool policy_store::replace_policy_key(key_message& k) {
+bool certifier::framework::policy_store::replace_policy_key(key_message& k) {
   policy_key_valid_ = true;
   policy_key_.CopyFrom((const key_message)k);
   return true;
 }
 
-const key_message* policy_store::get_policy_key() {
+const key_message* certifier::framework::policy_store::get_policy_key() {
   if (!policy_key_valid_)
     return nullptr;
   return &policy_key_;
 }
 
-int policy_store::get_num_trusted_services() {
+int certifier::framework::policy_store::get_num_trusted_services() {
   return num_ts_;
 }
 
-const trusted_service_message* policy_store::get_trusted_service_info_by_index(int n) {
+const trusted_service_message* certifier::framework::policy_store::get_trusted_service_info_by_index(int n) {
   if (n >= num_ts_)
     return nullptr;
   return ts_[n];
 }
 
-bool policy_store::add_trusted_service(trusted_service_message& to_add) {
+bool certifier::framework::policy_store::add_trusted_service(trusted_service_message& to_add) {
   if ((num_ts_+1) >= max_num_ts_)
     return true;
   trusted_service_message* t = new(trusted_service_message);
@@ -126,7 +128,7 @@ bool policy_store::add_trusted_service(trusted_service_message& to_add) {
   return true;
 }
 
-int policy_store::get_trusted_service_index_by_tag(const string tag) {
+int certifier::framework::policy_store::get_trusted_service_index_by_tag(const string tag) {
   for (int i = 0; i < num_ts_; i++) {
     if (ts_[i]->tag() == tag)
       return i;
@@ -134,7 +136,7 @@ int policy_store::get_trusted_service_index_by_tag(const string tag) {
   return -1;
 }
 
-void policy_store::delete_trusted_service_by_index(int n) {
+void certifier::framework::policy_store::delete_trusted_service_by_index(int n) {
   if (n >= num_ts_)
     return;
   const trusted_service_message* deleted = get_trusted_service_info_by_index(n);
@@ -145,17 +147,17 @@ void policy_store::delete_trusted_service_by_index(int n) {
   delete deleted;
 }
 
-int policy_store::get_num_storage_info() {
+int certifier::framework::policy_store::get_num_storage_info() {
   return num_si_;
 }
 
-const storage_info_message* policy_store::get_storage_info_by_index(int n) {
+const storage_info_message* certifier::framework::policy_store::get_storage_info_by_index(int n) {
   if (n >= num_si_)
     return nullptr;
   return si_[n];
 }
 
-bool policy_store::add_storage_info(storage_info_message& to_add) {
+bool certifier::framework::policy_store::add_storage_info(storage_info_message& to_add) {
   if ((num_si_ + 1) >= max_num_si_)
     return false;
   storage_info_message* t = new(storage_info_message);
@@ -165,7 +167,7 @@ bool policy_store::add_storage_info(storage_info_message& to_add) {
   return true;
 }
 
-void policy_store::delete_storage_info_by_index(int n) {
+void certifier::framework::policy_store::delete_storage_info_by_index(int n) {
   if (n >= num_si_)
     return;
   const storage_info_message* deleted = get_storage_info_by_index(n);
@@ -176,7 +178,7 @@ void policy_store::delete_storage_info_by_index(int n) {
   delete deleted;
 }
 
-int policy_store::get_storage_info_index_by_tag(const string& tag) {
+int certifier::framework::policy_store::get_storage_info_index_by_tag(const string& tag) {
   for (int i = 0; i < num_si_; i++) {
     if (si_[i]->tag() == tag)
       return i;
@@ -184,17 +186,17 @@ int policy_store::get_storage_info_index_by_tag(const string& tag) {
   return -1;
 }
 
-int policy_store::get_num_claims() {
+int certifier::framework::policy_store::get_num_claims() {
   return num_tc_;
 }
 
-const claim_message* policy_store::get_claim_by_index(int n) {
+const claim_message* certifier::framework::policy_store::get_claim_by_index(int n) {
   if (n >= num_tc_)
     return nullptr;
   return &(tc_[n]->claim());
 }
 
-bool policy_store::add_claim(const string& tag, const claim_message& to_add) {
+bool certifier::framework::policy_store::add_claim(const string& tag, const claim_message& to_add) {
   if ((num_tc_ + 1) >= max_num_tc_)
     return false;
   tagged_claim* t = new(tagged_claim);
@@ -205,7 +207,7 @@ bool policy_store::add_claim(const string& tag, const claim_message& to_add) {
   return true;
 }
 
-void policy_store::delete_claim_by_index(int n) {
+void certifier::framework::policy_store::delete_claim_by_index(int n) {
   if (n >= num_tc_)
     return;
   const tagged_claim* deleted = tc_[n];
@@ -216,7 +218,7 @@ void policy_store::delete_claim_by_index(int n) {
   delete deleted;
 }
 
-int policy_store::get_claim_index_by_tag(const string& tag) { // to do
+int certifier::framework::policy_store::get_claim_index_by_tag(const string& tag) { // to do
   for (int i = 0; i < num_tc_; i++) {
     if (tc_[i]->tag() == tag)
       return i;
@@ -224,7 +226,7 @@ int policy_store::get_claim_index_by_tag(const string& tag) { // to do
   return -1;
 }
 
-bool policy_store::add_authentication_key(const string& tag, const key_message& k) {
+bool certifier::framework::policy_store::add_authentication_key(const string& tag, const key_message& k) {
   if ((num_tkm_ + 1) >= max_num_tkm_)
     return false;
   channel_key_message* t = new(channel_key_message);
@@ -235,7 +237,7 @@ bool policy_store::add_authentication_key(const string& tag, const key_message& 
   return true;
 }
 
-const key_message* policy_store::get_authentication_key_by_tag(const string& tag) {
+const key_message* certifier::framework::policy_store::get_authentication_key_by_tag(const string& tag) {
   for (int i = 0; i < num_tkm_; i++) {
     if (tkm_[i]->tag() == tag)
       return &(tkm_[i]->auth_key());
@@ -243,13 +245,13 @@ const key_message* policy_store::get_authentication_key_by_tag(const string& tag
   return nullptr;
 }
 
-const key_message* policy_store::get_authentication_key_by_index(int i) {
+const key_message* certifier::framework::policy_store::get_authentication_key_by_index(int i) {
   if (i >= num_tkm_)
     return nullptr;
   return &(tkm_[i]->auth_key());
 }
 
-int policy_store::get_authentication_key_index_by_tag(const string& tag) {
+int certifier::framework::policy_store::get_authentication_key_index_by_tag(const string& tag) {
   for (int i = 0; i < num_tkm_; i++) {
     if (tkm_[i]->tag() == tag)
       return i;
@@ -257,7 +259,7 @@ int policy_store::get_authentication_key_index_by_tag(const string& tag) {
   return -1;
 }
 
-void policy_store::delete_authentication_key_by_index(int n) {
+void certifier::framework::policy_store::delete_authentication_key_by_index(int n) {
   if (n >= num_tkm_)
     return;
   const key_message* deleted = get_authentication_key_by_index(n);
@@ -268,7 +270,7 @@ void policy_store::delete_authentication_key_by_index(int n) {
   delete deleted;
 }
 
-bool policy_store::Serialize(string* out) {
+bool certifier::framework::policy_store::Serialize(string* out) {
   policy_store_message psm;
 
   // Copy data to psm
@@ -309,7 +311,7 @@ bool policy_store::Serialize(string* out) {
   return true;
 }
 
-bool policy_store::Deserialize(string& in) {
+bool certifier::framework::policy_store::Deserialize(string& in) {
   policy_store_message psm;
 
   if (!psm.ParseFromString(in))
@@ -366,13 +368,13 @@ bool policy_store::Deserialize(string& in) {
   return true;
 }
 
-const signed_claim_message* policy_store::get_signed_claim_by_index(int n) {
+const signed_claim_message* certifier::framework::policy_store::get_signed_claim_by_index(int n) {
   if (n >= num_tsc_)
     return nullptr;
   return &(tsc_[n]->sc());
 }
 
-bool policy_store::add_signed_claim(const string& tag, const signed_claim_message& to_add) {
+bool certifier::framework::policy_store::add_signed_claim(const string& tag, const signed_claim_message& to_add) {
   if ((num_tsc_ + 1) >= max_num_tsc_)
     return false;
   tagged_signed_claim* t = new(tagged_signed_claim);
@@ -383,7 +385,7 @@ bool policy_store::add_signed_claim(const string& tag, const signed_claim_messag
   return true;
 }
 
-int policy_store::get_signed_claim_index_by_tag(const string& tag) {
+int certifier::framework::policy_store::get_signed_claim_index_by_tag(const string& tag) {
   for (int i = 0; i < num_tsc_; i++) {
     if (tsc_[i]->tag() == tag)
       return i;
@@ -391,7 +393,7 @@ int policy_store::get_signed_claim_index_by_tag(const string& tag) {
   return -1;
 }
 
-void policy_store::delete_signed_claim_by_index(int n) {
+void certifier::framework::policy_store::delete_signed_claim_by_index(int n) {
   if (n >= num_tsc_)
     return;
   const signed_claim_message* deleted = get_signed_claim_by_index(n);
@@ -402,7 +404,7 @@ void policy_store::delete_signed_claim_by_index(int n) {
   delete deleted;
 }
 
-bool policy_store::add_blob(const string& tag, const string& s) {
+bool certifier::framework::policy_store::add_blob(const string& tag, const string& s) {
   if (num_blobs_ >= max_num_blobs_)
     return false;
   int n = get_blob_index_by_tag(tag);
@@ -415,26 +417,26 @@ bool policy_store::add_blob(const string& tag, const string& s) {
   return true;
 }
 
-const string* policy_store::get_blob_by_tag(const string& tag) {
+const string* certifier::framework::policy_store::get_blob_by_tag(const string& tag) {
   int index = get_blob_index_by_tag(tag);
   if (index < 0)
     return nullptr;
   return &tagged_blob_[index]->b();
 }
 
-const tagged_blob_message* policy_store::get_tagged_blob_info_by_index(int n) {
+const tagged_blob_message* certifier::framework::policy_store::get_tagged_blob_info_by_index(int n) {
   if (n >= num_blobs_)
     return nullptr;
   return tagged_blob_[n];
 }
 
-const string* policy_store::get_blob_by_index(int index) {
+const string* certifier::framework::policy_store::get_blob_by_index(int index) {
   if (index >= num_blobs_)
     return nullptr;
   return &(tagged_blob_[index]->b());
 }
 
-int policy_store::get_blob_index_by_tag(const string& tag) {
+int certifier::framework::policy_store::get_blob_index_by_tag(const string& tag) {
   for (int i = 0; i < num_blobs_; i++) {
     if (tag == tagged_blob_[i]->tag())
       return i;
@@ -442,7 +444,7 @@ int policy_store::get_blob_index_by_tag(const string& tag) {
   return -1;
 }
 
-void policy_store::delete_blob_by_index(int index) {
+void certifier::framework::policy_store::delete_blob_by_index(int index) {
   if (index >= num_blobs_)
     return;
   const tagged_blob_message* deleted = get_tagged_blob_info_by_index(index);
@@ -454,7 +456,7 @@ void policy_store::delete_blob_by_index(int index) {
 
 }
 
-int policy_store::get_num_blobs() {
+int certifier::framework::policy_store::get_num_blobs() {
   return num_blobs_;
 }
 
@@ -597,7 +599,7 @@ extern bool gramine_Unseal(int in_size, byte* in, int* size_out, byte* out);
 
 // Buffer overflow check: Seal returns true and the buffer size in size_out.
 // Check on Gramine.
-bool Seal(const string& enclave_type, const string& enclave_id,
+bool certifier::framework::Seal(const string& enclave_type, const string& enclave_id,
  int in_size, byte* in, int* size_out, byte* out) {
 
   if (enclave_type == "simulated-enclave") {
@@ -632,7 +634,7 @@ bool Seal(const string& enclave_type, const string& enclave_id,
 
 // Buffer overflow check: Done for SEV, OE, simulated enclave and application service.
 // If out is NULL, Unseal returns true and the buffer size in size_out.  Check Gramine.
-bool Unseal(const string& enclave_type, const string& enclave_id,
+bool certifier::framework::Unseal(const string& enclave_type, const string& enclave_id,
  int in_size, byte* in, int* size_out, byte* out) {
 
   if (enclave_type == "simulated-enclave") {
@@ -666,7 +668,7 @@ bool Unseal(const string& enclave_type, const string& enclave_id,
 }
 
 //  Buffer overflow check: Attest returns true and the buffer size in size_out.  Check on Gramine.
-bool Attest(const string& enclave_type, int what_to_say_size, byte* what_to_say,
+bool certifier::framework::Attest(const string& enclave_type, int what_to_say_size, byte* what_to_say,
  int* size_out, byte* out) {
 
   if (enclave_type == "simulated-enclave") {
@@ -785,7 +787,7 @@ bool GetParentEnclaveType(string* type) {
 const int max_key_seal_pad = 1024;
 const int protect_key_size = 64;
 
-bool Protect_Blob(const string& enclave_type, key_message& key,
+bool certifier::framework::Protect_Blob(const string& enclave_type, key_message& key,
   int size_unencrypted_data, byte* unencrypted_data,
   int* size_protected_blob, byte* blob) {
 
@@ -844,7 +846,7 @@ bool Protect_Blob(const string& enclave_type, key_message& key,
   return true;
 }
 
-bool Unprotect_Blob(const string& enclave_type, int size_protected_blob,
+bool certifier::framework::Unprotect_Blob(const string& enclave_type, int size_protected_blob,
       byte* protected_blob, key_message* key, int* size_of_unencrypted_data,
       byte* unencrypted_data) {
 
@@ -908,7 +910,7 @@ bool Unprotect_Blob(const string& enclave_type, int size_protected_blob,
 
 // -------------------------------------------------------------------
 
-bool check_date_range(const string& nb, const string& na) {
+bool certifier::utilities::check_date_range(const string& nb, const string& na) {
   time_point t_now;
   time_point t_nb;
   time_point t_na;

--- a/src/certifier_proofs.cc
+++ b/src/certifier_proofs.cc
@@ -26,6 +26,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using namespace certifier::framework;
+using namespace certifier::utilities;
 
 // Proof support
 // -----------------------------------------------------------------------

--- a/src/claims_tests.cc
+++ b/src/claims_tests.cc
@@ -1,6 +1,9 @@
 #include "certifier.h"
 #include "support.h"
 
+using namespace certifier::framework;
+using namespace certifier::utilities;
+
 //  Copyright (c) 2021-22, VMware Inc, and the Certifier Authors.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/openenclave/oe_support.cc
+++ b/src/openenclave/oe_support.cc
@@ -7,6 +7,8 @@
 #include <certifier.h>
 #include <support.h>
 
+using namespace certifier::utilities;
+
 string pem_cert_chain;
 bool pem_cert_chain_initialized = false;
 

--- a/src/pipe_read_test.cc
+++ b/src/pipe_read_test.cc
@@ -5,6 +5,8 @@
 #include "support.h"
 #include "simulated_enclave.h"
 
+using namespace certifier::utilities;
+
 //  Copyright (c) 2021-22, VMware Inc, and the Certifier Authors.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/primitive_tests.cc
+++ b/src/primitive_tests.cc
@@ -3,6 +3,9 @@
 #include "simulated_enclave.h"
 #include "application_enclave.h"
 
+using namespace certifier::framework;
+using namespace certifier::utilities;
+
 //  Copyright (c) 2021-22, VMware Inc, and the Certifier Authors.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/sev-snp/sev_support.cc
+++ b/src/sev-snp/sev_support.cc
@@ -43,12 +43,18 @@
 #include "certifier.h"
 #include "support.h"
 
+using namespace certifier::framework;
+using namespace certifier::utilities;
+
 #define SEV_GUEST_DEVICE  "/dev/sev-guest"
 
 #ifdef SEV_DUMMY_GUEST
 #define SEV_ECDSA_PRIV_KEY  "ec-secp384r1-priv-key.pem"
 #define SEV_ECDSA_PUB_KEY  "ec-secp384r1-pub-key.pem"
 #endif
+
+using namespace certifier::framework;
+using namespace certifier::utilities;
 
 static void reverse_bytes(uint8_t *buffer, size_t size) {
   if (!buffer || size == 0)

--- a/src/simulated_enclave.cc
+++ b/src/simulated_enclave.cc
@@ -6,12 +6,15 @@
 #include <openssl/hmac.h>
 #include <openssl/x509v3.h>
 
-#include "support.h" 
-#include "simulated_enclave.h" 
-#include "certifier.pb.h" 
+#include "support.h"
+#include "simulated_enclave.h"
+#include "certifier.pb.h"
 
 #include <string>
+
 using std::string;
+using namespace certifier::framework;
+using namespace certifier::utilities;
 
 //  Copyright (c) 2021-22, VMware Inc, and the Certifier Authors.  All rights reserved.
 //

--- a/src/store_tests.cc
+++ b/src/store_tests.cc
@@ -1,6 +1,9 @@
 #include "certifier.h"
 #include "support.h"
 
+using namespace certifier::framework;
+using namespace certifier::utilities;
+
 //  Copyright (c) 2021-22, VMware Inc, and the Certifier Authors.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/support.cc
+++ b/src/support.cc
@@ -24,13 +24,16 @@
 #include <openssl/evp.h>
 #include <openssl/ec.h>
 
-#include "support.h" 
-#include "certifier.pb.h" 
+#include "support.h"
+#include "certifier.pb.h"
 
 #include <sys/ioctl.h>
 #include <sys/socket.h>
 #include <string>
+
 using std::string;
+using namespace certifier::framework;
+using namespace certifier::utilities;
 
 string authenticated_encryption_algorithm("aes-256-cbc-hmac-sha256");
 
@@ -99,7 +102,7 @@ name_size mac_byte_name_size[] = {
   {"aes-256-gcm", 16},
 };
 
-int cipher_block_byte_size(const char* alg_name) {
+int certifier::utilities::cipher_block_byte_size(const char* alg_name) {
   int size = sizeof(cipher_block_byte_name_size) / sizeof(cipher_block_byte_name_size[0]);
 
   for (int i = 0; i < size; i++) {
@@ -109,7 +112,7 @@ int cipher_block_byte_size(const char* alg_name) {
   return -1;
 }
 
-int cipher_key_byte_size(const char* alg_name) {
+int certifier::utilities::cipher_key_byte_size(const char* alg_name) {
   int size = sizeof(cipher_key_byte_name_size) / sizeof(cipher_key_byte_name_size[0]);
 
   for (int i = 0; i < size; i++) {
@@ -119,7 +122,7 @@ int cipher_key_byte_size(const char* alg_name) {
   return -1;
 }
 
-int digest_output_byte_size(const char* alg_name) {
+int certifier::utilities::digest_output_byte_size(const char* alg_name) {
   int size = sizeof(digest_byte_name_size) / sizeof(digest_byte_name_size[0]);
 
   for (int i = 0; i < size; i++) {
@@ -129,7 +132,7 @@ int digest_output_byte_size(const char* alg_name) {
   return -1;
 }
 
-int mac_output_byte_size(const char* alg_name) {
+int certifier::utilities::mac_output_byte_size(const char* alg_name) {
   int size = sizeof(mac_byte_name_size) / sizeof(mac_byte_name_size[0]);
 
   for (int i = 0; i < size; i++) {
@@ -139,7 +142,7 @@ int mac_output_byte_size(const char* alg_name) {
   return -1;
 }
 
-bool write_file(const string& file_name, int size, byte* data) {
+bool certifier::utilities::write_file(const string& file_name, int size, byte* data) {
   int out = open(file_name.c_str(), O_RDWR | O_CREAT | O_TRUNC, 0644);
   if (out < 0)
     return false;
@@ -152,7 +155,7 @@ bool write_file(const string& file_name, int size, byte* data) {
   return true;
 }
 
-int file_size(const string& file_name) {
+int certifier::utilities::file_size(const string& file_name) {
   struct stat file_info;
 
   if (stat(file_name.c_str(), &file_info) != 0)
@@ -162,7 +165,7 @@ int file_size(const string& file_name) {
   return (int)file_info.st_size;
 }
 
-bool read_file(const string& file_name, int* size, byte* data) {
+bool certifier::utilities::read_file(const string& file_name, int* size, byte* data) {
   struct stat file_info;
 
   if (stat(file_name.c_str(), &file_info) != 0) {
@@ -188,7 +191,7 @@ bool read_file(const string& file_name, int* size, byte* data) {
   return true;
 }
 
-bool read_file_into_string(const string& file_name, string* out) {
+bool certifier::utilities::read_file_into_string(const string& file_name, string* out) {
   int size = file_size(file_name);
   if (size < 0) {
     printf("read_file_into_string: Can't size input file\n");
@@ -206,7 +209,7 @@ bool read_file_into_string(const string& file_name, string* out) {
 
 // -----------------------------------------------------------------------
 
-bool time_now(time_point* t) {
+bool certifier::utilities::time_now(time_point* t) {
   time_t now;
   struct tm current_time;
 
@@ -221,7 +224,7 @@ bool time_now(time_point* t) {
   return true;
 }
 
-bool time_to_string(time_point& t, string* s) {
+bool certifier::utilities::time_to_string(time_point& t, string* s) {
   char t_buf[128];
 
   // YYYY-MM-DDTHH:mm:ss.sssZ
@@ -232,7 +235,7 @@ bool time_to_string(time_point& t, string* s) {
   return true;
 }
 
-bool string_to_time(const string& s, time_point* t) {
+bool certifier::utilities::string_to_time(const string& s, time_point* t) {
   int y, m, d, h, min;
   double secs;
   sscanf(s.c_str(), "%04d-%02d-%02dT%02d:%02d:%lfZ",
@@ -249,7 +252,7 @@ bool string_to_time(const string& s, time_point* t) {
 // 1 if t1 > t2
 // 0 if t1 == t2
 // -1 if t1 < t2
-int compare_time(time_point& t1, time_point& t2) {
+int certifier::utilities::compare_time(time_point& t1, time_point& t2) {
   if (t1.year() > t2.year())
     return 1;
   if (t1.year() < t2.year())
@@ -277,7 +280,8 @@ int compare_time(time_point& t1, time_point& t2) {
   return 0;
 }
 
-bool add_interval_to_time_point(time_point& t_in, double hours, time_point* t_out) {
+bool certifier::utilities::add_interval_to_time_point(time_point& t_in, double hours,
+      time_point* t_out) {
   int y, m, d, h, min;
   double secs;
 
@@ -369,12 +373,12 @@ bool add_interval_to_time_point(time_point& t_in, double hours, time_point* t_ou
   return true;
 }
 
-void print_time_point(time_point& t) {
+void certifier::utilities::print_time_point(time_point& t) {
   printf("%02d-%02d-%02dT%02d:%02d:%8.5lfZ\n", t.year(), t.month(),
     t.day(), t.hour(), t.minute(), t.seconds());
 }
 
-void print_property(const property& prop) {
+void certifier::utilities::print_property(const property& prop) {
   printf("%s: ", prop.property_name().c_str());
 
   if (prop.value_type() == "int") {
@@ -393,7 +397,7 @@ void print_property(const property& prop) {
   printf("\n");
 }
 
-void print_platform(const platform& pl) {
+void certifier::utilities::print_platform(const platform& pl) {
   printf("platform: %s\n", pl.platform_type().c_str());
   if (pl.has_key()) {
     printf("  attest_key: ");
@@ -408,7 +412,7 @@ void print_platform(const platform& pl) {
   }
 }
 
-void print_environment(const environment& env) {
+void certifier::utilities::print_environment(const environment& env) {
   printf("environment\n");
   print_platform_descriptor(env.the_platform());
   printf("\n");
@@ -495,8 +499,8 @@ done:
     return ret;
 }
 
-bool digest_message(const char* alg, const byte* message, int message_len,
-    byte* digest, unsigned int digest_len) {
+bool certifier::utilities::digest_message(const char* alg, const byte* message,
+    int message_len, byte* digest, unsigned int digest_len) {
 
   int n = digest_output_byte_size(alg);
   if (n < 0)
@@ -762,8 +766,8 @@ done:
   return ret;
 }
 
-bool authenticated_encrypt(const char* alg_name, byte* in, int in_len, byte *key,
-            byte *iv, byte *out, int* out_size) {
+bool certifier::utilities::authenticated_encrypt(const char* alg_name, byte* in,
+            int in_len, byte *key, byte *iv, byte *out, int* out_size) {
 
   if (strcmp(alg_name, "aes-256-cbc-hmac-sha256") == 0) {
     return aes_256_cbc_sha256_encrypt(in, in_len, key, iv, out, out_size);
@@ -777,8 +781,8 @@ bool authenticated_encrypt(const char* alg_name, byte* in, int in_len, byte *key
   }
 }
 
-bool authenticated_decrypt(const char* alg_name, byte* in, int in_len, byte *key,
-            byte *out, int* out_size) {
+bool certifier::utilities::authenticated_decrypt(const char* alg_name, byte* in,
+            int in_len, byte *key, byte *out, int* out_size) {
 
   if (strcmp(alg_name, "aes-256-cbc-hmac-sha256") == 0) {
     return aes_256_cbc_sha256_decrypt(in, in_len, key, out, out_size);
@@ -794,7 +798,8 @@ bool authenticated_decrypt(const char* alg_name, byte* in, int in_len, byte *key
 
 const int rsa_alg_type = 1;
 const int ecc_alg_type = 2;
-bool private_key_to_public_key(const key_message& in, key_message* out) {
+bool certifier::utilities::private_key_to_public_key(const key_message& in,
+      key_message* out) {
 
   int n_bytes = 0;
   int alg_type = 0;
@@ -1238,7 +1243,7 @@ void print_point(const point_message& pt) {
   BN_free(y);
 }
 
-void print_ecc_key(const ecc_message& em) {
+void certifier::utilities::print_ecc_key(const ecc_message& em) {
 
   if (em.has_curve_name()) {
     printf("Curve name: %s\n", em.curve_name().c_str());
@@ -1349,7 +1354,7 @@ bool ecc_verify(const char* alg, EC_KEY* key, int size, byte* msg, int size_sig,
   return true;
 }
 
-EC_KEY* generate_new_ecc_key(int num_bits) {
+EC_KEY* certifier::utilities::generate_new_ecc_key(int num_bits) {
 
   EC_KEY* ecc_key = nullptr;
   if (num_bits == 384) {
@@ -1386,7 +1391,7 @@ EC_KEY* generate_new_ecc_key(int num_bits) {
 }
 
 // Todo: free k on error
-EC_KEY* key_to_ECC(const key_message& k) {
+EC_KEY* certifier::utilities::key_to_ECC(const key_message& k) {
 
   EC_KEY* ecc_key = nullptr;
   if (k.key_type() == "ecc-384-private" || k.key_type() == "ecc-384-public") {
@@ -1451,7 +1456,7 @@ EC_KEY* key_to_ECC(const key_message& k) {
   return ecc_key;
 }
 
-bool ECC_to_key(const EC_KEY* ecc_key, key_message* k) {
+bool certifier::utilities::ECC_to_key(const EC_KEY* ecc_key, key_message* k) {
   k->set_key_format("vse_key");
 
   ecc_message* ek = new ecc_message;
@@ -1634,7 +1639,7 @@ bool make_certifier_ecc_key(int n,  key_message* k) {
 
 // -----------------------------------------------------------------------
 
-bool get_random(int num_bits, byte* out) {
+bool certifier::utilities::get_random(int num_bits, byte* out) {
   bool ret = true;
   int k = 0;
   int n = ((num_bits + num_bits_in_byte - 1) / num_bits_in_byte);
@@ -1993,12 +1998,12 @@ bool make_claim(int size, byte* serialized_claim, string& format, string& descri
 
 // -----------------------------------------------------------------------
 
-void print_bytes(int n, byte* buf) {
+void certifier::utilities::print_bytes(int n, byte* buf) {
   for(int i = 0; i < n; i++)
     printf("%02x", buf[i]);
 }
 
-void print_rsa_key(const rsa_message& rsa) {
+void certifier::utilities::print_rsa_key(const rsa_message& rsa) {
   if (rsa.has_public_modulus()) {
     printf("Modulus: ");
     print_bytes(rsa.public_modulus().size(), (byte*)rsa.public_modulus().data());
@@ -2024,7 +2029,7 @@ void print_rsa_key(const rsa_message& rsa) {
   }
 }
 
-void print_key(const key_message& k) {
+void certifier::utilities::print_key(const key_message& k) {
   if (k.has_key_name()) {
     printf("Key name: %s\n", k.key_name().c_str());
   }
@@ -2228,7 +2233,7 @@ void print_signed_claim(const signed_claim_message& signed_claim) {
   }
 }
 
-void print_entity(const entity_message& em) {
+void certifier::utilities::print_entity(const entity_message& em) {
   if (!em.has_entity_type())
     printf("%s entity\n", em.entity_type().c_str());
   if (em.entity_type() == "key") {
@@ -2495,7 +2500,8 @@ int add_ext(X509 *cert, int nid, const char *value) {
 
 // Caller should have allocated X509
 // name is some printable version of the measurement
-bool produce_artifact(key_message& signing_key, string& issuer_name_str,
+bool certifier::utilities::produce_artifact(
+                      key_message& signing_key, string& issuer_name_str,
                       string& issuer_organization_str, key_message& subject_key,
                       string& subject_name_str, string& subject_organization_str,
                       uint64_t sn, double secs_duration, X509* x509, bool is_root) {
@@ -2647,7 +2653,7 @@ bool produce_artifact(key_message& signing_key, string& issuer_name_str,
   return true;
 }
 
-bool verify_artifact(X509& cert, key_message& verify_key, 
+bool certifier::utilities::verify_artifact(X509& cert, key_message& verify_key,
     string* issuer_name_str, string* issuer_description_str,
     key_message* subject_key, string* subject_name_str, string* subject_organization_str,
     uint64_t* sn) {
@@ -2715,7 +2721,7 @@ bool verify_artifact(X509& cert, key_message& verify_key,
 
 // -----------------------------------------------------------------------
 
-bool asn1_to_x509(const string& in, X509 *x) {
+bool certifier::utilities::asn1_to_x509(const string& in, X509 *x) {
   int len = in.size();
 
   byte* p = (byte*) in.data();
@@ -2725,7 +2731,7 @@ bool asn1_to_x509(const string& in, X509 *x) {
   return true;
 }
 
-bool x509_to_asn1(X509 *x, string* out) {
+bool certifier::utilities::x509_to_asn1(X509 *x, string* out) {
   int len = i2d_X509(x, nullptr);
   byte buf[len];
   byte* p = buf;
@@ -2818,7 +2824,7 @@ int sized_ssl_read(SSL* ssl, string* out) {
 }
 
 // little endian only
-int sized_socket_read(int fd, string* out) {
+int certifier::utilities::sized_socket_read(int fd, string* out) {
   out->clear();
   int n = 0;
   int size = 0;
@@ -2845,7 +2851,7 @@ int sized_socket_read(int fd, string* out) {
 }
 
 // little endian only
-int sized_socket_write(int fd, int size, byte* buf) {
+int certifier::utilities::sized_socket_write(int fd, int size, byte* buf) {
   if (write(fd, (byte*)&size, sizeof(int)) < (int)sizeof(int))
     return -1;
   if (write(fd, buf, size) < size)
@@ -3050,7 +3056,8 @@ bool x509_to_public_key(X509* x, key_message* k) {
   return true;
 }
 
-bool make_root_key_with_cert(string& type, string& name, string& issuer_name, key_message* k) {
+bool certifier::utilities::make_root_key_with_cert(string& type, string& name,
+      string& issuer_name, key_message* k) {
   string root_name("root");
 
   if (type == "rsa-4096-private" || type == "rsa-2048-private" || type == "rsa-1024-private") {

--- a/src/support_tests.cc
+++ b/src/support_tests.cc
@@ -1,6 +1,8 @@
 #include "certifier.h"
 #include "support.h"
 
+using namespace certifier::utilities;
+
 //  Copyright (c) 2021-22, VMware Inc, and the Certifier Authors.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test_channel.cc
+++ b/src/test_channel.cc
@@ -18,6 +18,9 @@
 #include <openssl/hmac.h>
 #include <openssl/err.h>
 
+using namespace certifier::framework;
+using namespace certifier::utilities;
+
 //  Copyright (c) 2021-22, VMware Inc, and the Certifier Authors.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test_support.cc
+++ b/src/test_support.cc
@@ -4,6 +4,9 @@
 #include "sev-snp/attestation.h"
 #endif
 
+using namespace certifier::framework;
+using namespace certifier::utilities;
+
 //  Copyright (c) 2021-22, VMware Inc, and the Certifier Authors.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/x509_tests.cc
+++ b/src/x509_tests.cc
@@ -3,6 +3,9 @@
 #include "simulated_enclave.h"
 #include "application_enclave.h"
 
+using namespace certifier::framework;
+using namespace certifier::utilities;
+
 //  Copyright (c) 2021-22, VMware Inc, and the Certifier Authors.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/utilities/cert_utility.cc
+++ b/utilities/cert_utility.cc
@@ -15,6 +15,8 @@
 #include <gflags/gflags.h>
 #include "support.h"
 
+using namespace certifier::utilities;
+
 DEFINE_bool(print_all, false,  "verbose");
 // "generate-policy-key-and-test-keys" is the other option
 DEFINE_string(operation, "",  "generate policy key and self-signed cert");

--- a/utilities/combine_properties.cc
+++ b/utilities/combine_properties.cc
@@ -18,6 +18,8 @@
 #include "certifier.h"
 #include "support.h"
 
+using namespace certifier::utilities;
+
 DEFINE_bool(print_all, false,  "verbose");
 DEFINE_string(in, "",  "input files");
 DEFINE_string(output, "",  "output file");

--- a/utilities/key_utility.cc
+++ b/utilities/key_utility.cc
@@ -15,6 +15,8 @@
 #include <gflags/gflags.h>
 #include "support.h"
 
+using namespace certifier::utilities;
+
 DEFINE_bool(print_all, false,  "verbose");
 
 DEFINE_bool(is_root, false,  "verbose");

--- a/utilities/make_environment.cc
+++ b/utilities/make_environment.cc
@@ -18,6 +18,8 @@
 #include "certifier.h"
 #include "support.h"
 
+using namespace certifier::utilities;
+
 DEFINE_bool(print_all, false,  "verbose");
 DEFINE_string(platform_file, "",  "platform file");
 DEFINE_string(measurement_file, "",  "measurement file");

--- a/utilities/make_indirect_vse_clause.cc
+++ b/utilities/make_indirect_vse_clause.cc
@@ -18,6 +18,8 @@
 #include "certifier.h"
 #include "support.h"
 
+using namespace certifier::utilities;
+
 DEFINE_bool(print_all, false,  "verbose");
 DEFINE_string(output, "simple_clause.bin",  "output file");
 DEFINE_string(key_subject, "",  "subject file");

--- a/utilities/make_platform.cc
+++ b/utilities/make_platform.cc
@@ -18,6 +18,8 @@
 #include "certifier.h"
 #include "support.h"
 
+using namespace certifier::utilities;
+
 DEFINE_bool(print_all, false,  "verbose");
 DEFINE_string(platform_type, "",  "platform type");
 DEFINE_string(properties_file, "",  "properties files");

--- a/utilities/make_property.cc
+++ b/utilities/make_property.cc
@@ -19,6 +19,8 @@
 #include "certifier.h"
 #include "support.h"
 
+using namespace certifier::utilities;
+
 DEFINE_bool(print_all, false,  "verbose");
 DEFINE_string(property_name, "",  "property name");
 DEFINE_string(property_type, "",  "property type");

--- a/utilities/make_signed_claim_from_vse_clause.cc
+++ b/utilities/make_signed_claim_from_vse_clause.cc
@@ -18,6 +18,8 @@
 #include "certifier.h"
 #include "support.h"
 
+using namespace certifier::utilities;
+
 DEFINE_bool(print_all, false,  "verbose");
 DEFINE_string(vse_file, "vse_claim.bin",  "clause file");
 DEFINE_string(output, "signed_claim.bin",  "output file");

--- a/utilities/make_simple_vse_clause.cc
+++ b/utilities/make_simple_vse_clause.cc
@@ -21,6 +21,8 @@
 #include "certifier.h"
 #include "support.h"
 
+using namespace certifier::utilities;
+
 DEFINE_bool(print_all, false,  "verbose");
 DEFINE_string(output, "simple_clause.bin",  "output file");
 DEFINE_string(key_subject, "",  "subject file");

--- a/utilities/make_unary_vse_clause.cc
+++ b/utilities/make_unary_vse_clause.cc
@@ -19,6 +19,8 @@
 #include "certifier.h"
 #include "support.h"
 
+using namespace certifier::utilities;
+
 DEFINE_bool(print_all, false,  "verbose");
 DEFINE_string(output, "simple_clause.bin",  "output file");
 DEFINE_string(key_subject, "",  "key subject file");

--- a/utilities/measurement_utility.cc
+++ b/utilities/measurement_utility.cc
@@ -18,6 +18,8 @@
 #include "certifier.h"
 #include "support.h"
 
+using namespace certifier::utilities;
+
 DEFINE_bool(print_all, false,  "verbose");
 DEFINE_string(type, "hash",  "measurement type");
 DEFINE_string(input, "measurement_utility.exe",  "input file");

--- a/utilities/package_claims.cc
+++ b/utilities/package_claims.cc
@@ -18,6 +18,8 @@
 #include "certifier.h"
 #include "support.h"
 
+using namespace certifier::utilities;
+
 DEFINE_bool(print_all, false,  "verbose");
 DEFINE_string(input, "input1,input2,...,inputk",  "input file");
 DEFINE_string(output, "claims_sequence.bin",  "output file");

--- a/utilities/print_packaged_claims.cc
+++ b/utilities/print_packaged_claims.cc
@@ -18,6 +18,8 @@
 #include "certifier.h"
 #include "support.h"
 
+using namespace certifier::utilities;
+
 DEFINE_bool(print_all, false,  "verbose");
 DEFINE_string(input, "simple_clause.bin",  "input file");
 

--- a/utilities/print_signed_claim.cc
+++ b/utilities/print_signed_claim.cc
@@ -18,6 +18,8 @@
 #include "certifier.h"
 #include "support.h"
 
+using namespace certifier::utilities;
+
 DEFINE_bool(print_all, false,  "verbose");
 DEFINE_string(input, "",  "input file");
 

--- a/utilities/print_vse_clause.cc
+++ b/utilities/print_vse_clause.cc
@@ -18,6 +18,8 @@
 #include "certifier.h"
 #include "support.h"
 
+using namespace certifier::utilities;
+
 DEFINE_bool(print_all, false,  "verbose");
 DEFINE_string(input, "measurement_utility.exe",  "input file");
 

--- a/utilities/sample_sev_key_generation.cc
+++ b/utilities/sample_sev_key_generation.cc
@@ -17,6 +17,8 @@
 #include "support.h"
 #include "attestation.h"
 
+using namespace certifier::utilities;
+
 DEFINE_bool(print_all, false,  "verbose");
 DEFINE_string(ark_der, "sev_ark_cert.der",  "ark cert file");
 DEFINE_string(ask_der, "sev_ask_cert.der",  "ask cert file");

--- a/utilities/simulated_sev_attest.cc
+++ b/utilities/simulated_sev_attest.cc
@@ -17,6 +17,7 @@
 #include "attestation.h"
 #include <gflags/gflags.h>
 
+using namespace certifier::utilities;
 
 DEFINE_bool(print_all, false,  "verbose");
 DEFINE_string(key_file, "../certifier_service/certlib/test_data/ec-secp384r1-priv-key.pem",  "private key file name");

--- a/utilities/simulated_sev_key_generation.cc
+++ b/utilities/simulated_sev_key_generation.cc
@@ -22,6 +22,8 @@
 #include "support.h"
 #include "attestation.h"
 
+using namespace certifier::utilities;
+
 DEFINE_bool(print_all, false,  "verbose");
 DEFINE_string(ark_der, "sev_ark_cert.der",  "ark cert file");
 DEFINE_string(ask_der, "sev_ask_cert.der",  "ask cert file");


### PR DESCRIPTION
Refactored Certifier headers. All Certifier user facing public interfaces are moved to certifier_framework.h and all the Certifier utilities are moved to certifier_utilities.h. No other headers should be used by user applications. As a first step, some internal headers now include the public headers to maintain consistency. These will be cleaned up in the followup patches.