### PR TITLE
(#106) Integrate build-and-test of Keystone app under run_example.sh

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,6 +78,9 @@ jobs:
         ./run_example.sh --help simple_app_under_app_service
         ./run_example.sh --list simple_app_under_app_service
 
+        ./run_example.sh --help simple_app_under_keystone
+        ./run_example.sh --list simple_app_under_keystone
+
         popd
 
     - name: test-run_example-dry-run
@@ -118,6 +121,7 @@ jobs:
         #! Should do nothing but just emit usage messages
         ./run_example.sh --dry-run application_service run_test
 
+        ./run_example.sh --dry-run simple_app_under_keystone
         popd
 
     - name: test-run_example-simple_app
@@ -142,7 +146,7 @@ jobs:
 
         popd
 
-    - name: test-build-and-setup-App-Service-and-Simple-App
+    - name: test-build-and-setup-App-Service-and-simple_app_under_app_service
       run: |
         echo " "
         echo "***************************************"
@@ -270,10 +274,27 @@ jobs:
         echo " "
         pushd ./sample_apps
 
+        ./run_example.sh rm_non_git_files
         ./run_example.sh simple_app_under_sev setup
         sudo ./run_example.sh simple_app_under_sev run_test
 
         sudo ./cleanup.sh
+        popd
+
+    - name: test-simple_app_under_keystone-using-shim
+      run: |
+        echo " "
+        echo "********************************************"
+        echo "* Run simple_app_under_keystone using shim"
+        echo "********************************************"
+        echo " "
+        pushd ./sample_apps
+
+        ./run_example.sh rm_non_git_files
+        ./run_example.sh simple_app_under_keystone setup
+        ./run_example.sh simple_app_under_keystone run_test
+
+        ./cleanup.sh
         popd
 
     - name: test-miscellaneous

--- a/sample_apps/simple_app_under_keystone/temporary_instructions.txt
+++ b/sample_apps/simple_app_under_keystone/temporary_instructions.txt
@@ -1,9 +1,23 @@
+#!/bin/bash
+
 export GOPATH=$HOME
-export CERTIFIER_PROTOTYPE=~/src/github.com/jlmucb/crypto/v2/certifier-framework-for-confidential-computing
+
+pushd "$(dirname "$0")" > /dev/null 2>&1
+
+cd ../..
+CERTIFIER_PROTOTYPE="$(pwd)"; export CERTIFIER_PROTOTYPE
+
+popd
+
 export KEYSTONE_EXAMPLE_DIR=$CERTIFIER_PROTOTYPE/sample_apps/simple_app_under_keystone
 export KEYSTONE_SRC=$CERTIFIER_PROTOTYPE/src/keystone
 
+env | grep -E 'CERTIFIER_PROTOTYPE|KEYSTONE_EXAMPLE_DIR|KEYSTONE_SRC'
+
 # Make directories
+set -x
+rm -rf $KEYSTONE_EXAMPLE_DIR/{provisioning,service,app1_data,app2_data}
+
 mkdir -p $KEYSTONE_EXAMPLE_DIR/provisioning
 mkdir -p $KEYSTONE_EXAMPLE_DIR/service
 mkdir -p $KEYSTONE_EXAMPLE_DIR/app1_data
@@ -16,7 +30,7 @@ cd $KEYSTONE_SRC
 
 make -f shim_test.mak
 ./keystone_test.exe
-cp $KEYSTONE_SRC/emulated_keystone_key.bin $KEYSTONE_SRC/emulated_keystone_key_cert.bin $KEYSTONE_EXAMPLE_DIR/provisioning
+cp -p $KEYSTONE_SRC/emulated_keystone_key.bin $KEYSTONE_SRC/emulated_keystone_key_cert.bin $KEYSTONE_EXAMPLE_DIR/provisioning
 
 
 #build the utilities
@@ -28,6 +42,7 @@ make -f policy_utilities.mak
 
 #generate the keys
 cd $KEYSTONE_EXAMPLE_DIR/provisioning
+
 $CERTIFIER_PROTOTYPE/utilities/cert_utility.exe --operation=generate-policy-key-and-test-keys \
     --policy_key_output_file=policy_key_file.bin --policy_cert_output_file=policy_cert_file.bin \
     --platform_key_output_file=platform_key_file.bin --attest_key_output_file=attest_key_file.bin
@@ -35,6 +50,7 @@ $CERTIFIER_PROTOTYPE/utilities/cert_utility.exe --operation=generate-policy-key-
 
 # embed policy key and compile app
 cd $KEYSTONE_EXAMPLE_DIR/provisioning
+
 $CERTIFIER_PROTOTYPE/utilities/embed_policy_key.exe --input=policy_cert_file.bin --output=../policy_key.cc
 
 # make app and compute app measurement
@@ -48,19 +64,24 @@ cd $KEYSTONE_EXAMPLE_DIR/provisioning
 # policyKey says the attestationKey is-trusted-for-attestation
 $CERTIFIER_PROTOTYPE/utilities/make_unary_vse_clause.exe --cert_subject=emulated_keystone_key_cert.bin \
   --verb="is-trusted-for-attestation" --output=ts1.bin
+
 $CERTIFIER_PROTOTYPE/utilities/make_indirect_vse_clause.exe --key_subject=policy_key_file.bin \
   --verb="says" --clause=ts1.bin --output=vse_policy1.bin
+
+# Get Measurement: policy key says measurement is-trusted
+$CERTIFIER_PROTOTYPE/utilities/measurement_utility.exe --type=hash --input=../keystone_example_app.exe \
+      --output=example_app.measurement
+
+$CERTIFIER_PROTOTYPE/utilities/make_unary_vse_clause.exe --key_subject="" \
+  --measurement_subject=example_app.measurement --verb="is-trusted" \
+  --output=ts2.bin
+
+$CERTIFIER_PROTOTYPE/utilities/make_indirect_vse_clause.exe --key_subject=policy_key_file.bin \
+  --verb="says" --clause=ts2.bin --output=vse_policy2.bin
+
 $CERTIFIER_PROTOTYPE/utilities/make_signed_claim_from_vse_clause.exe --vse_file=vse_policy1.bin \
   --duration=9000 --private_key_file=policy_key_file.bin --output=signed_claim_1.bin
 
-# policy key says measurement is-trusted
-$CERTIFIER_PROTOTYPE/utilities/measurement_utility.exe --type=hash --input=../keystone_example_app.exe \
-      --output=keystone_example_app.measurement
-$CERTIFIER_PROTOTYPE/utilities/make_unary_vse_clause.exe --key_subject="" \
-  --measurement_subject=keystone_example_app.measurement --verb="is-trusted" \
-  --output=ts2.bin
-$CERTIFIER_PROTOTYPE/utilities/make_indirect_vse_clause.exe --key_subject=policy_key_file.bin \
-  --verb="says" --clause=ts2.bin --output=vse_policy2.bin
 $CERTIFIER_PROTOTYPE/utilities/make_signed_claim_from_vse_clause.exe \
   --vse_file=vse_policy2.bin --duration=9000 \
   --private_key_file=policy_key_file.bin --output=signed_claim_2.bin
@@ -70,45 +91,79 @@ $CERTIFIER_PROTOTYPE/utilities/package_claims.exe --input=signed_claim_1.bin,sig
 
 $CERTIFIER_PROTOTYPE/utilities/print_packaged_claims.exe --input=policy.bin
 
+# -----------------------------------------------------------------------------
+# NOTE: This arrangement is critical for this app to run cleanly.
+#       As we are working with a shim, simpleserver needs to be built with
+#       emulated key/cert bin files. So, provision them first.
 # provision service and apps
+# -----------------------------------------------------------------------------
 cd $KEYSTONE_EXAMPLE_DIR/provisioning
-cp ./* $KEYSTONE_EXAMPLE_DIR/service
-cp ./* $KEYSTONE_EXAMPLE_DIR/app1_data
-cp ./* $KEYSTONE_EXAMPLE_DIR/app2_data
+cp  -p ./* $KEYSTONE_EXAMPLE_DIR/service
+cp  -p ./* $KEYSTONE_EXAMPLE_DIR/app1_data
+cp  -p ./* $KEYSTONE_EXAMPLE_DIR/app2_data
 
 #compile the server
+cd $CERTIFIER_PROTOTYPE/certifier_service/certprotos
+
+protoc --go_opt=paths=source_relative --go_out=. --go_opt=M=certifier.proto ./certifier.proto
+
+cd $CERTIFIER_PROTOTYPE/certifier_service/oelib
+make dummy
+
+cd $CERTIFIER_PROTOTYPE/certifier_service/graminelib
+make dummy
+
 cd $CERTIFIER_PROTOTYPE/certifier_service
+
 go build simpleserver.go
 
 #run server
 cd $KEYSTONE_EXAMPLE_DIR/service
-$CERTIFIER_PROTOTYPE/certifier_service/simpleserver \
-      --policyFile=policy.bin --readPolicy=true
+
+$CERTIFIER_PROTOTYPE/certifier_service/simpleserver --policyFile=policy.bin --readPolicy=true &
+
+sleep 5
 
 # initialize client app
 cd $KEYSTONE_EXAMPLE_DIR
+
 $KEYSTONE_EXAMPLE_DIR/keystone_example_app.exe --print_all=true \
-      --operation=cold-init --data_dir=./app1_data/ --measurement_file="keystone_example_app.measurement" \
+      --operation=cold-init --data_dir=./app1_data/ --measurement_file="example_app.measurement" \
       --policy_store_file=policy_store
+
+sleep 5
+
 # get client app certified
 $KEYSTONE_EXAMPLE_DIR/keystone_example_app.exe --print_all=true \
-      --operation=get-certifier --data_dir=./app1_data/ --measurement_file="keystone_example_app.measurement" \
+      --operation=get-certifier --data_dir=./app1_data/ --measurement_file="example_app.measurement" \
       --policy_store_file=policy_store
+
+sleep 5
 
 # initialize server app
 $KEYSTONE_EXAMPLE_DIR/keystone_example_app.exe --print_all=true \
-      --operation=cold-init --data_dir=./app2_data/ --measurement_file="keystone_example_app.measurement" \
+      --operation=cold-init --data_dir=./app2_data/ --measurement_file="example_app.measurement" \
       --policy_store_file=policy_store
+
+sleep 5
+
 # get server app certified
 $KEYSTONE_EXAMPLE_DIR/keystone_example_app.exe --print_all=true \
-      --operation=get-certifier --data_dir=./app2_data/ --measurement_file="keystone_example_app.measurement" \
+      --operation=get-certifier --data_dir=./app2_data/ --measurement_file="example_app.measurement" \
        --policy_store_file=policy_store
+
+sleep 5
 
 #run the app
 cd $KEYSTONE_EXAMPLE_DIR
+
 $KEYSTONE_EXAMPLE_DIR/keystone_example_app.exe --print_all=true --operation=run-app-as-server --data_dir=./app2_data/ \
-      --policy_store_file=policy_store --measurement_file="keystone_example_app.measurement"
+      --policy_store_file=policy_store --measurement_file="example_app.measurement" &
+
+sleep 5
+
 cd $KEYSTONE_EXAMPLE_DIR
+
 $KEYSTONE_EXAMPLE_DIR/keystone_example_app.exe --print_all=true --operation=run-app-as-client --data_dir=./app1_data/ \
-      --policy_store_file=policy_store --measurement_file="keystone_example_app.measurement"
+      --policy_store_file=policy_store --measurement_file="example_app.measurement"
 

--- a/src/keystone/keystone_shim.cc
+++ b/src/keystone/keystone_shim.cc
@@ -1,12 +1,3 @@
-#include "keystone_api.h"
-#include "certifier_framework.h"
-#include "certifier_utilities.h"
-#include <string.h>
-
-using std::string;
-using namespace certifier::utilities;
-
-
 //  Copyright (c) 2021-22, VMware Inc, and the Regents of the University of California.
 //    All rights reserved.
 //
@@ -22,6 +13,13 @@ using namespace certifier::utilities;
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <string.h>
+#include "keystone_api.h"
+#include "certifier_framework.h"
+#include "certifier_utilities.h"
+
+using std::string;
+using namespace certifier::utilities;
 
 bool keystone_getSealingKey(byte* key) {
   for (int i = 0; i < 64; i++)
@@ -32,7 +30,10 @@ bool keystone_getSealingKey(byte* key) {
 bool g_m_initialized = false;
 const int g_m_size = 32;
 byte g_measurement[g_m_size];
-string g_measurement_file_name("./provisioning/keystone_example_app.measurement");
+
+// Keep name consistent with what is being used by other apps.
+// This simplifies the logic in driver run_example.sh script.
+string g_measurement_file_name("./provisioning/example_app.measurement");
 
 bool keystone_get_fake_measurement(int* size, byte* measurement) {
 

--- a/src/keystone/keystone_test.cc
+++ b/src/keystone/keystone_test.cc
@@ -93,6 +93,7 @@ bool keystone_test(const int cert_size, byte *cert) {
     return true;
 }
 
+// Return 0 if test succeeds; 1 otherwise to indicate failure.
 int main(int argc, char** argv) {
-    return keystone_test(0, NULL);
+    return (keystone_test(0, NULL) == false);
 }

--- a/src/keystone/shim_test.mak
+++ b/src/keystone/shim_test.mak
@@ -57,8 +57,14 @@ all:	$(CL)/keystone_test.exe
 clean:
 	@echo "removing object files"
 	rm -rf $(O)/*.o
+	@echo "removing generated emulated_keystone files"
+	rm -rf ./emulated_keystone_*
 	@echo "removing executable files"
 	rm -rf $(CL)/keystone_test.exe
+
+$(SRC_DIR)/certifier.pb.cc $(I)/certifier.pb.h: $(SRC_DIR)/certifier.proto
+	$(PROTO) --proto_path=$(SRC_DIR) --cpp_out=$(S) $(SRC_DIR)/certifier.proto
+	mv $(S)/certifier.pb.h $(I)
 
 $(CL)/keystone_test.exe: $(dobj)
 	@echo "linking certifier library"
@@ -74,7 +80,7 @@ $(O)/keystone_shim.o: $(S)/keystone_shim.cc $(I)/certifier.pb.h $(I)/certifier.h
 
 $(O)/certifier.pb.o: $(SRC_DIR)/certifier.pb.cc $(I)/certifier.pb.h
 	@echo "compiling certifier.pb.cc"
-	$(CC) $(CFLAGS) -Wno-array-bounds -c -o $(O)/certifier.pb.o $(SRC_DIR)/certifier.pb.cc
+	$(CC) $(CFLAGS) -Wno-array-bounds -c -o $(O)/certifier.pb.o $(S)/certifier.pb.cc
 
 $(O)/certifier.o: $(SRC_DIR)/certifier.cc $(I)/certifier.pb.h $(I)/certifier.h
 	@echo "compiling certifier.cc"


### PR DESCRIPTION
This commit enhances run_example.sh to 'setup' and 'run_test' the `simple_app_under_keystone`, which has been developed using Keystone shim APIs. Much of the workflow remains unchanged, except the
following salient changes were necessary to get things to work:

- keystone_shim.cc: Rename hard-coded 'keystone_example_app.measurement'
  to 'example_app.measurement' . This makes it easy to integrate
  workflow with driver shell script as all other sample programs
  are using the new name.

- Add setup_emulated_keystone_shim_bins(), to generated the
  emulated_keystone_key.bin & emulated_keystone_key_cert.bin
  files as a pre-setup work for this app.

- Adjust the script to deal with keystone_example_app.exe program
  name.

- Use emulated_keystone_key_cert.bin to construct policy.

- Rearrange sequencing of a few steps in setup_simple_app_under_keystone()
  to deal with hard-coded references to:
    keyFile := "emulated_keystone_key.bin" in certlib/certlib_proofs.go

  We need to provision service/ dir before building simpleserver as
  the build of latter needs emulated keystone*.bin files, compiled-in.

  This is a short-term thing due to the use of shim support.

Miscellaneous changes:

- Fixes in keystone/shim_test.mak to get 'make' running cleanly.
- Rework temporary_instructions.txt into a stand-alone runnable bash script
- Add test-simple_app_under_keystone-using-shim to build.yml (CI runs)