### PR TITLE
(#117) Remove private 'v2' refs from Go-module root-dir path

### DIFF
--- a/certifier_service/certlib/cert1_test.go
+++ b/certifier_service/certlib/cert1_test.go
@@ -35,7 +35,7 @@ import (
         "testing"
 
         "github.com/golang/protobuf/proto"
-        certprotos "github.com/jlmucb/crypto/v2/certifier-framework-for-confidential-computing/certifier_service/certprotos"
+        certprotos "github.com/vmware-research/certifier-framework-for-confidential-computing/certifier_service/certprotos"
 )
 
 func TestEntity(t *testing.T) {

--- a/certifier_service/certlib/certlib_proofs.go
+++ b/certifier_service/certlib/certlib_proofs.go
@@ -27,10 +27,10 @@ import (
 	"crypto/rand"
 	"os"
 	"google.golang.org/protobuf/proto"
-	certprotos "github.com/jlmucb/crypto/v2/certifier-framework-for-confidential-computing/certifier_service/certprotos"
-	oeverify "github.com/jlmucb/crypto/v2/certifier-framework-for-confidential-computing/certifier_service/oeverify"
-	gramineverify "github.com/jlmucb/crypto/v2/certifier-framework-for-confidential-computing/certifier_service/gramineverify"
-	ccaverify "github.com/jlmucb/crypto/v2/certifier-framework-for-confidential-computing/certifier_service/ccaverify"
+	certprotos    "github.com/vmware-research/certifier-framework-for-confidential-computing/certifier_service/certprotos"
+	oeverify      "github.com/vmware-research/certifier-framework-for-confidential-computing/certifier_service/oeverify"
+	gramineverify "github.com/vmware-research/certifier-framework-for-confidential-computing/certifier_service/gramineverify"
+	ccaverify     "github.com/vmware-research/certifier-framework-for-confidential-computing/certifier_service/ccaverify"
 )
 
 func testSign(PK1 *ecdsa.PublicKey) {

--- a/certifier_service/certlib/certlib_support.go
+++ b/certifier_service/certlib/certlib_support.go
@@ -36,8 +36,8 @@ import (
 	"strings"
 	"time"
 	"google.golang.org/protobuf/proto"
-	certprotos "github.com/jlmucb/crypto/v2/certifier-framework-for-confidential-computing/certifier_service/certprotos"
-	// oeverify "github.com/jlmucb/crypto/v2/certifier-framework-for-confidential-computing/certifier_service/oeverify"
+	certprotos "github.com/vmware-research/certifier-framework-for-confidential-computing/certifier_service/certprotos"
+	// oeverify   "github.com/vmware-research/certifier-framework-for-confidential-computing/certifier_service/oeverify"
 )
 
 //  --------------------------------------------------------------------

--- a/certifier_service/go.mod
+++ b/certifier_service/go.mod
@@ -1,4 +1,4 @@
-module github.com/jlmucb/crypto/v2/certifier-framework-for-confidential-computing/certifier_service
+module github.com/vmware-research/certifier-framework-for-confidential-computing/certifier_service
 
 go 1.18
 

--- a/certifier_service/simpleserver.go
+++ b/certifier_service/simpleserver.go
@@ -18,7 +18,7 @@ package main
 
 import (
         "crypto/x509"
-	"encoding/hex"
+        "encoding/hex"
         "flag"
         "fmt"
         "io/ioutil"
@@ -29,11 +29,10 @@ import (
         "time"
 
         "github.com/golang/protobuf/proto"
-        certprotos "github.com/jlmucb/crypto/v2/certifier-framework-for-confidential-computing/certifier_service/certprotos"
-        certlib "github.com/jlmucb/crypto/v2/certifier-framework-for-confidential-computing/certifier_service/certlib"
-
-        // NOTE: Enable this line when you enable the test-code in main().
-        //gramineverify "github.com/jlmucb/crypto/v2/certifier-framework-for-confidential-computing/certifier_service/gramineverify"
+        certprotos    "github.com/vmware-research/certifier-framework-for-confidential-computing/certifier_service/certprotos"
+        certlib       "github.com/vmware-research/certifier-framework-for-confidential-computing/certifier_service/certlib"
+     // NOTE: Enable this line when you enable the test-code in main().
+     // gramineverify "github.com/vmware-research/certifier-framework-for-confidential-computing/certifier_service/gramineverify"
 )
 
 var serverHost = flag.String("host", "localhost", "address for client/server")

--- a/certifier_service/test_sized_client.go
+++ b/certifier_service/test_sized_client.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
         "net"
 
-	certlib "github.com/jlmucb/crypto/v2/certifier-framework-for-confidential-computing/certifier_service/certlib"
+	certlib "github.com/vmware-research/certifier-framework-for-confidential-computing/certifier_service/certlib"
 )
 
 func client (conn net.Conn) bool {

--- a/certifier_service/test_sized_server.go
+++ b/certifier_service/test_sized_server.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
         "net"
 
-	certlib "github.com/jlmucb/crypto/v2/certifier-framework-for-confidential-computing/certifier_service/certlib"
+	certlib "github.com/vmware-research/certifier-framework-for-confidential-computing/certifier_service/certlib"
 )
 
 func service(conn net.Conn) {

--- a/deprecated/simpleclient.go.old
+++ b/deprecated/simpleclient.go.old
@@ -27,8 +27,8 @@ import (
 	"os"
 
 	"github.com/golang/protobuf/proto"
-	certprotos "github.com/jlmucb/crypto/v2/certifier/certifier_service/certprotos"
-	certlib "github.com/jlmucb/crypto/v2/certifier/certifier_service/certlib"
+	certprotos "github.com/vmware-research/certifier-framework-for-confidential-computing/certifier_service/certprotos"
+	certlib    "github.com/vmware-research/certifier-framework-for-confidential-computing/certifier_service/certlib"
 )
 
 var serverHost = flag.String("host", "localhost", "address for client/server")


### PR DESCRIPTION
This commit mildly reworks Go-package module dir-path names to remove name sub-strings that were added to track dev-history.  `go.mod` name is now the following, to be consistent with naming convention to allow `go get` to work with Git to download the module:

    "github.com/vmware-research/certifier-framework-for-confidential-computing/certifier_service"

is being used for go.mod .

All CI-tests seem to run clean with this name change, so it's expected that the Certifier Service build-processes should work correctly on all other platforms, such as Gramine, OE or SEV-enabled hardware.