### PR TITLE
Fix run_example.sh to get setup_with_auto_policy_generation_for_OE to work.

### DIFF
--- a/sample_apps/run_example.sh
+++ b/sample_apps/run_example.sh
@@ -194,6 +194,7 @@ Steps_OE=( "rm_non_git_files"
            "automated_policy_generation_for_OE"
               # These sub-step fns are subsumed under automated_policy_generation_for_OE()
               "edit_policy_file_OE"
+              "build_policy_generator_OE"
               "run_policy_generator_OE"
 
            "build_simple_server"
@@ -711,6 +712,7 @@ function automated_policy_generation_for_OE() {
     run_pushd "${PROV_DIR}"
 
     edit_policy_file_OE
+    build_policy_generator_OE
     run_policy_generator_OE
 
     run_popd
@@ -750,6 +752,15 @@ function edit_policy_file_OE() {
     # Update policy.json file with json.tmp file, created above.
     run_cmd mv ${policy_json_file}.tmp ${policy_json_file}
 
+    run_popd
+}
+
+# ###########################################################################
+function build_policy_generator_OE() {
+    run_cmd
+    run_pushd "${CERT_PROTO}/utilities"
+    local mkf="policy_generator.mak"
+    LOCAL_LIB=${Local_lib_path} run_cmd make -f ${mkf}
     run_popd
 }
 

--- a/sample_apps/simple_app_under_oe/instructions.md
+++ b/sample_apps/simple_app_under_oe/instructions.md
@@ -157,7 +157,7 @@ $CERTIFIER_PROTOTYPE/utilities/package_claims.exe     \
 $CERTIFIER_PROTOTYPE/utilities/print_packaged_claims.exe --input=policy.bin
 ```
 
-## Step 8: Use Policy Generator
+## Step 8: Use Automated Policy Generator
 
 ### a. Edit policy file
 
@@ -165,7 +165,14 @@ Open `simple_app_under_oe/oe_policy.json` and replace trusted measurements
 in the "measurements" property with the expected measurement from
 `make dump_mrenclave`.
 
-### b. Run Policy Generator
+### b. Build the Policy Generator
+
+```shell
+cd $CERTIFIER_PROTOTYPE/utilities
+LOCAL_LIB=/usr/local/lib64 make -f policy_generator.mak
+```
+
+### c. Run Policy Generator
 
 ```shell
 cd $EXAMPLE_DIR/provisioning


### PR DESCRIPTION
Add build_policy_generator_OE() in the series of steps needed to get setup-with-automated policy generation part of the workflow to run successfully. With this fix, the following should work:

$ run_example.sh simple_app_under_oe setup_with_auto_policy_generation_for_OE 
$ run_example.sh simple_app_under_oe run_test

Update instructions.md to reflect the addition of this small sub-step to the workflow.

----
NOTE: To the reviewer: This usage does not have CI coverage. I hand-tested this manually on sgx machine, and now `run_test` succeeds cleanly as follows:

```
run_example.sh: Running run_simple_app_under_oe_as_client_make_trusted_request
+ set +x

+ ./host/host enclave/enclave.signed run-app-as-client /home/sgx/agurajada/certifier-framework-for-confidential-computing/sample_apps/simple_app_under_oe/app1_data
Using data_dir: /home/sgx/agurajada/certifier-framework-for-confidential-computing/sample_apps/simple_app_under_oe/app1_data/
read_file_into_string: Can't size input file
oe_Init: No pem cert chain file. Assume empty endorsement.
running as client
Client peer id is Measured-8dc95a5f85212e0df11ac04909af2fd0c370fdc20102c841258d0713484d365d
Client peer cert is:
Server peer id is Measured-8dc95a5f85212e0df11ac04909af2fd0c370fdc20102c841258d0713484d365d
Server peer cert is:
SSL server read: Hi from your secret client

SSL client read: Hi from your secret server

run-app-as-client succeeded!
+ set +x
run_example.sh: Mon 22 May 2023 11:29:50 AM PDT Completed run_simple_app_under_oe_as_client_make_trusted_request .
run_example.sh: Mon 22 May 2023 11:29:50 AM PDT Completed run_test  for simple_app_under_oe.
```