### PR TITLE
(#111) Fix checks to report error messages when input args are invalid.

### DIFF
--- a/src/cc_helpers.cc
+++ b/src/cc_helpers.cc
@@ -242,7 +242,14 @@ bool certifier::framework::cc_trust_data::initialize_keystone_enclave_data(const
       printf("initialize_keystone_enclave_data: Not a simulated enclave\n");
       return false;
     }
-    // Todo
+    int m_size = file_size(measurement_file_name);
+    if (m_size < 0) {
+        printf("%s(): Invalid size=%d of measurement file '%s'.\n",
+               __func__, m_size, measurement_file_name.c_str());
+        return false;
+    }
+
+    // TODO
     byte der_cert[100];
     if (!keystone_Init(0, der_cert)) {
       printf("initialize_keystone_enclave_data: keystone_init failed\n");

--- a/utilities/embed_policy_key.cc
+++ b/utilities/embed_policy_key.cc
@@ -85,7 +85,11 @@ bool read_file(string file_name, int* size, byte* data) {
 bool generate_policy_cert_in_code(string& asn1_cert_file, string& include_file) {
   int cert_size = file_size(asn1_cert_file);
   if (cert_size <= 0)
+  {
+    printf("Invalid size=%d for input file '%s'.\n",
+           cert_size, asn1_cert_file.c_str());
     return false;
+  }
   byte bin_cert[cert_size];
  
   int t_size = cert_size;

--- a/utilities/print_packaged_claims.cc
+++ b/utilities/print_packaged_claims.cc
@@ -31,6 +31,8 @@ int main(int an, char** av) {
   int in_read = in_size;
 
   if (in_size <= 0) {
+    printf("Invalid size=%d for input file '%s'.\n",
+            in_size,  FLAGS_input.c_str());
     return 1;
   }
 
@@ -38,7 +40,7 @@ int main(int an, char** av) {
   string all_bufs;
 
   if (!read_file(FLAGS_input, &in_read, buf)) {
-    printf("Can't read %s\n", FLAGS_input.c_str());
+    printf("Can't read input file '%s'.\n", FLAGS_input.c_str());
     return 1;
   }
 

--- a/utilities/print_signed_claim.cc
+++ b/utilities/print_signed_claim.cc
@@ -30,7 +30,7 @@ bool get_signed_from_file(const string& in, signed_claim_message* sc) {
   byte serialized_cm[in_size];
 
   if (!read_file(in, &in_read, serialized_cm)) {
-    printf("Can't read %s\n", in.c_str());
+    printf("Can't read input file '%s'.\n", in.c_str());
     return false;
   }
   string cm_str;
@@ -48,7 +48,7 @@ int main(int an, char** av) {
 
   signed_claim_message sc;
   if (!get_signed_from_file(FLAGS_input, &sc)) {
-    printf("Can't get signed claim fro, file\n");
+    printf("Can't get signed claim from file '%s'.\n", FLAGS_input.c_str());
     return 1;
   }
 


### PR DESCRIPTION
This commit tightens some error checking of invalid arguments to few utility programs that were silently failing without reporting error messages.

No new error checks are added; only error messages are being printed when needed.