### PR TITLE
Fix CCA setup and shim test build

### DIFF
--- a/src/cca/islet_test/Makefile
+++ b/src/cca/islet_test/Makefile
@@ -1,7 +1,7 @@
 GPP=g++
 ISLET_PATH = ../../../third_party/islet
 ISLET_INCLUDE= -I$(ISLET_PATH)/include
-ISLET_LDFLAGS= -L$(ISLET_PATH)/lib -lislet_sdk
+ISLET_LDFLAGS= -L$(ISLET_PATH)/remote/out/x86_64-unknown-linux-gnu/debug/ -lislet_sdk
 
 .PHONY: all
 all: attest_seal_test
@@ -12,12 +12,12 @@ LDFLAGS += $(ISLET_LDFLAGS)
 .PHONY: attest_seal_test
 attest_seal_test: attest_seal_test.cc
 	@$(GPP) $< $(CFLAGS) $(LDFLAGS) -o $@
-	@LD_LIBRARY_PATH=$(ISLET_PATH)/lib ./$@
+	@LD_LIBRARY_PATH=$(ISLET_PATH)/remote/out/x86_64-unknown-linux-gnu/debug ./$@
 
 .PHONY: shim_test
 shim_test: shim_test.cc ../cca_shim.cc
 	@$(GPP) $^ $(CFLAGS) $(LDFLAGS) -o $@
-	@LD_LIBRARY_PATH=$(ISLET_PATH)/lib ./$@
+	@LD_LIBRARY_PATH=$(ISLET_PATH)/remote/out/x86_64-unknown-linux-gnu/debug ./$@
 
 .PHONY: test
 test: attest_seal_test shim_test

--- a/third_party/islet/setup.sh
+++ b/third_party/islet/setup.sh
@@ -41,9 +41,12 @@ mv islet-certifier-v1.0.1-beta "$ISLET"
 # Install rust to build ISLET SDK
 "$ISLET/scripts/deps/rust.sh"
 
+. "$HOME/.cargo/env"
 # Build ISLET SDK (simulated version for x86_64)
 cd "$ISLET_SDK" && cargo build
 
 mkdir -p "$ISLET_INC" "$ISLET_LIB"
 cp -p "$TARGET_HDR" "$ISLET_INC"
 cp -p "$TARGET_LIB" "$ISLET_LIB"
+
+echo "Restart your shell or source ~/.bashrc"


### PR DESCRIPTION
Fixed CCA setup script to add cargo installation to PATH. Also fixed the shim_test build for CCA to look for the correct libislet_sdk.so.