### PR TITLE
Update SEV-SNP simulator support

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -141,12 +141,13 @@ This is the only directory that contains GPL licensed code and it is not include
 the certifier API or certifier service, so all other code in the Certifier Framework
 for Confidential Computing is not affected by GPL license terms.
 
-To build this and install it on Linux: (RESOLVE: These steps did not work; got diff errors. Sort it out during review.)
+To build this and install it on Linux:
 
 ```shell
 $ cd $(CERTIFIER)/sev-snp-simulator
-$ make sev-guest
-$ sudo make insmod     # (You must be root to install the module)
+$ make
+$ make keys
+$ make insmod
 $ cd $(CERTIFIER)/sev-snp-simulator/test
 $ make sev-test
 $ sudo sev-test        # (You must be root to run the test)

--- a/sample_apps/simple_app_under_sev/instructions.txt
+++ b/sample_apps/simple_app_under_sev/instructions.txt
@@ -257,7 +257,7 @@ Step3a: Make sure there are der encoded versions of the ARK, ASK and VCEK certif
         cd $SEV_EXAMPLE_DIR/provisioning
         $CERTIFIER_PROTOTYPE/utilities/simulated_sev_key_generation.exe --ark_der=sev_ark_cert.der \
         --ask_der=sev_ask_cert.der --vcek_der=sev_vcek_cert.der \
-        --vcek_key_file=$CERTIFIER_PROTOTYPE/src/ec-secp384r1-pub-key.pem
+        --vcek_key_file=/etc/certifier-snp-sim/ec-secp384r1-pub-key.pem
         mv ark_cert.der ark_cert.der.old
         mv ask_cert.der ask_cert.der.old
         mv vcek_cert.der vcek_cert.der.old

--- a/sample_apps/simple_app_under_sev/script
+++ b/sample_apps/simple_app_under_sev/script
@@ -37,7 +37,7 @@ $CERTIFIER_PROTOTYPE/utilities/measurement_init.exe --mrenclave=5c19d5b4a50066c8
 $CERTIFIER_PROTOTYPE/utilities/measurement_init.exe --mrenclave=010203040506070801020304050607080102030405060708010203040506070801020304050607080102030405060708 --out_file=sev_example_app.measurement
 $CERTIFIER_PROTOTYPE/utilities/simulated_sev_key_generation.exe --ark_der=sev_ark_cert.der \
   --ask_der=sev_ask_cert.der --vcek_der=sev_vcek_cert.der \
-  --vcek_key_file=$CERTIFIER_PROTOTYPE/src/ec-secp384r1-pub-key.pem
+  --vcek_key_file=/etc/certifier-snp-sim/ec-secp384r1-pub-key.pem
 mv ark_cert.der ark_cert.der.old
 mv ask_cert.der ask_cert.der.old
 mv vcek_cert.der vcek_cert.der.old

--- a/sample_apps/simple_app_under_sev/sev_example_app.mak
+++ b/sample_apps/simple_app_under_sev/sev_example_app.mak
@@ -60,7 +60,7 @@ sev_example_app.exe: $(dobj)
 
 $(O)/certifier.pb.o: $(S)/certifier.pb.cc $(I)/certifier.pb.h
 	@echo "compiling certifier.pb.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/certifier.pb.o $(S)/certifier.pb.cc
+	$(CC) $(CFLAGS) -Wno-array-bounds -c -o $(O)/certifier.pb.o $(S)/certifier.pb.cc
 
 $(O)/sev_example_app.o: $(US)/sev_example_app.cc $(I)/certifier.h $(S)/certifier.pb.cc
 	@echo "compiling sev_example_app.cc"

--- a/sample_apps/simple_app_under_sev/sev_example_app_with_dummy.mak
+++ b/sample_apps/simple_app_under_sev/sev_example_app_with_dummy.mak
@@ -60,7 +60,7 @@ sev_example_app.exe: $(dobj)
 
 $(O)/certifier.pb.o: $(S)/certifier.pb.cc $(I)/certifier.pb.h
 	@echo "compiling certifier.pb.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/certifier.pb.o $(S)/certifier.pb.cc
+	$(CC) $(CFLAGS) -Wno-array-bounds -c -o $(O)/certifier.pb.o $(S)/certifier.pb.cc
 
 $(O)/sev_example_app.o: $(US)/sev_example_app.cc $(I)/certifier.h $(S)/certifier.pb.cc
 	@echo "compiling sev_example_app.cc"

--- a/sev-snp-simulator/Makefile
+++ b/sev-snp-simulator/Makefile
@@ -1,6 +1,7 @@
 MODULE_NAME := sevnull
 DEV_PATH := /dev/sev-guest
 EXTRA_CFLAGS  += -g -std=gnu99  -Wfatal-errors
+OPENSSL := openssl
 
 
 ifneq ($(KERNELRELEASE),) 	# kernelspace
@@ -23,6 +24,14 @@ modules:
 modules_install:
 	make -C $(LINUX_KERNEL_PATH) M=$(CURRENT_PATH) modules_install
 
+keys:
+	rm -rf keys
+	mkdir keys
+	$(OPENSSL) ecparam -name secp384r1 -genkey -noout -out keys/ec-secp384r1-priv-key.pem
+	$(OPENSSL) ec -in keys/ec-secp384r1-priv-key.pem -pubout > keys/ec-secp384r1-pub-key.pem
+	sudo rm -rf /etc/certifier-snp-sim
+	sudo mkdir /etc/certifier-snp-sim
+	sudo cp keys/* /etc/certifier-snp-sim/
 
 insmod:
 	sudo insmod $(MODULE_NAME).ko
@@ -37,6 +46,7 @@ rmmod:
 clean:
 	make -C $(LINUX_KERNEL_PATH) M=$(CURRENT_PATH) clean
 	rm -f modules.order Module.symvers Module.markers
+	rm -rf keys
 
 .PHNOY:
 	modules modules_install clean

--- a/sev-snp-simulator/instructions.txt
+++ b/sev-snp-simulator/instructions.txt
@@ -1,7 +1,6 @@
 make
+make keys
+make insmod
 cd test
 make
-make sev-keys
-sudo make insmod
 sudo sev-test
-make sev-guest

--- a/sev-snp-simulator/test/Makefile
+++ b/sev-snp-simulator/test/Makefile
@@ -15,10 +15,6 @@ all: $(TARGETS)
 sev-test: sev-test.o sev-ecdsa.o report.o
 	$(CC) $(CFLAGS) -DPROG_NAME=$@ -o $@ $^ $(OPENSSL_LDFLAGS)
 
-sev-keys:
-	$(OPENSSL) ecparam -name secp384r1 -genkey -noout -out ec-secp384r1-priv-key.pem
-	$(OPENSSL) ec -in ec-secp384r1-priv-key.pem -pubout > ec-secp384r1-pub-key.pem
-
 clean:
 	$(RM) $(TARGETS) $(OBJECTS) cscope.*
 

--- a/sev-snp-simulator/test/sev-test.c
+++ b/sev-snp-simulator/test/sev-test.c
@@ -38,8 +38,8 @@
 
 #define SEV_GUEST_DEVICE	"/dev/sev-guest"
 #define SEV_DUMMY_GUEST
-#define SEV_ECDSA_PRIV_KEY	"ec-secp384r1-priv-key.pem"
-#define SEV_ECDSA_PUB_KEY	"ec-secp384r1-pub-key.pem"
+#define SEV_ECDSA_PRIV_KEY	"/etc/certifier-snp-sim/ec-secp384r1-priv-key.pem"
+#define SEV_ECDSA_PUB_KEY	"/etc/certifier-snp-sim/ec-secp384r1-pub-key.pem"
 
 struct key_options {
 	union tcb_version tcb;

--- a/src/certifier.mak
+++ b/src/certifier.mak
@@ -83,7 +83,7 @@ $(O)/certifier_tests.o: $(S)/certifier_tests.cc $(I)/certifier.pb.h $(I)/certifi
 
 $(O)/certifier.pb.o: $(S)/certifier.pb.cc $(I)/certifier.pb.h
 	@echo "compiling certifier.pb.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/certifier.pb.o $(S)/certifier.pb.cc
+	$(CC) $(CFLAGS) -Wno-array-bounds -c -o $(O)/certifier.pb.o $(S)/certifier.pb.cc
 
 $(O)/certifier.o: $(S)/certifier.cc $(I)/certifier.pb.h $(I)/certifier.h
 	@echo "compiling certifier.cc"

--- a/src/sev-snp/sev_support.cc
+++ b/src/sev-snp/sev_support.cc
@@ -49,8 +49,8 @@ using namespace certifier::utilities;
 #define SEV_GUEST_DEVICE  "/dev/sev-guest"
 
 #ifdef SEV_DUMMY_GUEST
-#define SEV_ECDSA_PRIV_KEY  "ec-secp384r1-priv-key.pem"
-#define SEV_ECDSA_PUB_KEY  "ec-secp384r1-pub-key.pem"
+#define SEV_ECDSA_PRIV_KEY  "/etc/certifier-snp-sim/ec-secp384r1-priv-key.pem"
+#define SEV_ECDSA_PUB_KEY  "/etc/certifier-snp-sim/ec-secp384r1-pub-key.pem"
 #endif
 
 using namespace certifier::framework;

--- a/utilities/cert_utility.mak
+++ b/utilities/cert_utility.mak
@@ -96,7 +96,7 @@ $(US)/certifier.pb.cc $(I)/certifier.pb.h: $(S)/certifier.proto
 
 $(O)/certifier.pb.o: $(US)/certifier.pb.cc $(I)/certifier.pb.h
 	@echo "compiling certifier.pb.cc"
-	$(CC) $(CFLAGS_NOERROR) -c  -o $(O)/certifier.pb.o $(US)/certifier.pb.cc
+	$(CC) $(CFLAGS_NOERROR) -Wno-array-bounds -c  -o $(O)/certifier.pb.o $(US)/certifier.pb.cc
 
 $(O)/support.o: $(S)/support.cc $(I)/support.h $(I)/certifier.pb.h
 	@echo "compiling support.cc"

--- a/utilities/policy_utilities.mak
+++ b/utilities/policy_utilities.mak
@@ -128,7 +128,7 @@ $(CERT_SRC)/certifier.pb.cc $(I)/certifier.pb.h: $(CERT_SRC)/certifier.proto
 
 $(O)/certifier.pb.o: $(CERT_SRC)/certifier.pb.cc $(INC_DIR)/certifier.pb.h
 	@echo "compiling certifier.pb.cc"
-	$(CC) $(CFLAGS_NOERROR) -c  -o $(O)/certifier.pb.o $(CERT_SRC)/certifier.pb.cc
+	$(CC) $(CFLAGS_NOERROR) -Warray-bounds -c  -o $(O)/certifier.pb.o $(CERT_SRC)/certifier.pb.cc
 
 $(O)/support.o: $(CERT_SRC)/support.cc $(INC_DIR)/support.h $(INC_DIR)/certifier.pb.h
 	@echo "compiling support.cc"


### PR DESCRIPTION
Updated the SEV-SNP simulator to generate keys in fixed system directory so the instructions can be more consistent. Also added some missing compiler flags to remove Protobuf compilation warning.