### PR TITLE
(#120) Apply default 'gofmt' formatting for all .go files in repo.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,11 @@ jobs:
         sudo apt update -y
         sudo apt install -y libgtest-dev libgflags-dev openssl libssl-dev protobuf-compiler protoc-gen-go golang-go cmake
 
+
+    - name: test-code-formatting
+      run: |
+        ./CI/scripts/check-gofmt.sh
+
     - name: test-core-certifier-programs
       run: |
         echo "******************************************************************"

--- a/CI/scripts/check-gofmt.sh
+++ b/CI/scripts/check-gofmt.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# #############################################################################
+# Check 'gofmt' on all Go-files in the source code. If anything fails, exit
+# with a non-zero $rc, and print an informational error message.
+# #############################################################################
+
+pushd "$(dirname "$0")" > /dev/null 2>&1 || exit
+
+cd ../../
+
+CERTIFIER_ROOT="$(pwd)"
+
+popd > /dev/null 2>&1 || exit
+
+files=$(gofmt -l "${CERTIFIER_ROOT}")
+[ -z "$files" ]
+rc=$?
+if [ $rc -ne 0 ]; then
+    echo "Run 'gofmt -w' on these files to update them in-place with default gofmt formatting:"
+    for file in $files; do echo "  ${file}"; done
+fi
+
+exit $rc

--- a/certifier_service/certlib/cert1_test.go
+++ b/certifier_service/certlib/cert1_test.go
@@ -15,1252 +15,1247 @@
 package certlib
 
 import (
-        "bytes"
-        "crypto"
-        "crypto/elliptic"
-        "crypto/ecdsa"
-        "crypto/sha256"
-        "crypto/sha512"
-        "crypto/rand"
-        "crypto/rsa"
-        "crypto/x509"
-        "crypto/x509/pkix"
-        "fmt"
-        "io"
-        "math/big"
-        //"net"
-        "os"
-        //"syscall"
-        "time"
-        "testing"
+	"bytes"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/sha512"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"fmt"
+	"io"
+	"math/big"
+	//"net"
+	"os"
+	//"syscall"
+	"testing"
+	"time"
 
-        "github.com/golang/protobuf/proto"
-        certprotos "github.com/vmware-research/certifier-framework-for-confidential-computing/certifier_service/certprotos"
+	"github.com/golang/protobuf/proto"
+	certprotos "github.com/vmware-research/certifier-framework-for-confidential-computing/certifier_service/certprotos"
 )
 
 func TestEntity(t *testing.T) {
-        fmt.Print("\nTestEntity\n")
-        m:= make([]byte, 32)
-        for i := 0; i < 32; i++ {
-                m[i] = byte(i)
-        }
-        a := MakeMeasurementEntity(m)
-        if a == nil {
-                fmt.Print("cant allocate\n")
-                t.Errorf("MakeMeasurementEntity fails")
-        }
+	fmt.Print("\nTestEntity\n")
+	m := make([]byte, 32)
+	for i := 0; i < 32; i++ {
+		m[i] = byte(i)
+	}
+	a := MakeMeasurementEntity(m)
+	if a == nil {
+		fmt.Print("cant allocate\n")
+		t.Errorf("MakeMeasurementEntity fails")
+	}
 
-        PrintEntityDescriptor(a)
-        if bytes.Equal(m, a.GetMeasurement()) {
-                fmt.Printf("Measurements the same\n")
-        } else {
-                fmt.Printf("Measurements different\n")
-        }
+	PrintEntityDescriptor(a)
+	if bytes.Equal(m, a.GetMeasurement()) {
+		fmt.Printf("Measurements the same\n")
+	} else {
+		fmt.Printf("Measurements different\n")
+	}
 
-        fmt.Printf("\nTime now   : ")
-        tn := TimePointNow()
-        PrintTimePoint(tn)
-        fmt.Printf("\n")
-        fmt.Printf("Time future: ")
-        tf := TimePointPlus(tn, 365 * 86400)
-        PrintTimePoint(tf)
-        fmt.Printf("\n")
-        if CompareTimePoints(tn, tf) != (-1) {
-                t.Errorf("Comparetime fails")
-        }
-        st := TimePointToString(tf)
-        tf2:= StringToTimePoint(st)
-        fmt.Printf("%s, ", st)
-        PrintTimePoint(tf2)
-        fmt.Printf("\n")
-        if CompareTimePoints(tf2, tf) != 0 {
-                t.Errorf("string conversions fail")
-        }
+	fmt.Printf("\nTime now   : ")
+	tn := TimePointNow()
+	PrintTimePoint(tn)
+	fmt.Printf("\n")
+	fmt.Printf("Time future: ")
+	tf := TimePointPlus(tn, 365*86400)
+	PrintTimePoint(tf)
+	fmt.Printf("\n")
+	if CompareTimePoints(tn, tf) != (-1) {
+		t.Errorf("Comparetime fails")
+	}
+	st := TimePointToString(tf)
+	tf2 := StringToTimePoint(st)
+	fmt.Printf("%s, ", st)
+	PrintTimePoint(tf2)
+	fmt.Printf("\n")
+	if CompareTimePoints(tf2, tf) != 0 {
+		t.Errorf("string conversions fail")
+	}
 }
 
 func TestDominance(t *testing.T) {
-        fmt.Print("\nTestDominance\n")
+	fmt.Print("\nTestDominance\n")
 
-        printAll := true
+	printAll := true
 
-        root := PredicateDominance {
-                Predicate:  "is-trusted",
-                FirstChild: nil,
-                Next: nil,
-        }
-        if !InitDominance(&root) {
-                t.Error("Failed InitDominance")
-        }
-        if printAll {
-                fmt.Printf("\nDominance tree\n")
-                PrintDominanceTree(0, &root)
-        }
+	root := PredicateDominance{
+		Predicate:  "is-trusted",
+		FirstChild: nil,
+		Next:       nil,
+	}
+	if !InitDominance(&root) {
+		t.Error("Failed InitDominance")
+	}
+	if printAll {
+		fmt.Printf("\nDominance tree\n")
+		PrintDominanceTree(0, &root)
+	}
 
-        if !Dominates(&root, "is-trusted", "is-trusted") {
-                t.Error("is-trusted fails")
-        }
-        if !Dominates(&root, "is-trusted", "is-trusted-for-attestation") {
-                t.Error("is-trusted-for-attestation fails")
-        }
-        if !Dominates(&root, "is-trusted", "is-trusted-for-authentication") {
-                t.Error("is-trusted-for-attestation fails")
-        }
-        if Dominates(&root, "is-trusted", "is-trusted-for-crap") {
-                t.Error("is-trusted-for-crap fails")
-        }
+	if !Dominates(&root, "is-trusted", "is-trusted") {
+		t.Error("is-trusted fails")
+	}
+	if !Dominates(&root, "is-trusted", "is-trusted-for-attestation") {
+		t.Error("is-trusted-for-attestation fails")
+	}
+	if !Dominates(&root, "is-trusted", "is-trusted-for-authentication") {
+		t.Error("is-trusted-for-attestation fails")
+	}
+	if Dominates(&root, "is-trusted", "is-trusted-for-crap") {
+		t.Error("is-trusted-for-crap fails")
+	}
 }
 
 func TestKeys(t *testing.T) {
-        fmt.Print("\nTestKeys\n")
+	fmt.Print("\nTestKeys\n")
 
-        keyFile := "policy_key_file.bin"
-        certFile := "policy_cert_file.bin"
-        fmt.Printf("Key file: %s, Cert file: %s\n", keyFile, certFile)
-        serializedKey, err := os.ReadFile(keyFile)
-        if err != nil {
-                fmt.Println("can't read key file, ", err)
-        }
-        cert, err := os.ReadFile(certFile)
-        if err != nil {
-                fmt.Println("can't certkey file, ", err)
-        }
-        fmt.Printf("Key file length is %d\n", len(serializedKey))
-        fmt.Printf("Cert file length is %d\n", len(cert))
-        key := certprotos.KeyMessage {}
-        err = proto.Unmarshal(serializedKey, &key)
-        if err != nil {
-                fmt.Println("can't Unmarshal key file")
-        }
-        fmt.Printf("Policy key name: %s\n", key.GetKeyName())
-        fmt.Printf("Policy key type: %s\n", key.GetKeyType())
-        PK := rsa.PublicKey{}
-        pK := rsa.PrivateKey{}
-        if !GetRsaKeysFromInternal(&key, &pK, &PK) {
-                fmt.Printf("Can't recover keys\n")
-        }
+	keyFile := "policy_key_file.bin"
+	certFile := "policy_cert_file.bin"
+	fmt.Printf("Key file: %s, Cert file: %s\n", keyFile, certFile)
+	serializedKey, err := os.ReadFile(keyFile)
+	if err != nil {
+		fmt.Println("can't read key file, ", err)
+	}
+	cert, err := os.ReadFile(certFile)
+	if err != nil {
+		fmt.Println("can't certkey file, ", err)
+	}
+	fmt.Printf("Key file length is %d\n", len(serializedKey))
+	fmt.Printf("Cert file length is %d\n", len(cert))
+	key := certprotos.KeyMessage{}
+	err = proto.Unmarshal(serializedKey, &key)
+	if err != nil {
+		fmt.Println("can't Unmarshal key file")
+	}
+	fmt.Printf("Policy key name: %s\n", key.GetKeyName())
+	fmt.Printf("Policy key type: %s\n", key.GetKeyType())
+	PK := rsa.PublicKey{}
+	pK := rsa.PrivateKey{}
+	if !GetRsaKeysFromInternal(&key, &pK, &PK) {
+		fmt.Printf("Can't recover keys\n")
+	}
 
-        // test rsa sign and verify
-        rng := rand.Reader
-        message := []byte("message to be signed")
-        hashed := sha256.Sum256(message)
-        fmt.Printf("Hash: ")
-        PrintBytes(hashed[0:32])
-        fmt.Printf("\n")
-        signature, err := rsa.SignPKCS1v15(rng, &pK, crypto.SHA256, hashed[0:32])
-        if err == nil {
-                fmt.Printf("Signature: ")
-                PrintBytes(signature)
-                fmt.Printf("\n")
-        }
+	// test rsa sign and verify
+	rng := rand.Reader
+	message := []byte("message to be signed")
+	hashed := sha256.Sum256(message)
+	fmt.Printf("Hash: ")
+	PrintBytes(hashed[0:32])
+	fmt.Printf("\n")
+	signature, err := rsa.SignPKCS1v15(rng, &pK, crypto.SHA256, hashed[0:32])
+	if err == nil {
+		fmt.Printf("Signature: ")
+		PrintBytes(signature)
+		fmt.Printf("\n")
+	}
 
-        // verify cert
-        certPool := x509.NewCertPool()
-        x509cert, err := x509.ParseCertificate(cert)
-        if err != nil {
-                fmt.Println("Can't parse cert")
-        }
-        certPool.AddCert(x509cert)
-        opts := x509.VerifyOptions{
-                Roots:   certPool,
-        }
+	// verify cert
+	certPool := x509.NewCertPool()
+	x509cert, err := x509.ParseCertificate(cert)
+	if err != nil {
+		fmt.Println("Can't parse cert")
+	}
+	certPool.AddCert(x509cert)
+	opts := x509.VerifyOptions{
+		Roots: certPool,
+	}
 
-        if _, err := x509cert.Verify(opts); err != nil {
-                t.Error("failed to verify certificate")
-        }
-        fmt.Printf("Certificate verifies\n")
+	if _, err := x509cert.Verify(opts); err != nil {
+		t.Error("failed to verify certificate")
+	}
+	fmt.Printf("Certificate verifies\n")
 
-        k := MakeVseRsaKey(2048)
-        var tk  string = "testkey"
-        k.KeyName = &tk
-        PrintKey(k)
+	k := MakeVseRsaKey(2048)
+	var tk string = "testkey"
+	k.KeyName = &tk
+	PrintKey(k)
 }
 
-
 func TestClaims(t *testing.T) {
-        fmt.Print("\nTestClaims\n")
+	fmt.Print("\nTestClaims\n")
 
-        policyKey := MakeVseRsaKey(2048)
-        var tk  string = "policyKey"
-        policyKey.KeyName = &tk
-        PrintKey(policyKey)
+	policyKey := MakeVseRsaKey(2048)
+	var tk string = "policyKey"
+	policyKey.KeyName = &tk
+	PrintKey(policyKey)
 
-        subj := MakeKeyEntity(policyKey)
-        PrintEntity(subj)
-        fmt.Printf("\n")
-        m:= make([]byte, 32)
-        for i := 0; i < 32; i++ {
-                m[i] = byte(i)
-        }
-        obj:= MakeMeasurementEntity(m)
-        PrintEntity(obj)
-        fmt.Printf("\n")
-        verbIs := "is-trusted"
-        verbSays := "says"
-        verbSpeaksFor:= "speaks-for"
-        vcl1 := MakeUnaryVseClause(subj, &verbIs)
-        PrintVseClause(vcl1)
-        fmt.Printf("\n")
-        vcl2 := MakeIndirectVseClause(subj, &verbSays, vcl1)
-        PrintVseClause(vcl2)
-        fmt.Printf("\n")
-        vcl3 := MakeSimpleVseClause(subj, &verbSpeaksFor, obj)
-        PrintVseClause(vcl3)
-        fmt.Printf("\n")
+	subj := MakeKeyEntity(policyKey)
+	PrintEntity(subj)
+	fmt.Printf("\n")
+	m := make([]byte, 32)
+	for i := 0; i < 32; i++ {
+		m[i] = byte(i)
+	}
+	obj := MakeMeasurementEntity(m)
+	PrintEntity(obj)
+	fmt.Printf("\n")
+	verbIs := "is-trusted"
+	verbSays := "says"
+	verbSpeaksFor := "speaks-for"
+	vcl1 := MakeUnaryVseClause(subj, &verbIs)
+	PrintVseClause(vcl1)
+	fmt.Printf("\n")
+	vcl2 := MakeIndirectVseClause(subj, &verbSays, vcl1)
+	PrintVseClause(vcl2)
+	fmt.Printf("\n")
+	vcl3 := MakeSimpleVseClause(subj, &verbSpeaksFor, obj)
+	PrintVseClause(vcl3)
+	fmt.Printf("\n")
 
-        if !SameEntity(subj, subj) {
-                t.Errorf("sameEntity fails (1)\n")
-        }
-        if SameEntity(subj, obj) {
-                t.Errorf("sameEntity fails (2)\n")
-        }
-        if !SameKey(policyKey, policyKey) {
-                t.Errorf("sameKey fails (1)\n")
-        }
-        if !SameVseClause(vcl1, vcl1) {
-                t.Errorf("sameClause fails (1)\n")
-        }
-        if SameVseClause(vcl1, vcl2) {
-                t.Errorf("sameClause fails (2)\n")
-        }
+	if !SameEntity(subj, subj) {
+		t.Errorf("sameEntity fails (1)\n")
+	}
+	if SameEntity(subj, obj) {
+		t.Errorf("sameEntity fails (2)\n")
+	}
+	if !SameKey(policyKey, policyKey) {
+		t.Errorf("sameKey fails (1)\n")
+	}
+	if !SameVseClause(vcl1, vcl1) {
+		t.Errorf("sameClause fails (1)\n")
+	}
+	if SameVseClause(vcl1, vcl2) {
+		t.Errorf("sameClause fails (2)\n")
+	}
 
-        serClaim, err := proto.Marshal(vcl3)
-        if err != nil {
-                t.Errorf("Marshal fails\n")
-        }
+	serClaim, err := proto.Marshal(vcl3)
+	if err != nil {
+		t.Errorf("Marshal fails\n")
+	}
 
-        tn := TimePointNow()
-        tf := TimePointPlus(tn, 365 * 86400)
-        nb := TimePointToString(tn)
-        na := TimePointToString(tf)
-        cl1 := MakeClaim(serClaim, "vse-clause", "first says", nb, na)
-        PrintClaim(cl1)
-        sc1 := MakeSignedClaim(cl1, policyKey)
-        fmt.Printf("\nSigned claim\n")
-        PrintSignedClaim(sc1)
-        if !VerifySignedClaim(sc1, policyKey) {
-                t.Errorf("Verify signed claim fails\n")
-        }
+	tn := TimePointNow()
+	tf := TimePointPlus(tn, 365*86400)
+	nb := TimePointToString(tn)
+	na := TimePointToString(tf)
+	cl1 := MakeClaim(serClaim, "vse-clause", "first says", nb, na)
+	PrintClaim(cl1)
+	sc1 := MakeSignedClaim(cl1, policyKey)
+	fmt.Printf("\nSigned claim\n")
+	PrintSignedClaim(sc1)
+	if !VerifySignedClaim(sc1, policyKey) {
+		t.Errorf("Verify signed claim fails\n")
+	}
 
-/*
-        fmt.Printf("\nAttest\n")
-        vat := VseAttestation("testAttestation", "simulated-enclave", "", vcl3)
-        if  vat == nil {
-                t.Errorf("attestation fails")
-        }
-        uvat :=  certprotos.Attestation{}
-        err = proto.Unmarshal(vat, &uvat)
-        if err != nil {
-                t.Errorf("attestation unmarshal fails")
-        }
-        PrintAttestation(&uvat)
-*/
+	/*
+	   fmt.Printf("\nAttest\n")
+	   vat := VseAttestation("testAttestation", "simulated-enclave", "", vcl3)
+	   if  vat == nil {
+	           t.Errorf("attestation fails")
+	   }
+	   uvat :=  certprotos.Attestation{}
+	   err = proto.Unmarshal(vat, &uvat)
+	   if err != nil {
+	           t.Errorf("attestation unmarshal fails")
+	   }
+	   PrintAttestation(&uvat)
+	*/
 }
 
 func TestCrypt(t *testing.T) {
-        fmt.Println("\nTestCert")
+	fmt.Println("\nTestCert")
 
-        k := make([]byte, 32)
-        iv := make([]byte, 16)
-        for i := 0; i < 32; i++ {
-                k[i] = byte(i)
-        }
-        for i := 0; i < 16; i++ {
-                iv[i] = byte(i+8)
-        }
-        plainText := make([]byte, 62)
-        for i := 0; i < 62; i++ {
-                plainText[i] = byte(i+2)
-        }
-        cipherText := Encrypt(plainText, k, iv)
-        recoveredText := Decrypt(cipherText, k)
-        fmt.Printf("Plaintext size : %d\n", len(plainText))
-        fmt.Printf("Cipher size out: %d\n", len(cipherText))
-        fmt.Printf("Recovered size out: %d\n", len(recoveredText))
-        fmt.Print("Key           : ")
-        PrintBytes(k)
-        fmt.Println("")
-        fmt.Print("iv            : ")
-        PrintBytes(iv)
-        fmt.Println("")
-        fmt.Print("Plain text    : ")
-        PrintBytes(plainText)
-        fmt.Println("")
-        fmt.Print("Cipher text   : ")
-        PrintBytes(cipherText)
-        fmt.Println("")
-        fmt.Print("Recovered text: ")
-        PrintBytes(recoveredText)
-        fmt.Println("")
-        if !bytes.Equal(plainText, recoveredText) {
-                t.Errorf("encrypt/decrypt fails")
-        }
+	k := make([]byte, 32)
+	iv := make([]byte, 16)
+	for i := 0; i < 32; i++ {
+		k[i] = byte(i)
+	}
+	for i := 0; i < 16; i++ {
+		iv[i] = byte(i + 8)
+	}
+	plainText := make([]byte, 62)
+	for i := 0; i < 62; i++ {
+		plainText[i] = byte(i + 2)
+	}
+	cipherText := Encrypt(plainText, k, iv)
+	recoveredText := Decrypt(cipherText, k)
+	fmt.Printf("Plaintext size : %d\n", len(plainText))
+	fmt.Printf("Cipher size out: %d\n", len(cipherText))
+	fmt.Printf("Recovered size out: %d\n", len(recoveredText))
+	fmt.Print("Key           : ")
+	PrintBytes(k)
+	fmt.Println("")
+	fmt.Print("iv            : ")
+	PrintBytes(iv)
+	fmt.Println("")
+	fmt.Print("Plain text    : ")
+	PrintBytes(plainText)
+	fmt.Println("")
+	fmt.Print("Cipher text   : ")
+	PrintBytes(cipherText)
+	fmt.Println("")
+	fmt.Print("Recovered text: ")
+	PrintBytes(recoveredText)
+	fmt.Println("")
+	if !bytes.Equal(plainText, recoveredText) {
+		t.Errorf("encrypt/decrypt fails")
+	}
 
-        fmt.Println()
+	fmt.Println()
 
-        authenticatedPlainText := plainText
-        authenticatedCipherText := AuthenticatedEncrypt(authenticatedPlainText, k, iv)
-        authenticatedRecoveredText := AuthenticatedDecrypt(authenticatedCipherText, k)
-        fmt.Printf("Authenticated Plaintext size : %d\n", len(authenticatedPlainText))
-        fmt.Printf("Authenticated Cipher size out: %d\n", len(authenticatedCipherText))
-        fmt.Printf("Authenticated Recovered size out: %d\n", len(authenticatedRecoveredText))
-        fmt.Print("Key           : ")
-        PrintBytes(k)
-        fmt.Println("")
-        fmt.Print("iv            : ")
-        PrintBytes(iv)
-        fmt.Println("")
-        fmt.Print("Authenticated Plain text    : ")
-        PrintBytes(authenticatedPlainText)
-        fmt.Println("")
-        fmt.Print("Authenticated Cipher text   : ")
-        PrintBytes(authenticatedCipherText)
-        fmt.Print("Authenticated Recovered text: ")
-        PrintBytes(authenticatedRecoveredText)
-        fmt.Println("")
-        if !bytes.Equal(authenticatedPlainText, authenticatedRecoveredText) {
-                t.Errorf("encrypt/decrypt fails")
-        }
+	authenticatedPlainText := plainText
+	authenticatedCipherText := AuthenticatedEncrypt(authenticatedPlainText, k, iv)
+	authenticatedRecoveredText := AuthenticatedDecrypt(authenticatedCipherText, k)
+	fmt.Printf("Authenticated Plaintext size : %d\n", len(authenticatedPlainText))
+	fmt.Printf("Authenticated Cipher size out: %d\n", len(authenticatedCipherText))
+	fmt.Printf("Authenticated Recovered size out: %d\n", len(authenticatedRecoveredText))
+	fmt.Print("Key           : ")
+	PrintBytes(k)
+	fmt.Println("")
+	fmt.Print("iv            : ")
+	PrintBytes(iv)
+	fmt.Println("")
+	fmt.Print("Authenticated Plain text    : ")
+	PrintBytes(authenticatedPlainText)
+	fmt.Println("")
+	fmt.Print("Authenticated Cipher text   : ")
+	PrintBytes(authenticatedCipherText)
+	fmt.Print("Authenticated Recovered text: ")
+	PrintBytes(authenticatedRecoveredText)
+	fmt.Println("")
+	if !bytes.Equal(authenticatedPlainText, authenticatedRecoveredText) {
+		t.Errorf("encrypt/decrypt fails")
+	}
 }
 
 func TestProofsAuth(t *testing.T) {
-        fmt.Print("\nTestProofsAuth\n")
+	fmt.Print("\nTestProofsAuth\n")
 
-        if !InitSimulatedEnclave() {
-                t.Errorf("Cannot init simulated enclave")
-        }
+	if !InitSimulatedEnclave() {
+		t.Errorf("Cannot init simulated enclave")
+	}
 
-        privatePolicyKey := MakeVseRsaKey(2048)
-        var tpk  string = "policyKey"
-        privatePolicyKey.KeyName = &tpk
-        PrintKey(privatePolicyKey)
-        policyKey := InternalPublicFromPrivateKey(privatePolicyKey)
-        policySubj := MakeKeyEntity(policyKey)
-        fmt.Println("\nPolicy key")
-        PrintEntity(policySubj)
+	privatePolicyKey := MakeVseRsaKey(2048)
+	var tpk string = "policyKey"
+	privatePolicyKey.KeyName = &tpk
+	PrintKey(privatePolicyKey)
+	policyKey := InternalPublicFromPrivateKey(privatePolicyKey)
+	policySubj := MakeKeyEntity(policyKey)
+	fmt.Println("\nPolicy key")
+	PrintEntity(policySubj)
 
-        privateIntelKey := MakeVseRsaKey(2048)
-        iek  := "intelKey"
-        privateIntelKey.KeyName = &iek
-        PrintKey(privateIntelKey)
-        fmt.Println("")
-        intelKey := InternalPublicFromPrivateKey(privateIntelKey)
-        intelSubj := MakeKeyEntity(intelKey)
-        fmt.Println("\nAttest key")
-        PrintEntity(intelSubj)
+	privateIntelKey := MakeVseRsaKey(2048)
+	iek := "intelKey"
+	privateIntelKey.KeyName = &iek
+	PrintKey(privateIntelKey)
+	fmt.Println("")
+	intelKey := InternalPublicFromPrivateKey(privateIntelKey)
+	intelSubj := MakeKeyEntity(intelKey)
+	fmt.Println("\nAttest key")
+	PrintEntity(intelSubj)
 
-        privateAttestKey := MakeVseRsaKey(2048)
-        aek  := "attestKey"
-        privateAttestKey.KeyName = &aek
-        PrintKey(privateAttestKey)
-        fmt.Println("")
-        attestKey := InternalPublicFromPrivateKey(privateAttestKey)
-        attestSubj := MakeKeyEntity(attestKey)
-        fmt.Println("\nAttest key")
-        PrintEntity(attestSubj)
+	privateAttestKey := MakeVseRsaKey(2048)
+	aek := "attestKey"
+	privateAttestKey.KeyName = &aek
+	PrintKey(privateAttestKey)
+	fmt.Println("")
+	attestKey := InternalPublicFromPrivateKey(privateAttestKey)
+	attestSubj := MakeKeyEntity(attestKey)
+	fmt.Println("\nAttest key")
+	PrintEntity(attestSubj)
 
-        privateEnclaveKey := MakeVseRsaKey(2048)
-        tek  := "enclaveKey"
-        privateEnclaveKey.KeyName = &tek
-        PrintKey(privateEnclaveKey)
-        fmt.Println("")
-        enclaveKey := InternalPublicFromPrivateKey(privateEnclaveKey)
-        enclaveSubj := MakeKeyEntity(enclaveKey)
-        fmt.Println("\nEnclave key")
-        PrintEntity(enclaveSubj)
+	privateEnclaveKey := MakeVseRsaKey(2048)
+	tek := "enclaveKey"
+	privateEnclaveKey.KeyName = &tek
+	PrintKey(privateEnclaveKey)
+	fmt.Println("")
+	enclaveKey := InternalPublicFromPrivateKey(privateEnclaveKey)
+	enclaveSubj := MakeKeyEntity(enclaveKey)
+	fmt.Println("\nEnclave key")
+	PrintEntity(enclaveSubj)
 
-        m:= make([]byte, 32)
-        for i := 0; i < 32; i++ {
-                m[i] = byte(i)
-        }
-        entObj:= MakeMeasurementEntity(m)
-        fmt.Println("\nEnclave measurement")
-        PrintEntity(entObj)
+	m := make([]byte, 32)
+	for i := 0; i < 32; i++ {
+		m[i] = byte(i)
+	}
+	entObj := MakeMeasurementEntity(m)
+	fmt.Println("\nEnclave measurement")
+	PrintEntity(entObj)
 
-        verbIs := "is-trusted"
-        verbSays := "says"
-        verbSpeaksFor:= "speaks-for"
-        verbIsTrustedForAuth := "is-trusted-for-authentication"
-        verbIsTrustedForAtt := "is-trusted-for-attestation"
+	verbIs := "is-trusted"
+	verbSays := "says"
+	verbSpeaksFor := "speaks-for"
+	verbIsTrustedForAuth := "is-trusted-for-authentication"
+	verbIsTrustedForAtt := "is-trusted-for-attestation"
 
-        intelKeyIsTrusted := MakeUnaryVseClause(intelSubj, &verbIsTrustedForAtt)
-        attestKeyIsTrusted := MakeUnaryVseClause(attestSubj, &verbIsTrustedForAtt)
-        measurementIsTrusted :=  MakeUnaryVseClause(entObj, &verbIs)
-        enclaveKeyIsTrusted := MakeUnaryVseClause(enclaveSubj, &verbIsTrustedForAuth)
+	intelKeyIsTrusted := MakeUnaryVseClause(intelSubj, &verbIsTrustedForAtt)
+	attestKeyIsTrusted := MakeUnaryVseClause(attestSubj, &verbIsTrustedForAtt)
+	measurementIsTrusted := MakeUnaryVseClause(entObj, &verbIs)
+	enclaveKeyIsTrusted := MakeUnaryVseClause(enclaveSubj, &verbIsTrustedForAuth)
 
-        policyKeySaysIntelKeyIsTrusted :=  MakeIndirectVseClause(policySubj, &verbSays, intelKeyIsTrusted)
-        intelKeySaysAttestKeyIsTrusted := MakeIndirectVseClause(intelSubj, &verbSays, attestKeyIsTrusted)
-        policyKeySaysMeasurementIsTrusted :=  MakeIndirectVseClause(policySubj, &verbSays, measurementIsTrusted)
+	policyKeySaysIntelKeyIsTrusted := MakeIndirectVseClause(policySubj, &verbSays, intelKeyIsTrusted)
+	intelKeySaysAttestKeyIsTrusted := MakeIndirectVseClause(intelSubj, &verbSays, attestKeyIsTrusted)
+	policyKeySaysMeasurementIsTrusted := MakeIndirectVseClause(policySubj, &verbSays, measurementIsTrusted)
 
-        enclaveKeySpeaksForMeasurement:=  MakeSimpleVseClause(enclaveSubj, &verbSpeaksFor, entObj)
-        attestKeySaysEnclaveKeySpeaksForMeasurement:=  MakeIndirectVseClause(attestSubj, &verbSays, enclaveKeySpeaksForMeasurement)
+	enclaveKeySpeaksForMeasurement := MakeSimpleVseClause(enclaveSubj, &verbSpeaksFor, entObj)
+	attestKeySaysEnclaveKeySpeaksForMeasurement := MakeIndirectVseClause(attestSubj, &verbSays, enclaveKeySpeaksForMeasurement)
 
-        // make signed assertions
-        tn := TimePointNow()
-        tf := TimePointPlus(tn, 365 * 86400)
-        nb := TimePointToString(tn)
-        na := TimePointToString(tf)
-        vfmt := "vse-clause"
-        d1 := "policyKey says intelKey is-trusted-for-attestation"
-        d2 := "policyKey says Measurement is-trusted"
-        d3 := "intelKey says attestKey is-trusted-for-attestation"
-        d4 := "attest Key says entityKey speaks-for entityMeasurement"
+	// make signed assertions
+	tn := TimePointNow()
+	tf := TimePointPlus(tn, 365*86400)
+	nb := TimePointToString(tn)
+	na := TimePointToString(tf)
+	vfmt := "vse-clause"
+	d1 := "policyKey says intelKey is-trusted-for-attestation"
+	d2 := "policyKey says Measurement is-trusted"
+	d3 := "intelKey says attestKey is-trusted-for-attestation"
+	d4 := "attest Key says entityKey speaks-for entityMeasurement"
 
-        serPolicyKeySaysIntelKeyIsTrusted, _:= proto.Marshal(policyKeySaysIntelKeyIsTrusted)
-        clPolicyKeySaysIntelKeyIsTrusted := MakeClaim(serPolicyKeySaysIntelKeyIsTrusted, vfmt, d1, nb, na)
-        signedPolicyKeySaysIntelKeyIsTrusted := MakeSignedClaim(clPolicyKeySaysIntelKeyIsTrusted, privatePolicyKey)
+	serPolicyKeySaysIntelKeyIsTrusted, _ := proto.Marshal(policyKeySaysIntelKeyIsTrusted)
+	clPolicyKeySaysIntelKeyIsTrusted := MakeClaim(serPolicyKeySaysIntelKeyIsTrusted, vfmt, d1, nb, na)
+	signedPolicyKeySaysIntelKeyIsTrusted := MakeSignedClaim(clPolicyKeySaysIntelKeyIsTrusted, privatePolicyKey)
 
-        serPolicyKeySaysMeasurementIsTrusted, _:= proto.Marshal(policyKeySaysMeasurementIsTrusted)
-        clPolicyKeySaysMeasurementIsTrusted := MakeClaim(serPolicyKeySaysMeasurementIsTrusted, vfmt, d2, nb, na)
-        signedPolicyKeySaysMeasurementIsTrusted := MakeSignedClaim(clPolicyKeySaysMeasurementIsTrusted, privatePolicyKey)
+	serPolicyKeySaysMeasurementIsTrusted, _ := proto.Marshal(policyKeySaysMeasurementIsTrusted)
+	clPolicyKeySaysMeasurementIsTrusted := MakeClaim(serPolicyKeySaysMeasurementIsTrusted, vfmt, d2, nb, na)
+	signedPolicyKeySaysMeasurementIsTrusted := MakeSignedClaim(clPolicyKeySaysMeasurementIsTrusted, privatePolicyKey)
 
-        serIntelKeySaysAttestKeyIsTrusted, _:= proto.Marshal(intelKeySaysAttestKeyIsTrusted)
-        clIntelKeySaysAttestKeyIsTrusted := MakeClaim(serIntelKeySaysAttestKeyIsTrusted, vfmt, d3, nb, na)
-        signedIntelKeySaysAttestKeyIsTrusted := MakeSignedClaim(clIntelKeySaysAttestKeyIsTrusted, privateIntelKey)
+	serIntelKeySaysAttestKeyIsTrusted, _ := proto.Marshal(intelKeySaysAttestKeyIsTrusted)
+	clIntelKeySaysAttestKeyIsTrusted := MakeClaim(serIntelKeySaysAttestKeyIsTrusted, vfmt, d3, nb, na)
+	signedIntelKeySaysAttestKeyIsTrusted := MakeSignedClaim(clIntelKeySaysAttestKeyIsTrusted, privateIntelKey)
 
-        serAttestKeySaysEnclaveKeySpeaksForMeasurement, _ := proto.Marshal(attestKeySaysEnclaveKeySpeaksForMeasurement)
-        clAttestKeySaysEnclaveKeySpeaksForMeasurement := MakeClaim(serAttestKeySaysEnclaveKeySpeaksForMeasurement, vfmt, d4, nb, na)
-        signedAttestKeySaysEnclaveKeySpeaksForMeasurement := MakeSignedClaim(clAttestKeySaysEnclaveKeySpeaksForMeasurement, privateAttestKey)
+	serAttestKeySaysEnclaveKeySpeaksForMeasurement, _ := proto.Marshal(attestKeySaysEnclaveKeySpeaksForMeasurement)
+	clAttestKeySaysEnclaveKeySpeaksForMeasurement := MakeClaim(serAttestKeySaysEnclaveKeySpeaksForMeasurement, vfmt, d4, nb, na)
+	signedAttestKeySaysEnclaveKeySpeaksForMeasurement := MakeSignedClaim(clAttestKeySaysEnclaveKeySpeaksForMeasurement, privateAttestKey)
 
-        var evidenceList []*certprotos.Evidence
-        ps := certprotos.ProvedStatements{}
-        scStr := "signed-claim"
+	var evidenceList []*certprotos.Evidence
+	ps := certprotos.ProvedStatements{}
+	scStr := "signed-claim"
 
-        e1 := certprotos.Evidence {}
-        e1.EvidenceType = &scStr
-        sc1, err := proto.Marshal(signedPolicyKeySaysIntelKeyIsTrusted)
-        if err != nil {
-                t.Errorf("Marshal fails\n")
-        }
-        e1.SerializedEvidence = sc1
-        evidenceList = append(evidenceList, &e1)
+	e1 := certprotos.Evidence{}
+	e1.EvidenceType = &scStr
+	sc1, err := proto.Marshal(signedPolicyKeySaysIntelKeyIsTrusted)
+	if err != nil {
+		t.Errorf("Marshal fails\n")
+	}
+	e1.SerializedEvidence = sc1
+	evidenceList = append(evidenceList, &e1)
 
-        e2 := certprotos.Evidence {}
-        e2.EvidenceType = &scStr
-        sc2, err := proto.Marshal(signedPolicyKeySaysMeasurementIsTrusted)
-        if err != nil {
-                t.Errorf("Marshal fails\n")
-        }
-        e2.SerializedEvidence = sc2
-        evidenceList = append(evidenceList, &e2)
+	e2 := certprotos.Evidence{}
+	e2.EvidenceType = &scStr
+	sc2, err := proto.Marshal(signedPolicyKeySaysMeasurementIsTrusted)
+	if err != nil {
+		t.Errorf("Marshal fails\n")
+	}
+	e2.SerializedEvidence = sc2
+	evidenceList = append(evidenceList, &e2)
 
-        e3 := certprotos.Evidence {}
-        e3.EvidenceType = &scStr
-        sc3, err := proto.Marshal(signedIntelKeySaysAttestKeyIsTrusted)
-        if err != nil {
-                t.Errorf("Marshal fails\n")
-        }
-        e3.SerializedEvidence = sc3
-        evidenceList = append(evidenceList, &e3)
+	e3 := certprotos.Evidence{}
+	e3.EvidenceType = &scStr
+	sc3, err := proto.Marshal(signedIntelKeySaysAttestKeyIsTrusted)
+	if err != nil {
+		t.Errorf("Marshal fails\n")
+	}
+	e3.SerializedEvidence = sc3
+	evidenceList = append(evidenceList, &e3)
 
-        e4 := certprotos.Evidence {}
-        e4.EvidenceType = &scStr
-        sc4, err := proto.Marshal(signedAttestKeySaysEnclaveKeySpeaksForMeasurement)
-        if err != nil {
-                t.Errorf("Marshal fails\n")
-        }
-        e4.SerializedEvidence = sc4
-        evidenceList = append(evidenceList, &e4)
+	e4 := certprotos.Evidence{}
+	e4.EvidenceType = &scStr
+	sc4, err := proto.Marshal(signedAttestKeySaysEnclaveKeySpeaksForMeasurement)
+	if err != nil {
+		t.Errorf("Marshal fails\n")
+	}
+	e4.SerializedEvidence = sc4
+	evidenceList = append(evidenceList, &e4)
 
-
-        fmt.Println("Public policy key")
-        PrintKey(policyKey)
-        fmt.Println("")
+	fmt.Println("Public policy key")
+	PrintKey(policyKey)
+	fmt.Println("")
 
 	// Next statement is here because we removed InitAxiom from InitProvedStatements
 	InitAxiom(*policyKey, &ps)
-        if !InitProvedStatements(*policyKey, evidenceList, &ps) {
-                t.Errorf("Cannot init proved statements")
-        }
-        fmt.Printf("Initial proved statements %d\n", len(ps.Proved))
-        for i := 0; i < len(ps.Proved); i++ {
-                PrintVseClause(ps.Proved[i])
-                fmt.Println("")
-        }
-        fmt.Println("")
+	if !InitProvedStatements(*policyKey, evidenceList, &ps) {
+		t.Errorf("Cannot init proved statements")
+	}
+	fmt.Printf("Initial proved statements %d\n", len(ps.Proved))
+	for i := 0; i < len(ps.Proved); i++ {
+		PrintVseClause(ps.Proved[i])
+		fmt.Println("")
+	}
+	fmt.Println("")
 
-        // The proof
-        p := certprotos.Proof{}
+	// The proof
+	p := certprotos.Proof{}
 
-        r1 := int32(1)
-        r3 := int32(3)
-        r5 := int32(5)
-        r6 := int32(6)
-        ps1 := certprotos.ProofStep {
-                S1: ps.Proved[0],
-                S2: policyKeySaysMeasurementIsTrusted,
-                Conclusion: measurementIsTrusted,
-                RuleApplied: &r3,
-        }
-        p.Steps = append(p.Steps, &ps1)
-        ps2 := certprotos.ProofStep {
-                S1: ps.Proved[0],
-                S2: policyKeySaysIntelKeyIsTrusted,
-                Conclusion: intelKeyIsTrusted,
-                RuleApplied: &r5,
-        }
-        p.Steps = append(p.Steps, &ps2)
-        ps3 := certprotos.ProofStep {
-                S1: intelKeyIsTrusted,
-                S2: intelKeySaysAttestKeyIsTrusted,
-                Conclusion: attestKeyIsTrusted,
-                RuleApplied: &r5,
-        }
-        p.Steps = append(p.Steps, &ps3)
-        ps4 := certprotos.ProofStep {
-                S1: attestKeyIsTrusted,
-                S2: attestKeySaysEnclaveKeySpeaksForMeasurement,
-                Conclusion: enclaveKeySpeaksForMeasurement,
-                RuleApplied: &r6,
-        }
-        p.Steps = append(p.Steps, &ps4)
-        ps5 := certprotos.ProofStep {
-                S1: measurementIsTrusted,
-                S2: enclaveKeySpeaksForMeasurement,
-                Conclusion: enclaveKeyIsTrusted,
-                RuleApplied: &r1,
-        }
-        p.Steps = append(p.Steps, &ps5)
+	r1 := int32(1)
+	r3 := int32(3)
+	r5 := int32(5)
+	r6 := int32(6)
+	ps1 := certprotos.ProofStep{
+		S1:          ps.Proved[0],
+		S2:          policyKeySaysMeasurementIsTrusted,
+		Conclusion:  measurementIsTrusted,
+		RuleApplied: &r3,
+	}
+	p.Steps = append(p.Steps, &ps1)
+	ps2 := certprotos.ProofStep{
+		S1:          ps.Proved[0],
+		S2:          policyKeySaysIntelKeyIsTrusted,
+		Conclusion:  intelKeyIsTrusted,
+		RuleApplied: &r5,
+	}
+	p.Steps = append(p.Steps, &ps2)
+	ps3 := certprotos.ProofStep{
+		S1:          intelKeyIsTrusted,
+		S2:          intelKeySaysAttestKeyIsTrusted,
+		Conclusion:  attestKeyIsTrusted,
+		RuleApplied: &r5,
+	}
+	p.Steps = append(p.Steps, &ps3)
+	ps4 := certprotos.ProofStep{
+		S1:          attestKeyIsTrusted,
+		S2:          attestKeySaysEnclaveKeySpeaksForMeasurement,
+		Conclusion:  enclaveKeySpeaksForMeasurement,
+		RuleApplied: &r6,
+	}
+	p.Steps = append(p.Steps, &ps4)
+	ps5 := certprotos.ProofStep{
+		S1:          measurementIsTrusted,
+		S2:          enclaveKeySpeaksForMeasurement,
+		Conclusion:  enclaveKeyIsTrusted,
+		RuleApplied: &r1,
+	}
+	p.Steps = append(p.Steps, &ps5)
 
-
-        if VerifyProof(policyKey, enclaveKeyIsTrusted, &p, &ps) {
-                fmt.Printf("Proved: ")
-                PrintVseClause(enclaveKeyIsTrusted)
-                fmt.Println("")
-        } else {
-                fmt.Printf("Not proved: ")
-                PrintVseClause(enclaveKeyIsTrusted)
-                fmt.Println("")
-                t.Errorf("Cannot prove statement")
-        }
-        fmt.Printf("\n\nFinal proved statements %d\n", len(ps.Proved))
-        for i := 0; i < len(ps.Proved); i++ {
-                PrintVseClause(ps.Proved[i])
-                fmt.Println("")
-        }
+	if VerifyProof(policyKey, enclaveKeyIsTrusted, &p, &ps) {
+		fmt.Printf("Proved: ")
+		PrintVseClause(enclaveKeyIsTrusted)
+		fmt.Println("")
+	} else {
+		fmt.Printf("Not proved: ")
+		PrintVseClause(enclaveKeyIsTrusted)
+		fmt.Println("")
+		t.Errorf("Cannot prove statement")
+	}
+	fmt.Printf("\n\nFinal proved statements %d\n", len(ps.Proved))
+	for i := 0; i < len(ps.Proved); i++ {
+		PrintVseClause(ps.Proved[i])
+		fmt.Println("")
+	}
 }
 
 func TestProofsAttest(t *testing.T) {
-        fmt.Print("\nTestProofsAttest\n")
+	fmt.Print("\nTestProofsAttest\n")
 
-        if !InitSimulatedEnclave() {
-                t.Errorf("Cannot init simulated enclave")
-        }
+	if !InitSimulatedEnclave() {
+		t.Errorf("Cannot init simulated enclave")
+	}
 
-        privatePolicyKey := MakeVseRsaKey(2048)
-        var tpk  string = "policyKey"
-        privatePolicyKey.KeyName = &tpk
-        PrintKey(privatePolicyKey)
-        policyKey := InternalPublicFromPrivateKey(privatePolicyKey)
-        policySubj := MakeKeyEntity(policyKey)
-        fmt.Println("\nPolicy key")
-        PrintEntity(policySubj)
+	privatePolicyKey := MakeVseRsaKey(2048)
+	var tpk string = "policyKey"
+	privatePolicyKey.KeyName = &tpk
+	PrintKey(privatePolicyKey)
+	policyKey := InternalPublicFromPrivateKey(privatePolicyKey)
+	policySubj := MakeKeyEntity(policyKey)
+	fmt.Println("\nPolicy key")
+	PrintEntity(policySubj)
 
-        privateIntelKey := MakeVseRsaKey(2048)
-        iek  := "intelKey"
-        privateIntelKey.KeyName = &iek
-        PrintKey(privateIntelKey)
-        fmt.Println("")
-        intelKey := InternalPublicFromPrivateKey(privateIntelKey)
-        intelSubj := MakeKeyEntity(intelKey)
-        fmt.Println("\nAttest key")
-        PrintEntity(intelSubj)
+	privateIntelKey := MakeVseRsaKey(2048)
+	iek := "intelKey"
+	privateIntelKey.KeyName = &iek
+	PrintKey(privateIntelKey)
+	fmt.Println("")
+	intelKey := InternalPublicFromPrivateKey(privateIntelKey)
+	intelSubj := MakeKeyEntity(intelKey)
+	fmt.Println("\nAttest key")
+	PrintEntity(intelSubj)
 
-        privateAttestKey := MakeVseRsaKey(2048)
-        aek  := "attestKey"
-        privateAttestKey.KeyName = &aek
-        PrintKey(privateAttestKey)
-        fmt.Println("")
-        attestKey := InternalPublicFromPrivateKey(privateAttestKey)
-        attestSubj := MakeKeyEntity(attestKey)
-        fmt.Println("\nAttest key")
-        PrintEntity(attestSubj)
+	privateAttestKey := MakeVseRsaKey(2048)
+	aek := "attestKey"
+	privateAttestKey.KeyName = &aek
+	PrintKey(privateAttestKey)
+	fmt.Println("")
+	attestKey := InternalPublicFromPrivateKey(privateAttestKey)
+	attestSubj := MakeKeyEntity(attestKey)
+	fmt.Println("\nAttest key")
+	PrintEntity(attestSubj)
 
-        privateEnclaveKey := MakeVseRsaKey(2048)
-        tek  := "enclaveKey"
-        privateEnclaveKey.KeyName = &tek
-        PrintKey(privateEnclaveKey)
-        fmt.Println("")
-        enclaveKey := InternalPublicFromPrivateKey(privateEnclaveKey)
-        enclaveSubj := MakeKeyEntity(enclaveKey)
-        fmt.Println("\nEnclave key")
-        PrintEntity(enclaveSubj)
+	privateEnclaveKey := MakeVseRsaKey(2048)
+	tek := "enclaveKey"
+	privateEnclaveKey.KeyName = &tek
+	PrintKey(privateEnclaveKey)
+	fmt.Println("")
+	enclaveKey := InternalPublicFromPrivateKey(privateEnclaveKey)
+	enclaveSubj := MakeKeyEntity(enclaveKey)
+	fmt.Println("\nEnclave key")
+	PrintEntity(enclaveSubj)
 
-        m:= make([]byte, 32)
-        for i := 0; i < 32; i++ {
-                m[i] = byte(i)
-        }
-        entObj:= MakeMeasurementEntity(m)
-        fmt.Println("\nEnclave measurement")
-        PrintEntity(entObj)
+	m := make([]byte, 32)
+	for i := 0; i < 32; i++ {
+		m[i] = byte(i)
+	}
+	entObj := MakeMeasurementEntity(m)
+	fmt.Println("\nEnclave measurement")
+	PrintEntity(entObj)
 
-        verbIs := "is-trusted"
-        verbSays := "says"
-        verbSpeaksFor:= "speaks-for"
-        verbIsTrustedForAtt := "is-trusted-for-attestation"
+	verbIs := "is-trusted"
+	verbSays := "says"
+	verbSpeaksFor := "speaks-for"
+	verbIsTrustedForAtt := "is-trusted-for-attestation"
 
-        intelKeyIsTrusted := MakeUnaryVseClause(intelSubj, &verbIsTrustedForAtt)
-        attestKeyIsTrusted := MakeUnaryVseClause(attestSubj, &verbIsTrustedForAtt)
-        measurementIsTrusted :=  MakeUnaryVseClause(entObj, &verbIs)
-        enclaveKeyIsTrusted := MakeUnaryVseClause(enclaveSubj, &verbIsTrustedForAtt)
+	intelKeyIsTrusted := MakeUnaryVseClause(intelSubj, &verbIsTrustedForAtt)
+	attestKeyIsTrusted := MakeUnaryVseClause(attestSubj, &verbIsTrustedForAtt)
+	measurementIsTrusted := MakeUnaryVseClause(entObj, &verbIs)
+	enclaveKeyIsTrusted := MakeUnaryVseClause(enclaveSubj, &verbIsTrustedForAtt)
 
-        policyKeySaysIntelKeyIsTrusted :=  MakeIndirectVseClause(policySubj, &verbSays, intelKeyIsTrusted)
-        intelKeySaysAttestKeyIsTrusted := MakeIndirectVseClause(intelSubj, &verbSays, attestKeyIsTrusted)
-        policyKeySaysMeasurementIsTrusted :=  MakeIndirectVseClause(policySubj, &verbSays, measurementIsTrusted)
+	policyKeySaysIntelKeyIsTrusted := MakeIndirectVseClause(policySubj, &verbSays, intelKeyIsTrusted)
+	intelKeySaysAttestKeyIsTrusted := MakeIndirectVseClause(intelSubj, &verbSays, attestKeyIsTrusted)
+	policyKeySaysMeasurementIsTrusted := MakeIndirectVseClause(policySubj, &verbSays, measurementIsTrusted)
 
-        enclaveKeySpeaksForMeasurement:=  MakeSimpleVseClause(enclaveSubj, &verbSpeaksFor, entObj)
-        attestKeySaysEnclaveKeySpeaksForMeasurement:=  MakeIndirectVseClause(attestSubj, &verbSays, enclaveKeySpeaksForMeasurement)
+	enclaveKeySpeaksForMeasurement := MakeSimpleVseClause(enclaveSubj, &verbSpeaksFor, entObj)
+	attestKeySaysEnclaveKeySpeaksForMeasurement := MakeIndirectVseClause(attestSubj, &verbSays, enclaveKeySpeaksForMeasurement)
 
-        // make signed assertions
-        tn := TimePointNow()
-        tf := TimePointPlus(tn, 365 * 86400)
-        nb := TimePointToString(tn)
-        na := TimePointToString(tf)
-        vfmt := "vse-clause"
-        d1 := "policyKey says intelKey is-trusted-for-attestation"
-        d2 := "policyKey says Measurement is-trusted"
-        d3 := "intelKey says attestKey is-trusted-for-attestation"
-        d4 := "attest Key says entityKey speaks-for entityMeasurement"
+	// make signed assertions
+	tn := TimePointNow()
+	tf := TimePointPlus(tn, 365*86400)
+	nb := TimePointToString(tn)
+	na := TimePointToString(tf)
+	vfmt := "vse-clause"
+	d1 := "policyKey says intelKey is-trusted-for-attestation"
+	d2 := "policyKey says Measurement is-trusted"
+	d3 := "intelKey says attestKey is-trusted-for-attestation"
+	d4 := "attest Key says entityKey speaks-for entityMeasurement"
 
-        serPolicyKeySaysIntelKeyIsTrusted, _:= proto.Marshal(policyKeySaysIntelKeyIsTrusted)
-        clPolicyKeySaysIntelKeyIsTrusted := MakeClaim(serPolicyKeySaysIntelKeyIsTrusted, vfmt, d1, nb, na)
-        signedPolicyKeySaysIntelKeyIsTrusted := MakeSignedClaim(clPolicyKeySaysIntelKeyIsTrusted, privatePolicyKey)
+	serPolicyKeySaysIntelKeyIsTrusted, _ := proto.Marshal(policyKeySaysIntelKeyIsTrusted)
+	clPolicyKeySaysIntelKeyIsTrusted := MakeClaim(serPolicyKeySaysIntelKeyIsTrusted, vfmt, d1, nb, na)
+	signedPolicyKeySaysIntelKeyIsTrusted := MakeSignedClaim(clPolicyKeySaysIntelKeyIsTrusted, privatePolicyKey)
 
-        serPolicyKeySaysMeasurementIsTrusted, _:= proto.Marshal(policyKeySaysMeasurementIsTrusted)
-        clPolicyKeySaysMeasurementIsTrusted := MakeClaim(serPolicyKeySaysMeasurementIsTrusted, vfmt, d2, nb, na)
-        signedPolicyKeySaysMeasurementIsTrusted := MakeSignedClaim(clPolicyKeySaysMeasurementIsTrusted, privatePolicyKey)
+	serPolicyKeySaysMeasurementIsTrusted, _ := proto.Marshal(policyKeySaysMeasurementIsTrusted)
+	clPolicyKeySaysMeasurementIsTrusted := MakeClaim(serPolicyKeySaysMeasurementIsTrusted, vfmt, d2, nb, na)
+	signedPolicyKeySaysMeasurementIsTrusted := MakeSignedClaim(clPolicyKeySaysMeasurementIsTrusted, privatePolicyKey)
 
-        serIntelKeySaysAttestKeyIsTrusted, _:= proto.Marshal(intelKeySaysAttestKeyIsTrusted)
-        clIntelKeySaysAttestKeyIsTrusted := MakeClaim(serIntelKeySaysAttestKeyIsTrusted, vfmt, d3, nb, na)
-        signedIntelKeySaysAttestKeyIsTrusted := MakeSignedClaim(clIntelKeySaysAttestKeyIsTrusted, privateIntelKey)
+	serIntelKeySaysAttestKeyIsTrusted, _ := proto.Marshal(intelKeySaysAttestKeyIsTrusted)
+	clIntelKeySaysAttestKeyIsTrusted := MakeClaim(serIntelKeySaysAttestKeyIsTrusted, vfmt, d3, nb, na)
+	signedIntelKeySaysAttestKeyIsTrusted := MakeSignedClaim(clIntelKeySaysAttestKeyIsTrusted, privateIntelKey)
 
-        serAttestKeySaysEnclaveKeySpeaksForMeasurement, _ := proto.Marshal(attestKeySaysEnclaveKeySpeaksForMeasurement)
-        clAttestKeySaysEnclaveKeySpeaksForMeasurement := MakeClaim(serAttestKeySaysEnclaveKeySpeaksForMeasurement, vfmt, d4, nb, na)
-        signedAttestKeySaysEnclaveKeySpeaksForMeasurement := MakeSignedClaim(clAttestKeySaysEnclaveKeySpeaksForMeasurement, privateAttestKey)
+	serAttestKeySaysEnclaveKeySpeaksForMeasurement, _ := proto.Marshal(attestKeySaysEnclaveKeySpeaksForMeasurement)
+	clAttestKeySaysEnclaveKeySpeaksForMeasurement := MakeClaim(serAttestKeySaysEnclaveKeySpeaksForMeasurement, vfmt, d4, nb, na)
+	signedAttestKeySaysEnclaveKeySpeaksForMeasurement := MakeSignedClaim(clAttestKeySaysEnclaveKeySpeaksForMeasurement, privateAttestKey)
 
-        var evidenceList []*certprotos.Evidence
-        ps := certprotos.ProvedStatements{}
-        scStr := "signed-claim"
+	var evidenceList []*certprotos.Evidence
+	ps := certprotos.ProvedStatements{}
+	scStr := "signed-claim"
 
-        e1 := certprotos.Evidence {}
-        e1.EvidenceType = &scStr
-        sc1, err := proto.Marshal(signedPolicyKeySaysIntelKeyIsTrusted)
-        if err != nil {
-                t.Errorf("Marshal fails\n")
-        }
-        e1.SerializedEvidence = sc1
-        evidenceList = append(evidenceList, &e1)
+	e1 := certprotos.Evidence{}
+	e1.EvidenceType = &scStr
+	sc1, err := proto.Marshal(signedPolicyKeySaysIntelKeyIsTrusted)
+	if err != nil {
+		t.Errorf("Marshal fails\n")
+	}
+	e1.SerializedEvidence = sc1
+	evidenceList = append(evidenceList, &e1)
 
-        e2 := certprotos.Evidence {}
-        e2.EvidenceType = &scStr
-        sc2, err := proto.Marshal(signedPolicyKeySaysMeasurementIsTrusted)
-        if err != nil {
-                t.Errorf("Marshal fails\n")
-        }
-        e2.SerializedEvidence = sc2
-        evidenceList = append(evidenceList, &e2)
+	e2 := certprotos.Evidence{}
+	e2.EvidenceType = &scStr
+	sc2, err := proto.Marshal(signedPolicyKeySaysMeasurementIsTrusted)
+	if err != nil {
+		t.Errorf("Marshal fails\n")
+	}
+	e2.SerializedEvidence = sc2
+	evidenceList = append(evidenceList, &e2)
 
-        e3 := certprotos.Evidence {}
-        e3.EvidenceType = &scStr
-        sc3, err := proto.Marshal(signedIntelKeySaysAttestKeyIsTrusted)
-        if err != nil {
-                t.Errorf("Marshal fails\n")
-        }
-        e3.SerializedEvidence = sc3
-        evidenceList = append(evidenceList, &e3)
+	e3 := certprotos.Evidence{}
+	e3.EvidenceType = &scStr
+	sc3, err := proto.Marshal(signedIntelKeySaysAttestKeyIsTrusted)
+	if err != nil {
+		t.Errorf("Marshal fails\n")
+	}
+	e3.SerializedEvidence = sc3
+	evidenceList = append(evidenceList, &e3)
 
-        e4 := certprotos.Evidence {}
-        e4.EvidenceType = &scStr
-        sc4, err := proto.Marshal(signedAttestKeySaysEnclaveKeySpeaksForMeasurement)
-        if err != nil {
-                t.Errorf("Marshal fails\n")
-        }
-        e4.SerializedEvidence = sc4
-        evidenceList = append(evidenceList, &e4)
+	e4 := certprotos.Evidence{}
+	e4.EvidenceType = &scStr
+	sc4, err := proto.Marshal(signedAttestKeySaysEnclaveKeySpeaksForMeasurement)
+	if err != nil {
+		t.Errorf("Marshal fails\n")
+	}
+	e4.SerializedEvidence = sc4
+	evidenceList = append(evidenceList, &e4)
 
-
-        fmt.Println("Public policy key")
-        PrintKey(policyKey)
-        fmt.Println("")
+	fmt.Println("Public policy key")
+	PrintKey(policyKey)
+	fmt.Println("")
 
 	// Next statement is here because we removed InitAxiom from InitProvedStatements
 	InitAxiom(*policyKey, &ps)
-        if !InitProvedStatements(*policyKey, evidenceList, &ps) {
-                t.Errorf("Cannot init proved statements")
-        }
-        fmt.Printf("Initial proved statements %d\n", len(ps.Proved))
-        for i := 0; i < len(ps.Proved); i++ {
-                PrintVseClause(ps.Proved[i])
-                fmt.Println("")
-        }
-        fmt.Println("")
+	if !InitProvedStatements(*policyKey, evidenceList, &ps) {
+		t.Errorf("Cannot init proved statements")
+	}
+	fmt.Printf("Initial proved statements %d\n", len(ps.Proved))
+	for i := 0; i < len(ps.Proved); i++ {
+		PrintVseClause(ps.Proved[i])
+		fmt.Println("")
+	}
+	fmt.Println("")
 
-        // The proof
-        p := certprotos.Proof{}
+	// The proof
+	p := certprotos.Proof{}
 
-        r3 := int32(3)
-        r5 := int32(5)
-        r6 := int32(6)
-        r7 := int32(7)
-        ps1 := certprotos.ProofStep {
-                S1: ps.Proved[0],
-                S2: policyKeySaysMeasurementIsTrusted,
-                Conclusion: measurementIsTrusted,
-                RuleApplied: &r3,
-        }
-        p.Steps = append(p.Steps, &ps1)
-        ps2 := certprotos.ProofStep {
-                S1: ps.Proved[0],
-                S2: policyKeySaysIntelKeyIsTrusted,
-                Conclusion: intelKeyIsTrusted,
-                RuleApplied: &r5,
-        }
-        p.Steps = append(p.Steps, &ps2)
-        ps3 := certprotos.ProofStep {
-                S1: intelKeyIsTrusted,
-                S2: intelKeySaysAttestKeyIsTrusted,
-                Conclusion: attestKeyIsTrusted,
-                RuleApplied: &r5,
-        }
-        p.Steps = append(p.Steps, &ps3)
-        ps4 := certprotos.ProofStep {
-                S1: attestKeyIsTrusted,
-                S2: attestKeySaysEnclaveKeySpeaksForMeasurement,
-                Conclusion: enclaveKeySpeaksForMeasurement,
-                RuleApplied: &r6,
-        }
-        p.Steps = append(p.Steps, &ps4)
-        ps5 := certprotos.ProofStep {
-                S1: measurementIsTrusted,
-                S2: enclaveKeySpeaksForMeasurement,
-                Conclusion: enclaveKeyIsTrusted,
-                RuleApplied: &r7,
-        }
-        p.Steps = append(p.Steps, &ps5)
+	r3 := int32(3)
+	r5 := int32(5)
+	r6 := int32(6)
+	r7 := int32(7)
+	ps1 := certprotos.ProofStep{
+		S1:          ps.Proved[0],
+		S2:          policyKeySaysMeasurementIsTrusted,
+		Conclusion:  measurementIsTrusted,
+		RuleApplied: &r3,
+	}
+	p.Steps = append(p.Steps, &ps1)
+	ps2 := certprotos.ProofStep{
+		S1:          ps.Proved[0],
+		S2:          policyKeySaysIntelKeyIsTrusted,
+		Conclusion:  intelKeyIsTrusted,
+		RuleApplied: &r5,
+	}
+	p.Steps = append(p.Steps, &ps2)
+	ps3 := certprotos.ProofStep{
+		S1:          intelKeyIsTrusted,
+		S2:          intelKeySaysAttestKeyIsTrusted,
+		Conclusion:  attestKeyIsTrusted,
+		RuleApplied: &r5,
+	}
+	p.Steps = append(p.Steps, &ps3)
+	ps4 := certprotos.ProofStep{
+		S1:          attestKeyIsTrusted,
+		S2:          attestKeySaysEnclaveKeySpeaksForMeasurement,
+		Conclusion:  enclaveKeySpeaksForMeasurement,
+		RuleApplied: &r6,
+	}
+	p.Steps = append(p.Steps, &ps4)
+	ps5 := certprotos.ProofStep{
+		S1:          measurementIsTrusted,
+		S2:          enclaveKeySpeaksForMeasurement,
+		Conclusion:  enclaveKeyIsTrusted,
+		RuleApplied: &r7,
+	}
+	p.Steps = append(p.Steps, &ps5)
 
-
-        if VerifyProof(policyKey, enclaveKeyIsTrusted, &p, &ps) {
-                fmt.Printf("Proved: ")
-                PrintVseClause(enclaveKeyIsTrusted)
-                fmt.Println("")
-        } else {
-                fmt.Printf("Not proved: ")
-                PrintVseClause(enclaveKeyIsTrusted)
-                fmt.Println("")
-                t.Errorf("Cannot prove statement")
-        }
-        fmt.Printf("\n\nFinal proved statements %d\n", len(ps.Proved))
-        for i := 0; i < len(ps.Proved); i++ {
-                PrintVseClause(ps.Proved[i])
-                fmt.Println("")
-        }
+	if VerifyProof(policyKey, enclaveKeyIsTrusted, &p, &ps) {
+		fmt.Printf("Proved: ")
+		PrintVseClause(enclaveKeyIsTrusted)
+		fmt.Println("")
+	} else {
+		fmt.Printf("Not proved: ")
+		PrintVseClause(enclaveKeyIsTrusted)
+		fmt.Println("")
+		t.Errorf("Cannot prove statement")
+	}
+	fmt.Printf("\n\nFinal proved statements %d\n", len(ps.Proved))
+	for i := 0; i < len(ps.Proved); i++ {
+		PrintVseClause(ps.Proved[i])
+		fmt.Println("")
+	}
 }
 
 func TestArtifacts(t *testing.T) {
-        fmt.Print("\nTestArtifacts\n")
+	fmt.Print("\nTestArtifacts\n")
 
-        privateIssuerKey := MakeVseRsaKey(2048)
-        var ipk  string = "issuerKey"
-        privateIssuerKey.KeyName = &ipk
-        PrintKey(privateIssuerKey)
-        // issuerKey := InternalPublicFromPrivateKey(privateIssuerKey)
-        fmt.Println("\nIssuer key")
-        PrintKey(privateIssuerKey)
+	privateIssuerKey := MakeVseRsaKey(2048)
+	var ipk string = "issuerKey"
+	privateIssuerKey.KeyName = &ipk
+	PrintKey(privateIssuerKey)
+	// issuerKey := InternalPublicFromPrivateKey(privateIssuerKey)
+	fmt.Println("\nIssuer key")
+	PrintKey(privateIssuerKey)
 
-        privateSubjKey := MakeVseRsaKey(2048)
-        var spk  string = "subjKey"
-        privateSubjKey.KeyName = &spk
-        PrintKey(privateSubjKey)
-        subjKey := InternalPublicFromPrivateKey(privateSubjKey)
-        fmt.Println("\nSubj key")
-        PrintKey(privateSubjKey)
+	privateSubjKey := MakeVseRsaKey(2048)
+	var spk string = "subjKey"
+	privateSubjKey.KeyName = &spk
+	PrintKey(privateSubjKey)
+	subjKey := InternalPublicFromPrivateKey(privateSubjKey)
+	fmt.Println("\nSubj key")
+	PrintKey(privateSubjKey)
 
-        sn := big.Int{}
-        sn.SetInt64(int64(1))
-        parentCert := x509.Certificate{
-                SerialNumber: &sn,
-                Subject: pkix.Name{
-                        CommonName:   "testIssuer",
-                },
-                NotBefore:             time.Now(),
-                NotAfter:              time.Now().Add(365*86400*1000000000),
-                KeyUsage:              x509.KeyUsageCertSign,
-                ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
-                BasicConstraintsValid: true,
-                IsCA: true,
-        }
-        ipK := rsa.PrivateKey{}
-        iPK := rsa.PublicKey{}
-        if !GetRsaKeysFromInternal(privateIssuerKey, &ipK, &iPK) {
-                t.Error("Can't Create parent Key")
-        }
+	sn := big.Int{}
+	sn.SetInt64(int64(1))
+	parentCert := x509.Certificate{
+		SerialNumber: &sn,
+		Subject: pkix.Name{
+			CommonName: "testIssuer",
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(365 * 86400 * 1000000000),
+		KeyUsage:              x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	ipK := rsa.PrivateKey{}
+	iPK := rsa.PublicKey{}
+	if !GetRsaKeysFromInternal(privateIssuerKey, &ipK, &iPK) {
+		t.Error("Can't Create parent Key")
+	}
 
-        parentDerCert, err := x509.CreateCertificate(rand.Reader, &parentCert, &parentCert,
-                &ipK.PublicKey, crypto.Signer(&ipK))
-        if err != nil {
-                t.Error("Can't Create parent Certificate")
-        }
-        newParentCert, err := x509.ParseCertificate(parentDerCert)
-        if err != nil {
-                t.Error("Can't parse parent Certificate")
-        }
+	parentDerCert, err := x509.CreateCertificate(rand.Reader, &parentCert, &parentCert,
+		&ipK.PublicKey, crypto.Signer(&ipK))
+	if err != nil {
+		t.Error("Can't Create parent Certificate")
+	}
+	newParentCert, err := x509.ParseCertificate(parentDerCert)
+	if err != nil {
+		t.Error("Can't parse parent Certificate")
+	}
 
-        cert := ProduceAdmissionCert(privateIssuerKey, newParentCert, subjKey, "testSubject", "",
-                uint64(5), 365.0 * 86400)
-        fmt.Println("")
-        if cert == nil {
-                fmt.Println("ProduceArtifact returned nil")
-        }
-        //issuerName := GetIssuerNameFromCert(cert)
-        subjName := GetSubjectNameFromCert(cert)
-        if subjName != nil {
-                fmt.Printf("Subject Name: %s\n",  *subjName)
-        }
-        sk := GetSubjectKey(cert)
-        if sk != nil {
-                PrintKey(sk)
-        }
-        if !VerifyAdmissionCert(newParentCert, cert) {
-                t.Error("Artifact does not verify")
-        }
+	cert := ProduceAdmissionCert(privateIssuerKey, newParentCert, subjKey, "testSubject", "",
+		uint64(5), 365.0*86400)
+	fmt.Println("")
+	if cert == nil {
+		fmt.Println("ProduceArtifact returned nil")
+	}
+	//issuerName := GetIssuerNameFromCert(cert)
+	subjName := GetSubjectNameFromCert(cert)
+	if subjName != nil {
+		fmt.Printf("Subject Name: %s\n", *subjName)
+	}
+	sk := GetSubjectKey(cert)
+	if sk != nil {
+		PrintKey(sk)
+	}
+	if !VerifyAdmissionCert(newParentCert, cert) {
+		t.Error("Artifact does not verify")
+	}
 }
 
 type MyInterface interface {
-        Func1(i int) int
-        Func2(i int) string
+	Func1(i int) int
+	Func2(i int) string
 }
 
 type MyInt int
 
 func (r *MyInt) Func1(in int) int {
-        return in + 1
+	return in + 1
 }
 
-func (r *MyInt) Func2(in int) string{
-        return  fmt.Sprintf("***%d", in)
+func (r *MyInt) Func2(in int) string {
+	return fmt.Sprintf("***%d", in)
 }
 
 type MyCryptoSigner rsa.PrivateKey
 
 func (r *MyCryptoSigner) Sign(rand io.Reader, digest []byte, opts crypto.SignerOpts) (signature []byte, err error) {
-        return nil, nil
+	return nil, nil
 }
 
 func TestInterface(t *testing.T) {
-        fmt.Print("\nTestInterface\n")
+	fmt.Print("\nTestInterface\n")
 
-        var i MyInt = 3
-        fmt.Println(i.Func1(3))
-        fmt.Println(i.Func2(3))
+	var i MyInt = 3
+	fmt.Println(i.Func1(3))
+	fmt.Println(i.Func2(3))
 }
 
 func TestEcc384(t *testing.T) {
-        fmt.Printf("\nTestECC384\n")
-        pK, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
-        if err != nil {
-                t.Errorf("ecdsa.GenerateKey fails\n")
-                return
-        }
-        name := "test-key"
-        k := new(certprotos.KeyMessage)
-        PK := pK.Public()
-        if !GetInternalKeyFromEccPublicKey(name, PK.(*ecdsa.PublicKey), k) {
-                t.Errorf("GetInternalKeyFromEccPublicKey fails\n")
-                return
-        }
-        PrintKey(k)
-        _, new_PK, err := GetEccKeysFromInternal(k)
-        if err != nil || new_PK == nil {
-                t.Errorf("GetInternalKeyFromEccPublicKey fails\n")
-                return
-        }
+	fmt.Printf("\nTestECC384\n")
+	pK, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	if err != nil {
+		t.Errorf("ecdsa.GenerateKey fails\n")
+		return
+	}
+	name := "test-key"
+	k := new(certprotos.KeyMessage)
+	PK := pK.Public()
+	if !GetInternalKeyFromEccPublicKey(name, PK.(*ecdsa.PublicKey), k) {
+		t.Errorf("GetInternalKeyFromEccPublicKey fails\n")
+		return
+	}
+	PrintKey(k)
+	_, new_PK, err := GetEccKeysFromInternal(k)
+	if err != nil || new_PK == nil {
+		t.Errorf("GetInternalKeyFromEccPublicKey fails\n")
+		return
+	}
 
-        new_k := new(certprotos.KeyMessage)
-        if !GetInternalKeyFromEccPublicKey(name, PK.(*ecdsa.PublicKey), new_k) {
-                t.Errorf("GetInternalKeyFromEccPublicKey fails\n")
-                return
-        }
-        PrintKey(new_k)
-        if !SameKey(k, new_k) {
-                t.Errorf("Translated key doesnt match\n")
-                return
-        }
+	new_k := new(certprotos.KeyMessage)
+	if !GetInternalKeyFromEccPublicKey(name, PK.(*ecdsa.PublicKey), new_k) {
+		t.Errorf("GetInternalKeyFromEccPublicKey fails\n")
+		return
+	}
+	PrintKey(new_k)
+	if !SameKey(k, new_k) {
+		t.Errorf("Translated key doesnt match\n")
+		return
+	}
 
-        toHash := make([]byte, 50)
-        for i := 0; i < 50; i++ {
-                toHash[i] = byte(i)
-        }
-        hashed := sha512.Sum384(toHash)
-        fmt.Printf("hashed: ")
-        PrintBytes(hashed[0:])
-        fmt.Printf("\n")
-        r, s, err := ecdsa.Sign(rand.Reader, pK, hashed[0:])
-        if err != nil {
-                t.Errorf("Couldn't sign\n")
-                return
-        }
-        if !ecdsa.Verify(PK.(*ecdsa.PublicKey), hashed[0:], r, s) {
-                t.Errorf("Couldn't verify with old PK\n")
-                return
-        }
-        fmt.Printf("\n\nr: ")
-        fmt.Print(r)
-        fmt.Printf("\n")
-        fmt.Printf("s: ")
-        fmt.Print(s)
-        fmt.Printf("\nr: ")
-        r_bytes := r.Bytes()
-        PrintBytes(r_bytes)
-        fmt.Printf("\ns: ")
-        s_bytes := s.Bytes()
-        PrintBytes(s_bytes)
-        fmt.Printf("\n\n")
-        fmt.Printf("New internal:\n")
-        fmt.Print(new_PK)
-        fmt.Printf("\n")
-        fmt.Printf("X: ")
-        fmt.Print(new_PK.X)
-        fmt.Printf("\n")
-        if !ecdsa.Verify(new_PK, hashed[0:], r, s) {
-                t.Errorf("Couldn't verify with new PK\n")
-                return
-        }
-        // certlib.VerifySevAttestation(serialized []byte, k *certprotos.KeyMessage) []byte
+	toHash := make([]byte, 50)
+	for i := 0; i < 50; i++ {
+		toHash[i] = byte(i)
+	}
+	hashed := sha512.Sum384(toHash)
+	fmt.Printf("hashed: ")
+	PrintBytes(hashed[0:])
+	fmt.Printf("\n")
+	r, s, err := ecdsa.Sign(rand.Reader, pK, hashed[0:])
+	if err != nil {
+		t.Errorf("Couldn't sign\n")
+		return
+	}
+	if !ecdsa.Verify(PK.(*ecdsa.PublicKey), hashed[0:], r, s) {
+		t.Errorf("Couldn't verify with old PK\n")
+		return
+	}
+	fmt.Printf("\n\nr: ")
+	fmt.Print(r)
+	fmt.Printf("\n")
+	fmt.Printf("s: ")
+	fmt.Print(s)
+	fmt.Printf("\nr: ")
+	r_bytes := r.Bytes()
+	PrintBytes(r_bytes)
+	fmt.Printf("\ns: ")
+	s_bytes := s.Bytes()
+	PrintBytes(s_bytes)
+	fmt.Printf("\n\n")
+	fmt.Printf("New internal:\n")
+	fmt.Print(new_PK)
+	fmt.Printf("\n")
+	fmt.Printf("X: ")
+	fmt.Print(new_PK.X)
+	fmt.Printf("\n")
+	if !ecdsa.Verify(new_PK, hashed[0:], r, s) {
+		t.Errorf("Couldn't verify with new PK\n")
+		return
+	}
+	// certlib.VerifySevAttestation(serialized []byte, k *certprotos.KeyMessage) []byte
 
-        new_name := "vcertKey"
-        km := new(certprotos.KeyMessage)
-        if !GetInternalKeyFromEccPublicKey(new_name, new_PK, km) {
-                t.Errorf("Couldn't GetInternalKeyFromEccPublicKey\n")
-                return
-        }
-        PrintKey(km)
-        fmt.Printf("\n")
+	new_name := "vcertKey"
+	km := new(certprotos.KeyMessage)
+	if !GetInternalKeyFromEccPublicKey(new_name, new_PK, km) {
+		t.Errorf("Couldn't GetInternalKeyFromEccPublicKey\n")
+		return
+	}
+	PrintKey(km)
+	fmt.Printf("\n")
 
-        _, recovered_PK, err := GetEccKeysFromInternal(km)
-        if err != nil {
-                t.Errorf("GetEccKeysFromInternal failed\n")
-                return
-        }
+	_, recovered_PK, err := GetEccKeysFromInternal(km)
+	if err != nil {
+		t.Errorf("GetEccKeysFromInternal failed\n")
+		return
+	}
 
-        new_km := new(certprotos.KeyMessage)
-        if !GetInternalKeyFromEccPublicKey(new_name, recovered_PK, new_km) {
-                t.Errorf("Couldn't GetInternalKeyFromEccPublicKey\n")
-                return
-        }
-        PrintKey(new_km)
-        fmt.Printf("\n")
+	new_km := new(certprotos.KeyMessage)
+	if !GetInternalKeyFromEccPublicKey(new_name, recovered_PK, new_km) {
+		t.Errorf("Couldn't GetInternalKeyFromEccPublicKey\n")
+		return
+	}
+	PrintKey(new_km)
+	fmt.Printf("\n")
 
-        ttt :=  make([]byte, 48)
-        for i := 0; i < 48; i++ {
-                ttt[i] = byte(i)
-        }
-        fmt.Printf("One (%d): ", len(ttt[0:47]))
-        PrintBytes(ttt[0:47])
-        fmt.Printf("\n")
-        fmt.Printf("Two (%d): ", len(ttt[0:48]))
-        PrintBytes(ttt[0:48])
-        fmt.Printf("\n")
+	ttt := make([]byte, 48)
+	for i := 0; i < 48; i++ {
+		ttt[i] = byte(i)
+	}
+	fmt.Printf("One (%d): ", len(ttt[0:47]))
+	PrintBytes(ttt[0:47])
+	fmt.Printf("\n")
+	fmt.Printf("Two (%d): ", len(ttt[0:48]))
+	PrintBytes(ttt[0:48])
+	fmt.Printf("\n")
 }
 
 func TestEcc256(t *testing.T) {
-        fmt.Printf("\nTestECC256\n")
-        pK, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-        if err != nil {
-                t.Errorf("ecdsa.GenerateKey fails\n")
-                return
-        }
-        name := "test-key"
-        k := new(certprotos.KeyMessage)
-        PK := pK.Public()
-        if !GetInternalKeyFromEccPublicKey(name, PK.(*ecdsa.PublicKey), k) {
-                t.Errorf("GetInternalKeyFromEccPublicKey fails\n")
-                return
-        }
-        PrintKey(k)
-        _, new_PK, err := GetEccKeysFromInternal(k)
-        if err != nil || new_PK == nil {
-                t.Errorf("GetInternalKeyFromEccPublicKey fails\n")
-                return
-        }
-        new_k := new(certprotos.KeyMessage)
-        if !GetInternalKeyFromEccPublicKey(name, PK.(*ecdsa.PublicKey), new_k) {
-                t.Errorf("GetInternalKeyFromEccPublicKey fails\n")
-                return
-        }
-        PrintKey(new_k)
-        if !SameKey(k, new_k) {
-                t.Errorf("Translated key doesnt match\n")
-                return
-        }
+	fmt.Printf("\nTestECC256\n")
+	pK, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Errorf("ecdsa.GenerateKey fails\n")
+		return
+	}
+	name := "test-key"
+	k := new(certprotos.KeyMessage)
+	PK := pK.Public()
+	if !GetInternalKeyFromEccPublicKey(name, PK.(*ecdsa.PublicKey), k) {
+		t.Errorf("GetInternalKeyFromEccPublicKey fails\n")
+		return
+	}
+	PrintKey(k)
+	_, new_PK, err := GetEccKeysFromInternal(k)
+	if err != nil || new_PK == nil {
+		t.Errorf("GetInternalKeyFromEccPublicKey fails\n")
+		return
+	}
+	new_k := new(certprotos.KeyMessage)
+	if !GetInternalKeyFromEccPublicKey(name, PK.(*ecdsa.PublicKey), new_k) {
+		t.Errorf("GetInternalKeyFromEccPublicKey fails\n")
+		return
+	}
+	PrintKey(new_k)
+	if !SameKey(k, new_k) {
+		t.Errorf("Translated key doesnt match\n")
+		return
+	}
 
-        toHash := make([]byte, 50)
-        for i := 0; i < 50; i++ {
-                toHash[i] = byte(i)
-        }
-        hashed := sha256.Sum256(toHash)
-        fmt.Printf("hashed: ")
-        PrintBytes(hashed[0:])
-        fmt.Printf("\n")
+	toHash := make([]byte, 50)
+	for i := 0; i < 50; i++ {
+		toHash[i] = byte(i)
+	}
+	hashed := sha256.Sum256(toHash)
+	fmt.Printf("hashed: ")
+	PrintBytes(hashed[0:])
+	fmt.Printf("\n")
 
-        r, s, err := ecdsa.Sign(rand.Reader, pK, hashed[0:])
-        if err != nil {
-                t.Errorf("Couldn't sign\n")
-                return
-        }
-        if !ecdsa.Verify(PK.(*ecdsa.PublicKey), hashed[0:], r, s) {
-                t.Errorf("Couldn't verify with old PK\n")
-                return
-        }
-        fmt.Printf("\n\nr: ")
-        fmt.Print(r)
-        fmt.Printf("\n")
-        fmt.Printf("s: ")
-        fmt.Print(s)
-        fmt.Printf("\nr: ")
-        r_bytes := r.Bytes()
-        PrintBytes(r_bytes)
-        fmt.Printf("\ns: ")
-        s_bytes := s.Bytes()
-        PrintBytes(s_bytes)
-        fmt.Printf("\n\n")
-        fmt.Printf("New internal:\n")
-        fmt.Print(new_PK)
-        fmt.Printf("\n")
-        fmt.Printf("X: ")
-        fmt.Print(new_PK.X)
-        fmt.Printf("\n")
-        if !ecdsa.Verify(new_PK, hashed[0:], r, s) {
-                t.Errorf("Couldn't verify with new PK\n")
-                return
-        }
-        // certlib.VerifySevAttestation(serialized []byte, k *certprotos.KeyMessage) []byte
+	r, s, err := ecdsa.Sign(rand.Reader, pK, hashed[0:])
+	if err != nil {
+		t.Errorf("Couldn't sign\n")
+		return
+	}
+	if !ecdsa.Verify(PK.(*ecdsa.PublicKey), hashed[0:], r, s) {
+		t.Errorf("Couldn't verify with old PK\n")
+		return
+	}
+	fmt.Printf("\n\nr: ")
+	fmt.Print(r)
+	fmt.Printf("\n")
+	fmt.Printf("s: ")
+	fmt.Print(s)
+	fmt.Printf("\nr: ")
+	r_bytes := r.Bytes()
+	PrintBytes(r_bytes)
+	fmt.Printf("\ns: ")
+	s_bytes := s.Bytes()
+	PrintBytes(s_bytes)
+	fmt.Printf("\n\n")
+	fmt.Printf("New internal:\n")
+	fmt.Print(new_PK)
+	fmt.Printf("\n")
+	fmt.Printf("X: ")
+	fmt.Print(new_PK.X)
+	fmt.Printf("\n")
+	if !ecdsa.Verify(new_PK, hashed[0:], r, s) {
+		t.Errorf("Couldn't verify with new PK\n")
+		return
+	}
+	// certlib.VerifySevAttestation(serialized []byte, k *certprotos.KeyMessage) []byte
 
-        new_name := "vcertKey"
-        km := new(certprotos.KeyMessage)
-        if !GetInternalKeyFromEccPublicKey(new_name, new_PK, km) {
-                t.Errorf("Couldn't GetInternalKeyFromEccPublicKey\n")
-                return
-        }
-        PrintKey(km)
-        fmt.Printf("\n")
+	new_name := "vcertKey"
+	km := new(certprotos.KeyMessage)
+	if !GetInternalKeyFromEccPublicKey(new_name, new_PK, km) {
+		t.Errorf("Couldn't GetInternalKeyFromEccPublicKey\n")
+		return
+	}
+	PrintKey(km)
+	fmt.Printf("\n")
 
-        _, recovered_PK, err := GetEccKeysFromInternal(km)
-        if err != nil {
-                t.Errorf("GetEccKeysFromInternal failed\n")
-                return
-        }
+	_, recovered_PK, err := GetEccKeysFromInternal(km)
+	if err != nil {
+		t.Errorf("GetEccKeysFromInternal failed\n")
+		return
+	}
 
-        new_km := new(certprotos.KeyMessage)
-        if !GetInternalKeyFromEccPublicKey(new_name, recovered_PK, new_km) {
-                t.Errorf("Couldn't GetInternalKeyFromEccPublicKey\n")
-                return
-        }
-        PrintKey(new_km)
-        fmt.Printf("\n")
+	new_km := new(certprotos.KeyMessage)
+	if !GetInternalKeyFromEccPublicKey(new_name, recovered_PK, new_km) {
+		t.Errorf("Couldn't GetInternalKeyFromEccPublicKey\n")
+		return
+	}
+	PrintKey(new_km)
+	fmt.Printf("\n")
 
-        ttt :=  make([]byte, 32)
-        for i := 0; i < 32; i++ {
-                ttt[i] = byte(i)
-        }
-        fmt.Printf("One (%d): ", len(ttt[0:31]))
-        PrintBytes(ttt[0:31])
-        fmt.Printf("\n")
-        fmt.Printf("Two (%d): ", len(ttt[0:32]))
-        PrintBytes(ttt[0:32])
-        fmt.Printf("\n")
+	ttt := make([]byte, 32)
+	for i := 0; i < 32; i++ {
+		ttt[i] = byte(i)
+	}
+	fmt.Printf("One (%d): ", len(ttt[0:31]))
+	PrintBytes(ttt[0:31])
+	fmt.Printf("\n")
+	fmt.Printf("Two (%d): ", len(ttt[0:32]))
+	PrintBytes(ttt[0:32])
+	fmt.Printf("\n")
 }
 
 func TestPEM(t *testing.T) {
-        fmt.Printf("\nTestPEM\n")
+	fmt.Printf("\nTestPEM\n")
 
-        certFile := "vse.crt"
-        certPem, err := os.ReadFile(certFile)
-        if err != nil  || certPem == nil {
-                return // Todo: Remove
-                t.Errorf("Can't read pem cert file\n")
-                return
-        }
-        stripped := StripPemHeaderAndTrailer(string(certPem))
-        if stripped == nil {
-                t.Errorf("No headers?\n")
-                return
-        }
-        fmt.Printf("PEM: %s\n", *stripped)
-        k := KeyFromPemFormat(*stripped)
-        if  k == nil {
-                t.Errorf("Can't retrieve key from pem cert\n")
-                return
-        }
-        fmt.Printf("Key from pem cert\n")
-        PrintKey(k)
-        fmt.Printf("\n")
+	certFile := "vse.crt"
+	certPem, err := os.ReadFile(certFile)
+	if err != nil || certPem == nil {
+		return // Todo: Remove
+		t.Errorf("Can't read pem cert file\n")
+		return
+	}
+	stripped := StripPemHeaderAndTrailer(string(certPem))
+	if stripped == nil {
+		t.Errorf("No headers?\n")
+		return
+	}
+	fmt.Printf("PEM: %s\n", *stripped)
+	k := KeyFromPemFormat(*stripped)
+	if k == nil {
+		t.Errorf("Can't retrieve key from pem cert\n")
+		return
+	}
+	fmt.Printf("Key from pem cert\n")
+	PrintKey(k)
+	fmt.Printf("\n")
 }
 
 func TestPlatformPrimitives(t *testing.T) {
-        fmt.Print("\nTestPlatformPrimitives\n")
+	fmt.Print("\nTestPlatformPrimitives\n")
 
-        t1 := "amd-sev-snp"
-        props := &certprotos.Properties{}
-        name := "debug"
-        t2 := "string"
-        t3 := "int"
-        sv := "no"
-        c := "="
-        iv := uint64(5)
-        p1 :=  MakeProperty(name, t2, &sv, &c, nil)
-        if p1 != nil {
-                props.Props = append(props.Props, p1)
-        }
-        name2 := "api-major"
-        p2 :=  MakeProperty(name2, t3, nil, &c, &iv)
-        if p2 != nil {
-                props.Props = append(props.Props, p2)
-        }
+	t1 := "amd-sev-snp"
+	props := &certprotos.Properties{}
+	name := "debug"
+	t2 := "string"
+	t3 := "int"
+	sv := "no"
+	c := "="
+	iv := uint64(5)
+	p1 := MakeProperty(name, t2, &sv, &c, nil)
+	if p1 != nil {
+		props.Props = append(props.Props, p1)
+	}
+	name2 := "api-major"
+	p2 := MakeProperty(name2, t3, nil, &c, &iv)
+	if p2 != nil {
+		props.Props = append(props.Props, p2)
+	}
 
-        pl := MakePlatform(t1, nil, props)
-        PrintPlatform(pl);
+	pl := MakePlatform(t1, nil, props)
+	PrintPlatform(pl)
 
-        measurement := []byte {
-                0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,
-                16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,
-        }
-        e := MakeEnvironment(pl, measurement)
-        if e == nil {
-                fmt.Printf("Can't make environment\n")
-        } else {
-                PrintEnvironment(e)
-        }
+	measurement := []byte{
+		0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
+		16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
+	}
+	e := MakeEnvironment(pl, measurement)
+	if e == nil {
+		fmt.Printf("Can't make environment\n")
+	} else {
+		PrintEnvironment(e)
+	}
 
-        pe := MakePlatformEntity(pl)
-        ee := MakeEnvironmentEntity(e)
-        PrintEntity(pe)
-        PrintEntity(ee)
+	pe := MakePlatformEntity(pl)
+	ee := MakeEnvironmentEntity(e)
+	PrintEntity(pe)
+	PrintEntity(ee)
 
-        fmt.Printf("\n\nDescriptors:\n")
-        PrintEntityDescriptor(ee);
-        fmt.Printf("\n")
-        PrintEntityDescriptor(pe);
-        fmt.Printf("\n\n")
+	fmt.Printf("\n\nDescriptors:\n")
+	PrintEntityDescriptor(ee)
+	fmt.Printf("\n")
+	PrintEntityDescriptor(pe)
+	fmt.Printf("\n\n")
 
-        if !SameProperty(p1, p1) {
-                t.Errorf("Properties should match\n")
-        }
-        if SameProperty(p1, p2) {
-                t.Errorf("Properties shouldn't match\n")
-        }
-        if !SameEnvironment(e, e) {
-                t.Errorf("Environments should match\n")
-        }
+	if !SameProperty(p1, p1) {
+		t.Errorf("Properties should match\n")
+	}
+	if SameProperty(p1, p2) {
+		t.Errorf("Properties shouldn't match\n")
+	}
+	if !SameEnvironment(e, e) {
+		t.Errorf("Environments should match\n")
+	}
 
-        pl2 := &certprotos.Platform {
-                HasKey: pl.HasKey,
-                PlatformType: pl.PlatformType,
-                AttestKey: pl.AttestKey,
-                Props: pl.Props,
-        }
-        if !SamePlatform(pl, pl2) {
-                t.Errorf("Platforms should match\n")
-        }
-        pl3, _ := proto.Clone(pl).(*certprotos.Platform)
-        if !SamePlatform(pl, pl3) {
-                t.Errorf("Platforms should match\n")
-        }
+	pl2 := &certprotos.Platform{
+		HasKey:       pl.HasKey,
+		PlatformType: pl.PlatformType,
+		AttestKey:    pl.AttestKey,
+		Props:        pl.Props,
+	}
+	if !SamePlatform(pl, pl2) {
+		t.Errorf("Platforms should match\n")
+	}
+	pl3, _ := proto.Clone(pl).(*certprotos.Platform)
+	if !SamePlatform(pl, pl3) {
+		t.Errorf("Platforms should match\n")
+	}
 
-        if !SatisfyingProperty(p1, p1) {
-                t.Errorf("Properties should satisfy (1)\n")
-        }
-        if SatisfyingProperty(p1, p2) {
-                t.Errorf("Properties shouldn't satisfy (1)\n")
-        }
-        properties := &certprotos.Properties{}
-        properties.Props = append(properties.Props,p1)
-        properties.Props = append(properties.Props, p2)
-        if !SameProperties(properties, properties) {
-                t.Errorf("Series of properties shouldn't match (2)\n")
-        }
-        if !SatisfyingProperties(properties, properties) {
-                t.Errorf("Series of properties shouldn't satisfy (2)\n")
-        }
+	if !SatisfyingProperty(p1, p1) {
+		t.Errorf("Properties should satisfy (1)\n")
+	}
+	if SatisfyingProperty(p1, p2) {
+		t.Errorf("Properties shouldn't satisfy (1)\n")
+	}
+	properties := &certprotos.Properties{}
+	properties.Props = append(properties.Props, p1)
+	properties.Props = append(properties.Props, p2)
+	if !SameProperties(properties, properties) {
+		t.Errorf("Series of properties shouldn't match (2)\n")
+	}
+	if !SatisfyingProperties(properties, properties) {
+		t.Errorf("Series of properties shouldn't satisfy (2)\n")
+	}
 
-        c3 := ">="
-        p3 := MakeProperty(name2, t3, nil, &c3, &iv)
-        props2 := &certprotos.Properties{}
-        if p1 != nil {
-                props2.Props = append(props2.Props, p1)
-        }
-        if p3 != nil {
-                props2.Props = append(props2.Props, p3)
-        }
-        if !SatisfyingProperty(p3, p2) {
-                t.Errorf("Properties should satisfy (3)\n")
-                fmt.Printf("First\n")
-                PrintProperty(p3)
-                fmt.Printf("\n\n")
-                fmt.Printf("Second\n")
-                PrintProperty(p2)
-                fmt.Printf("\n\n")
-        }
-        if SatisfyingProperty(p2, p3) {
-                t.Errorf("Properties should satisfy (3)\n")
-                fmt.Printf("First\n")
-                PrintProperty(p3)
-                fmt.Printf("\n\n")
-                fmt.Printf("Second\n")
-                PrintProperty(p2)
-                fmt.Printf("\n\n")
-        }
-        if !SatisfyingProperties(props2, props) {
-                t.Errorf("Series of properties shouldn't satisfy (3)\n")
-                fmt.Printf("First List\n")
-                PrintProperties(props)
-                fmt.Printf("\n\n")
-                fmt.Printf("Second List\n")
-                PrintProperties(props2)
-                fmt.Printf("\n\n")
-        }
+	c3 := ">="
+	p3 := MakeProperty(name2, t3, nil, &c3, &iv)
+	props2 := &certprotos.Properties{}
+	if p1 != nil {
+		props2.Props = append(props2.Props, p1)
+	}
+	if p3 != nil {
+		props2.Props = append(props2.Props, p3)
+	}
+	if !SatisfyingProperty(p3, p2) {
+		t.Errorf("Properties should satisfy (3)\n")
+		fmt.Printf("First\n")
+		PrintProperty(p3)
+		fmt.Printf("\n\n")
+		fmt.Printf("Second\n")
+		PrintProperty(p2)
+		fmt.Printf("\n\n")
+	}
+	if SatisfyingProperty(p2, p3) {
+		t.Errorf("Properties should satisfy (3)\n")
+		fmt.Printf("First\n")
+		PrintProperty(p3)
+		fmt.Printf("\n\n")
+		fmt.Printf("Second\n")
+		PrintProperty(p2)
+		fmt.Printf("\n\n")
+	}
+	if !SatisfyingProperties(props2, props) {
+		t.Errorf("Series of properties shouldn't satisfy (3)\n")
+		fmt.Printf("First List\n")
+		PrintProperties(props)
+		fmt.Printf("\n\n")
+		fmt.Printf("Second List\n")
+		PrintProperties(props2)
+		fmt.Printf("\n\n")
+	}
 
-/*
-          uint64_t    policy;                   // 0x008
-          uint8_t     report_data[64];          // 0x050
-          uint8_t     measurement[48];          // 0x090
-          union tcb_version reported_tcb;       // 0x180
-        };
-*/
-        var ar[0x2A0] byte
-        fakeSevAtt := []byte(ar[0:0x2a0])
-        for i := 0; i < 0x2A0; i++ {
-                fakeSevAtt[i] = 0
-        }
-        fakeSevAtt[8] = 0xff
-        fakeSevAtt[0x50] = 0x01
-        fakeSevAtt[0x51] = 0x01
-        fakeSevAtt[0x52] = 0x01
-        fakeSevAtt[0x53] = 0x01
-        for i := 0; i < 48; i++ {
-                fakeSevAtt[i + 0x90] = byte(i)
-        }
-        m := GetMeasurementFromSevAttest(fakeSevAtt)
-        if m == nil {
-                t.Errorf("Can't get measurement")
-        } else {
-                fmt.Printf("Measurement: ")
-                PrintBytes(m)
-                fmt.Printf("\n")
-        }
-        ud := GetUserDataHashFromSevAttest(fakeSevAtt)
-        if ud == nil {
-                t.Errorf("Can't get user data")
-        } else {
-                fmt.Printf("User data: ")
-                PrintBytes(ud)
-                fmt.Printf("\n")
-        }
-        plat := GetPlatformFromSevAttest(fakeSevAtt)
-        if plat == nil {
-                t.Errorf("Can't get platform")
-        } else {
-                PrintPlatform(plat)
-                fmt.Printf("\n")
-        }
+	/*
+	     uint64_t    policy;                   // 0x008
+	     uint8_t     report_data[64];          // 0x050
+	     uint8_t     measurement[48];          // 0x090
+	     union tcb_version reported_tcb;       // 0x180
+	   };
+	*/
+	var ar [0x2A0]byte
+	fakeSevAtt := []byte(ar[0:0x2a0])
+	for i := 0; i < 0x2A0; i++ {
+		fakeSevAtt[i] = 0
+	}
+	fakeSevAtt[8] = 0xff
+	fakeSevAtt[0x50] = 0x01
+	fakeSevAtt[0x51] = 0x01
+	fakeSevAtt[0x52] = 0x01
+	fakeSevAtt[0x53] = 0x01
+	for i := 0; i < 48; i++ {
+		fakeSevAtt[i+0x90] = byte(i)
+	}
+	m := GetMeasurementFromSevAttest(fakeSevAtt)
+	if m == nil {
+		t.Errorf("Can't get measurement")
+	} else {
+		fmt.Printf("Measurement: ")
+		PrintBytes(m)
+		fmt.Printf("\n")
+	}
+	ud := GetUserDataHashFromSevAttest(fakeSevAtt)
+	if ud == nil {
+		t.Errorf("Can't get user data")
+	} else {
+		fmt.Printf("User data: ")
+		PrintBytes(ud)
+		fmt.Printf("\n")
+	}
+	plat := GetPlatformFromSevAttest(fakeSevAtt)
+	if plat == nil {
+		t.Errorf("Can't get platform")
+	} else {
+		PrintPlatform(plat)
+		fmt.Printf("\n")
+	}
 
 }
 

--- a/certifier_service/certlib/certlib_proofs.go
+++ b/certifier_service/certlib/certlib_proofs.go
@@ -16,21 +16,21 @@ package certlib
 
 import (
 	"bytes"
+	"crypto/ecdsa"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/sha512"
+	"crypto/x509"
 	"errors"
 	"fmt"
-	"math/big"
-	"crypto/ecdsa"
-	"crypto/rsa"
-	"crypto/sha512"
-	"crypto/sha256"
-	"crypto/x509"
-	"crypto/rand"
-	"os"
-	"google.golang.org/protobuf/proto"
-	certprotos    "github.com/vmware-research/certifier-framework-for-confidential-computing/certifier_service/certprotos"
-	oeverify      "github.com/vmware-research/certifier-framework-for-confidential-computing/certifier_service/oeverify"
+	certprotos "github.com/vmware-research/certifier-framework-for-confidential-computing/certifier_service/certprotos"
 	gramineverify "github.com/vmware-research/certifier-framework-for-confidential-computing/certifier_service/gramineverify"
-	isletverify     "github.com/vmware-research/certifier-framework-for-confidential-computing/certifier_service/isletverify"
+	isletverify "github.com/vmware-research/certifier-framework-for-confidential-computing/certifier_service/isletverify"
+	oeverify "github.com/vmware-research/certifier-framework-for-confidential-computing/certifier_service/oeverify"
+	"google.golang.org/protobuf/proto"
+	"math/big"
+	"os"
 )
 
 func testSign(PK1 *ecdsa.PublicKey) {
@@ -53,7 +53,7 @@ func testSign(PK1 *ecdsa.PublicKey) {
 		fmt.Printf("testSign: Can't convertkey\n")
 		return
 	}
-	toHash := []byte{1,2,3,4,5,6,7,8,9}
+	toHash := []byte{1, 2, 3, 4, 5, 6, 7, 8, 9}
 	hashed := sha256.Sum256(toHash)
 
 	signed, err := ecdsa.SignASN1(rand.Reader, pK, hashed[:])
@@ -80,23 +80,22 @@ func testSign(PK1 *ecdsa.PublicKey) {
 	fmt.Printf("\n")
 }
 
-
 func InitAxiom(pk certprotos.KeyMessage, ps *certprotos.ProvedStatements) bool {
 	// add pk is-trusted to proved statenments
 	ke := MakeKeyEntity(&pk)
 	ist := "is-trusted"
-	vc :=  MakeUnaryVseClause(ke, &ist)
+	vc := MakeUnaryVseClause(ke, &ist)
 	ps.Proved = append(ps.Proved, vc)
 	return true
 }
 
 func FilterOePolicy(policyKey *certprotos.KeyMessage, evp *certprotos.EvidencePackage,
-		original *certprotos.ProvedStatements) *certprotos.ProvedStatements {
+	original *certprotos.ProvedStatements) *certprotos.ProvedStatements {
 	// Todo: Fix
-        filtered :=  &certprotos.ProvedStatements {}
+	filtered := &certprotos.ProvedStatements{}
 	for i := 0; i < len(original.Proved); i++ {
 		from := original.Proved[i]
-		to :=  proto.Clone(from).(*certprotos.VseClause)
+		to := proto.Clone(from).(*certprotos.VseClause)
 		filtered.Proved = append(filtered.Proved, to)
 	}
 
@@ -104,13 +103,13 @@ func FilterOePolicy(policyKey *certprotos.KeyMessage, evp *certprotos.EvidencePa
 }
 
 func FilterInternalPolicy(policyKey *certprotos.KeyMessage, evp *certprotos.EvidencePackage,
-		original *certprotos.ProvedStatements) *certprotos.ProvedStatements {
+	original *certprotos.ProvedStatements) *certprotos.ProvedStatements {
 
 	// Todo: Fix.  Normally the policy used for tests need not be filtered, but we should do it anyway.
-        filtered :=  &certprotos.ProvedStatements {}
+	filtered := &certprotos.ProvedStatements{}
 	for i := 0; i < len(original.Proved); i++ {
 		from := original.Proved[i]
-		to :=  proto.Clone(from).(*certprotos.VseClause)
+		to := proto.Clone(from).(*certprotos.VseClause)
 		filtered.Proved = append(filtered.Proved, to)
 	}
 
@@ -118,9 +117,9 @@ func FilterInternalPolicy(policyKey *certprotos.KeyMessage, evp *certprotos.Evid
 }
 
 func FilterSevPolicy(policyKey *certprotos.KeyMessage, evp *certprotos.EvidencePackage,
-		original *certprotos.ProvedStatements) *certprotos.ProvedStatements {
-	n := len(evp.FactAssertion);
-	ev := evp.FactAssertion[n - 1]
+	original *certprotos.ProvedStatements) *certprotos.ProvedStatements {
+	n := len(evp.FactAssertion)
+	ev := evp.FactAssertion[n-1]
 	if ev.GetEvidenceType() != "sev-attestation" {
 		fmt.Printf("FilterPolicy: sev attestation expected\n")
 		return nil
@@ -206,10 +205,10 @@ func FilterSevPolicy(policyKey *certprotos.KeyMessage, evp *certprotos.EvidenceP
 		return nil
 	}
 	return alreadyProved
- }
+}
 
 func InitPolicy(publicPolicyKey *certprotos.KeyMessage, signedPolicy *certprotos.SignedClaimSequence,
-		alreadyProved *certprotos.ProvedStatements) bool {
+	alreadyProved *certprotos.ProvedStatements) bool {
 	if publicPolicyKey == nil {
 		fmt.Printf("Policy key empty\n")
 		return false
@@ -230,21 +229,21 @@ func InitPolicy(publicPolicyKey *certprotos.KeyMessage, signedPolicy *certprotos
 			fmt.Printf("Not vse claim\n")
 			return false
 		}
-		vse := &certprotos.VseClause {}
+		vse := &certprotos.VseClause{}
 		err = proto.Unmarshal(cm.SerializedClaim, vse)
 		if err != nil {
 			fmt.Printf("Can't unmarshal vse claim\n")
 			return false
 		}
-		alreadyProved.Proved = append(alreadyProved.Proved , vse)
+		alreadyProved.Proved = append(alreadyProved.Proved, vse)
 	}
 	return true
 }
 
 func InitProvedStatements(pk certprotos.KeyMessage, evidenceList []*certprotos.Evidence,
-		ps *certprotos.ProvedStatements) bool {
+	ps *certprotos.ProvedStatements) bool {
 
-	seenList := new (CertSeenList)
+	seenList := new(CertSeenList)
 	seenList.maxSize = 30
 	seenList.size = 0
 
@@ -253,7 +252,7 @@ func InitProvedStatements(pk certprotos.KeyMessage, evidenceList []*certprotos.E
 
 	for i := 0; i < len(evidenceList); i++ {
 		ev := evidenceList[i]
-		if  ev.GetEvidenceType() == "signed-claim" {
+		if ev.GetEvidenceType() == "signed-claim" {
 			signedClaim := certprotos.SignedClaimMessage{}
 			err := proto.Unmarshal(ev.SerializedEvidence, &signedClaim)
 			if err != nil {
@@ -273,7 +272,7 @@ func InitProvedStatements(pk certprotos.KeyMessage, evidenceList []*certprotos.E
 		} else if ev.GetEvidenceType() == "pem-cert-chain" {
 			// nothing to do
 		} else if ev.GetEvidenceType() == "gramine-attestation" {
-			succeeded, serializedUD, m, err  := VerifyGramineAttestation(ev.SerializedEvidence)
+			succeeded, serializedUD, m, err := VerifyGramineAttestation(ev.SerializedEvidence)
 			if !succeeded || err != nil {
 				fmt.Printf("InitProvedStatements: Can't verify gramine evidence\n")
 				return false
@@ -298,12 +297,12 @@ func InitProvedStatements(pk certprotos.KeyMessage, evidenceList []*certprotos.E
 			// Ignore SGX TCB level check for now
 			var serializedUD, m []byte
 			var err error
-			if i < 1  || evidenceList[i-1].GetEvidenceType() != "pem-cert-chain" {
+			if i < 1 || evidenceList[i-1].GetEvidenceType() != "pem-cert-chain" {
 				// No endorsement presented
-				serializedUD, m, err  = oeverify.OEHostVerifyEvidence(evidenceList[i].SerializedEvidence,
+				serializedUD, m, err = oeverify.OEHostVerifyEvidence(evidenceList[i].SerializedEvidence,
 					nil, false)
 			} else {
-				serializedUD, m, err  = oeverify.OEHostVerifyEvidence(evidenceList[i].SerializedEvidence,
+				serializedUD, m, err = oeverify.OEHostVerifyEvidence(evidenceList[i].SerializedEvidence,
 					evidenceList[i-1].SerializedEvidence, false)
 			}
 			if err != nil || serializedUD == nil || m == nil {
@@ -335,7 +334,7 @@ func InitProvedStatements(pk certprotos.KeyMessage, evidenceList []*certprotos.E
 		} else if ev.GetEvidenceType() == "islet-attestation" {
 			n := 1
 			if ps.Proved[n] == nil || ps.Proved[n].Clause == nil ||
-					ps.Proved[n].Clause.Subject == nil {
+				ps.Proved[n].Clause.Subject == nil {
 				fmt.Printf("InitProvedStatements: Can't get attestKey key (1)\n")
 				return false
 			}
@@ -390,7 +389,7 @@ func InitProvedStatements(pk certprotos.KeyMessage, evidenceList []*certprotos.E
 		} else if ev.GetEvidenceType() == "keystone-attestation" {
 			n := 1
 			if ps.Proved[n] == nil || ps.Proved[n].Clause == nil ||
-					ps.Proved[n].Clause.Subject == nil {
+				ps.Proved[n].Clause.Subject == nil {
 				fmt.Printf("InitProvedStatements: Can't get attestKey key (1)\n")
 				return false
 			}
@@ -450,7 +449,7 @@ func InitProvedStatements(pk certprotos.KeyMessage, evidenceList []*certprotos.E
 				return false
 			}
 			if ps.Proved[n] == nil || ps.Proved[n].Clause == nil ||
-					ps.Proved[n].Clause.Subject == nil {
+				ps.Proved[n].Clause.Subject == nil {
 				fmt.Printf("InitProvedStatements: Can't get vcek key (1)\n")
 				return false
 			}
@@ -552,7 +551,7 @@ func InitProvedStatements(pk certprotos.KeyMessage, evidenceList []*certprotos.E
 			certPool := x509.NewCertPool()
 			certPool.AddCert(cert)
 			opts := x509.VerifyOptions{
-				Roots:   certPool,
+				Roots: certPool,
 			}
 			if _, err := cert.Verify(opts); err != nil {
 				fmt.Printf("InitProvedStatements: Cert.Vertify fails\n")
@@ -560,30 +559,30 @@ func InitProvedStatements(pk certprotos.KeyMessage, evidenceList []*certprotos.E
 			}
 
 			/*
-			// This code will replace the above eventually
-			if signerKey.GetName() == subjKey.GetKeyName {
-				err := cert.CheckSignatureFrom(cert)
-				if err != nil {
-					fmt.Printf("InitProvedStatements: parent signature check fails\n")
-					return false
+				// This code will replace the above eventually
+				if signerKey.GetName() == subjKey.GetKeyName {
+					err := cert.CheckSignatureFrom(cert)
+					if err != nil {
+						fmt.Printf("InitProvedStatements: parent signature check fails\n")
+						return false
+					}
+				} else {
+					if i <= 0 {
+						fmt.Printf("InitProvedStatements: No parent cert\n")
+						return false
+					}
+					parentCert := Asn1ToX509(evidenceList[i - 1].SerializedEvidence)
+					if parentCert == nil {
+						fmt.Printf("InitProvedStatements: Can't convert parent cert\n")
+						return false
+					}
+					err := cert.CheckSignatureFrom(parentCert)
+					if err != nil {
+						fmt.Printf("InitProvedStatements: parent signature check fails\n")
+						return false
+					}
 				}
-			} else {
-				if i <= 0 {
-					fmt.Printf("InitProvedStatements: No parent cert\n")
-					return false
-				}
-				parentCert := Asn1ToX509(evidenceList[i - 1].SerializedEvidence)
-				if parentCert == nil {
-					fmt.Printf("InitProvedStatements: Can't convert parent cert\n")
-					return false
-				}
-				err := cert.CheckSignatureFrom(parentCert)
-				if err != nil {
-					fmt.Printf("InitProvedStatements: parent signature check fails\n")
-					return false
-				}
-			}
-			 */
+			*/
 
 			cl := ConstructVseAttestationFromCert(subjKey, signerKey)
 			if cl == nil {
@@ -620,7 +619,7 @@ func InitProvedStatements(pk certprotos.KeyMessage, evidenceList []*certprotos.E
 			} else {
 				fmt.Printf("InitProvedStatements: vse-attestation-report fails to verify\n")
 				return false
-                        }
+			}
 		} else {
 			fmt.Printf("Unknown evidence type\n")
 			return false
@@ -630,31 +629,31 @@ func InitProvedStatements(pk certprotos.KeyMessage, evidenceList []*certprotos.E
 }
 
 func InitCerifierRules(cr *certprotos.CertifierRules) bool {
-/*
-	Certifier proofs
+	/*
+		Certifier proofs
 
-	rule 1 (R1): If measurement is-trusted and key1 speaks-for measurement then
-		key1 is-trusted-for-authentication.
-	rule 2 (R2): If key2 speaks-for key1 and key3 speaks-for key2 then key3 speaks-for key1
-	rule 3 (R3): If key1 is-trusted and key1 says X, then X is true
-	rule 4 (R4): If key2 speaks-for key1 and key1 is-trusted then key2 is-trusted
-	rule 5 (R5): If key1 is-trustedXXX and key1 says key2 is-trustedYYY then key2 is-trustedYYY
-		provided is-trustedXXX dominates is-trustedYYY
-	rule 6 (R6): if key1 is-trustedXXX and key1 says key2 speaks-for measurement then
-		key2 speaks-for measurement provided is-trustedXXX dominates is-trusted-for-attestation 
-	rule 7 (R7): If measurement is-trusted and key1 speaks-for measurement then
-		key1 is-trusted-for-attestation.
-	rule 8 (R8): If environment[platform, measurement] is-environment AND platform-template
-		has-trusted-platform-property then environment[platform, measurement]
-		environment-platform-is-trusted provided platform properties satisfy platform template
-	rule 9 (R9): If environment[platform, measurement] is-environment AND measurement is-trusted then
-		environment[platform, measurement] environment-measurement is-trusted
-	rule 10 (R10): If environment[platform, measurement] environment-platform-is-trusted AND
-		environment[platform, measurement] environment-measurement-is-trusted then
-		environment[platform, measurement] is-trusted
- */
+		rule 1 (R1): If measurement is-trusted and key1 speaks-for measurement then
+			key1 is-trusted-for-authentication.
+		rule 2 (R2): If key2 speaks-for key1 and key3 speaks-for key2 then key3 speaks-for key1
+		rule 3 (R3): If key1 is-trusted and key1 says X, then X is true
+		rule 4 (R4): If key2 speaks-for key1 and key1 is-trusted then key2 is-trusted
+		rule 5 (R5): If key1 is-trustedXXX and key1 says key2 is-trustedYYY then key2 is-trustedYYY
+			provided is-trustedXXX dominates is-trustedYYY
+		rule 6 (R6): if key1 is-trustedXXX and key1 says key2 speaks-for measurement then
+			key2 speaks-for measurement provided is-trustedXXX dominates is-trusted-for-attestation
+		rule 7 (R7): If measurement is-trusted and key1 speaks-for measurement then
+			key1 is-trusted-for-attestation.
+		rule 8 (R8): If environment[platform, measurement] is-environment AND platform-template
+			has-trusted-platform-property then environment[platform, measurement]
+			environment-platform-is-trusted provided platform properties satisfy platform template
+		rule 9 (R9): If environment[platform, measurement] is-environment AND measurement is-trusted then
+			environment[platform, measurement] environment-measurement is-trusted
+		rule 10 (R10): If environment[platform, measurement] environment-platform-is-trusted AND
+			environment[platform, measurement] environment-measurement-is-trusted then
+			environment[platform, measurement] is-trusted
+	*/
 
-	return true;
+	return true
 }
 
 func PrintProofStep(prefix string, step *certprotos.ProofStep) {
@@ -700,9 +699,8 @@ func AddFactFromSignedClaim(signedClaim *certprotos.SignedClaimMessage,
 	return true
 }
 
-
 func ProducePlatformRule(issuerKey *certprotos.KeyMessage, issuerCert *x509.Certificate,
-		subjKey *certprotos.KeyMessage, durationSeconds float64) []byte {
+	subjKey *certprotos.KeyMessage, durationSeconds float64) []byte {
 
 	// Return signed claim: issuer-Key says subjKey is-trusted-for-attestation
 	s1 := MakeKeyEntity(subjKey)
@@ -710,7 +708,7 @@ func ProducePlatformRule(issuerKey *certprotos.KeyMessage, issuerCert *x509.Cert
 		return nil
 	}
 	isTrustedForAttest := "is-trusted-for-attestation"
-	c1 :=  MakeUnaryVseClause(s1, &isTrustedForAttest)
+	c1 := MakeUnaryVseClause(s1, &isTrustedForAttest)
 	if c1 == nil {
 		return nil
 	}
@@ -730,7 +728,7 @@ func ProducePlatformRule(issuerKey *certprotos.KeyMessage, issuerCert *x509.Cert
 	}
 
 	tn := TimePointNow()
-	tf := TimePointPlus(tn, 365 * 86400)
+	tf := TimePointPlus(tn, 365*86400)
 	nb := TimePointToString(tn)
 	na := TimePointToString(tf)
 	ser, err := proto.Marshal(c2)
@@ -755,7 +753,7 @@ func ProducePlatformRule(issuerKey *certprotos.KeyMessage, issuerCert *x509.Cert
 }
 
 func ConstructVseAttestClaim(attestKey *certprotos.KeyMessage, enclaveKey *certprotos.KeyMessage,
-		measurement []byte) *certprotos.VseClause {
+	measurement []byte) *certprotos.VseClause {
 	am := MakeKeyEntity(attestKey)
 	if am == nil {
 		fmt.Printf("ConstructVseAttestClaim: Can't make attest entity\n")
@@ -823,7 +821,6 @@ func ConstructOESpeaksForStatement(vcertKey *certprotos.KeyMessage, enclaveKey *
 	return MakeIndirectVseClause(vcertKeyEntity, &says_verb, tcl)
 }
 
-
 // vcek says environment is-environment
 func ConstructSevIsEnvironmentStatement(vcekKey *certprotos.KeyMessage, binSevAttest []byte) *certprotos.VseClause {
 	plat := GetPlatformFromSevAttest(binSevAttest)
@@ -836,8 +833,8 @@ func ConstructSevIsEnvironmentStatement(vcekKey *certprotos.KeyMessage, binSevAt
 		fmt.Printf("ConstructSevIsEnvironmentStatement: can't get measurement\n")
 		return nil
 	}
-	e := &certprotos.Environment {
-		ThePlatform: plat,
+	e := &certprotos.Environment{
+		ThePlatform:    plat,
 		TheMeasurement: m,
 	}
 	isEnvVerb := "is-environment"
@@ -846,9 +843,9 @@ func ConstructSevIsEnvironmentStatement(vcekKey *certprotos.KeyMessage, binSevAt
 		fmt.Printf("ConstructSevIsEnvironmentStatement: can't make environment entity\n")
 		return nil
 	}
-	vse := &certprotos.VseClause {
+	vse := &certprotos.VseClause{
 		Subject: ee,
-		Verb: &isEnvVerb,
+		Verb:    &isEnvVerb,
 	}
 	ke := MakeKeyEntity(vcekKey)
 	if ke == nil {
@@ -856,27 +853,27 @@ func ConstructSevIsEnvironmentStatement(vcekKey *certprotos.KeyMessage, binSevAt
 		return nil
 	}
 	saysVerb := "says"
-	vseSays := &certprotos.VseClause {
-                Subject: ke,
-                Verb: &saysVerb,
-		Clause: vse,
-        }
+	vseSays := &certprotos.VseClause{
+		Subject: ke,
+		Verb:    &saysVerb,
+		Clause:  vse,
+	}
 	return vseSays
 }
 
 // vcekKey says enclaveKey speaksfor environment
 func ConstructSevSpeaksForEnvironmentStatement(vcekKey *certprotos.KeyMessage, enclaveKey *certprotos.KeyMessage,
-		env *certprotos.EntityMessage) *certprotos.VseClause {
+	env *certprotos.EntityMessage) *certprotos.VseClause {
 	eke := MakeKeyEntity(enclaveKey)
 	if eke == nil {
 		fmt.Printf("ConstructSevIsEnvironmentStatement: can't make enclave key entity\n")
 		return nil
 	}
 	speaksForVerb := "speaks-for"
-	vseSpeaksFor := &certprotos.VseClause {
+	vseSpeaksFor := &certprotos.VseClause{
 		Subject: eke,
-		Verb: &speaksForVerb,
-		Object: env,
+		Verb:    &speaksForVerb,
+		Object:  env,
 	}
 	ke := MakeKeyEntity(vcekKey)
 	if ke == nil {
@@ -884,11 +881,11 @@ func ConstructSevSpeaksForEnvironmentStatement(vcekKey *certprotos.KeyMessage, e
 		return nil
 	}
 	saysVerb := "says"
-	vseSays := &certprotos.VseClause {
-                Subject: ke,
-                Verb: &saysVerb,
-		Clause: vseSpeaksFor,
-        }
+	vseSays := &certprotos.VseClause{
+		Subject: ke,
+		Verb:    &saysVerb,
+		Clause:  vseSpeaksFor,
+	}
 	return vseSays
 }
 
@@ -902,7 +899,7 @@ func ConstructEnclaveKeySpeaksForMeasurement(k *certprotos.KeyMessage, m []byte)
 		return nil
 	}
 	speaks_for := "speaks-for"
-        return MakeSimpleVseClause(e1, &speaks_for, e2)
+	return MakeSimpleVseClause(e1, &speaks_for, e2)
 }
 
 /*
@@ -910,17 +907,17 @@ func ConstructEnclaveKeySpeaksForMeasurement(k *certprotos.KeyMessage, m []byte)
 
 // attestKey says enclaveKey speaksfor environment
 func ConstructIsletSpeaksForMeasurementStatement(attestKey *certprotos.KeyMessage, enclaveKey *certprotos.KeyMessage,
-		mEnt *certprotos.EntityMessage) *certprotos.VseClause {
+	mEnt *certprotos.EntityMessage) *certprotos.VseClause {
 	eke := MakeKeyEntity(enclaveKey)
 	if eke == nil {
 		fmt.Printf("ConstructIsletIsEnvironmentStatement: can't make enclave key entity\n")
 		return nil
 	}
 	speaksForVerb := "speaks-for"
-	vseSpeaksFor := &certprotos.VseClause {
+	vseSpeaksFor := &certprotos.VseClause{
 		Subject: eke,
-		Verb: &speaksForVerb,
-		Object: mEnt,
+		Verb:    &speaksForVerb,
+		Object:  mEnt,
 	}
 	ke := MakeKeyEntity(attestKey)
 	if ke == nil {
@@ -928,27 +925,27 @@ func ConstructIsletSpeaksForMeasurementStatement(attestKey *certprotos.KeyMessag
 		return nil
 	}
 	saysVerb := "says"
-	vseSays := &certprotos.VseClause {
-                Subject: ke,
-                Verb: &saysVerb,
-		Clause: vseSpeaksFor,
-        }
+	vseSays := &certprotos.VseClause{
+		Subject: ke,
+		Verb:    &saysVerb,
+		Clause:  vseSpeaksFor,
+	}
 	return vseSays
 }
 
 // attestKey says enclaveKey speaksfor environment
 func ConstructKeystoneSpeaksForMeasurementStatement(attestKey *certprotos.KeyMessage, enclaveKey *certprotos.KeyMessage,
-		mEnt *certprotos.EntityMessage) *certprotos.VseClause {
+	mEnt *certprotos.EntityMessage) *certprotos.VseClause {
 	eke := MakeKeyEntity(enclaveKey)
 	if eke == nil {
 		fmt.Printf("ConstructKeystoneIsEnvironmentStatement: can't make enclave key entity\n")
 		return nil
 	}
 	speaksForVerb := "speaks-for"
-	vseSpeaksFor := &certprotos.VseClause {
+	vseSpeaksFor := &certprotos.VseClause{
 		Subject: eke,
-		Verb: &speaksForVerb,
-		Object: mEnt,
+		Verb:    &speaksForVerb,
+		Object:  mEnt,
 	}
 	ke := MakeKeyEntity(attestKey)
 	if ke == nil {
@@ -956,11 +953,11 @@ func ConstructKeystoneSpeaksForMeasurementStatement(attestKey *certprotos.KeyMes
 		return nil
 	}
 	saysVerb := "says"
-	vseSays := &certprotos.VseClause {
-                Subject: ke,
-                Verb: &saysVerb,
-		Clause: vseSpeaksFor,
-        }
+	vseSays := &certprotos.VseClause{
+		Subject: ke,
+		Verb:    &saysVerb,
+		Clause:  vseSpeaksFor,
+	}
 	return vseSays
 }
 
@@ -1002,7 +999,7 @@ func GetUserDataHashFromSevAttest(binSevAttest []byte) []byte {
 		Bit 2: Debugging disallowed if 0
 		Bit 1: Migration disallowed if 0
 		Bit 0: SMT disallowed if 0
- */
+*/
 func GetPlatformFromSevAttest(binSevAttest []byte) *certprotos.Platform {
 
 	// get properties
@@ -1017,7 +1014,7 @@ func GetPlatformFromSevAttest(binSevAttest []byte) *certprotos.Platform {
 
 	pn0 := "single-socket"
 	vp0 := "no"
-	if pol_byte & 0x08  == 1 {
+	if pol_byte&0x08 == 1 {
 		vp0 = "yes"
 	}
 	p0 := MakeProperty(pn0, svt, &vp0, &ce, nil)
@@ -1025,7 +1022,7 @@ func GetPlatformFromSevAttest(binSevAttest []byte) *certprotos.Platform {
 
 	pn1 := "debug"
 	vp1 := "no"
-	if pol_byte & 0x04  == 1 {
+	if pol_byte&0x04 == 1 {
 		vp1 = "yes"
 	}
 	p1 := MakeProperty(pn1, svt, &vp1, &ce, nil)
@@ -1033,7 +1030,7 @@ func GetPlatformFromSevAttest(binSevAttest []byte) *certprotos.Platform {
 
 	pn2 := "smt"
 	vp2 := "no"
-	if pol_byte & 0x01  == 1 {
+	if pol_byte&0x01 == 1 {
 		vp2 = "yes"
 	}
 	p2 := MakeProperty(pn2, svt, &vp2, &ce, nil)
@@ -1041,7 +1038,7 @@ func GetPlatformFromSevAttest(binSevAttest []byte) *certprotos.Platform {
 
 	pn3 := "migrate"
 	vp3 := "no"
-	if pol_byte & 0x02  == 1 {
+	if pol_byte&0x02 == 1 {
 		vp3 = "yes"
 	}
 	p3 := MakeProperty(pn3, svt, &vp3, &ce, nil)
@@ -1056,7 +1053,6 @@ func GetPlatformFromSevAttest(binSevAttest []byte) *certprotos.Platform {
 	pn5 := "api-minor"
 	p5 := MakeProperty(pn5, ivt, nil, &ce, &m2iv)
 	props.Props = append(props.Props, p5)
-
 
 	tcb := uint64(binSevAttest[0x180])
 	tcb = (uint64(binSevAttest[0x181]) << 8) | tcb
@@ -1112,7 +1108,7 @@ func VerifyReport(etype string, pk *certprotos.KeyMessage, serialized []byte) bo
 	}
 
 	if RsaSha256Verify(&rPK, sr.Report, sr.Signature) {
-		return true;
+		return true
 	}
 	return false
 }
@@ -1136,7 +1132,7 @@ func VerifySevAttestation(serialized []byte, k *certprotos.KeyMessage) []byte {
 
 	// Get public key so we can check the attestation
 	_, PK, err := GetEccKeysFromInternal(k)
-	if err!= nil || PK == nil {
+	if err != nil || PK == nil {
 		fmt.Printf("VerifySevAttestation: Can't extract key.\n")
 		return nil
 	}
@@ -1166,9 +1162,9 @@ func VerifySevAttestation(serialized []byte, k *certprotos.KeyMessage) []byte {
 	hashOfHeader := sha512.Sum384(ptr[0:0x2a0])
 
 	sig := ptr[0x2a0:0x330]
-	rb := sig[0:48];
+	rb := sig[0:48]
 	sb := sig[72:120]
-	measurement := ptr[0x90: 0xc0]
+	measurement := ptr[0x90:0xc0]
 
 	// Debug
 	fmt.Printf("\nHashed report header: ")
@@ -1193,15 +1189,15 @@ func VerifySevAttestation(serialized []byte, k *certprotos.KeyMessage) []byte {
 	}
 
 	// Debug
-	fmt.Printf("  Reversed R: ");
+	fmt.Printf("  Reversed R: ")
 	PrintBytes(reversedR)
 	fmt.Printf("\n")
-	fmt.Printf("  Reversed S: ");
+	fmt.Printf("  Reversed S: ")
 	PrintBytes(reversedS)
 	fmt.Printf("\n")
 
-	r :=  new(big.Int).SetBytes(reversedR)
-	s :=  new(big.Int).SetBytes(reversedS)
+	r := new(big.Int).SetBytes(reversedR)
+	s := new(big.Int).SetBytes(reversedS)
 	if !ecdsa.Verify(PK, hashOfHeader[0:48], r, s) {
 		fmt.Printf("VerifySevAttestation: ecdsa.Verify failed\n")
 		return nil
@@ -1238,7 +1234,7 @@ func VerifySevAttestation(serialized []byte, k *certprotos.KeyMessage) []byte {
 		  struct sm_report_t sm;
 		  byte dev_public_key[PUBLIC_KEY_SIZE];
 		};
- */
+*/
 
 /*
  * Design approaches to explore and refine in future revs:
@@ -1287,24 +1283,24 @@ func VerifyIsletAttestation(serialized []byte, k *certprotos.KeyMessage) []byte 
 		return nil
 	}
 
-    /*
-     * This is the hard-coded measurement provided by Islet-shim.
-     *
-	measurement := []byte {
-		0x61, 0x90, 0xEB, 0x90, 0xB2, 0x93, 0x88, 0x6C,
-		0x17, 0x2E, 0xC6, 0x44, 0xDA, 0xFB, 0x7E, 0x33,
-		0xEE, 0x2C, 0xEA, 0x65, 0x41, 0xAB, 0xE1, 0x53,
-		0x00, 0xD9, 0x63, 0x80, 0xDF, 0x52, 0x5B, 0xF9,
-	}
-    */
+	/*
+		     * This is the hard-coded measurement provided by Islet-shim.
+		     *
+			measurement := []byte {
+				0x61, 0x90, 0xEB, 0x90, 0xB2, 0x93, 0x88, 0x6C,
+				0x17, 0x2E, 0xC6, 0x44, 0xDA, 0xFB, 0x7E, 0x33,
+				0xEE, 0x2C, 0xEA, 0x65, 0x41, 0xAB, 0xE1, 0x53,
+				0x00, 0xD9, 0x63, 0x80, 0xDF, 0x52, 0x5B, 0xF9,
+			}
+	*/
 	// return measurement
-    // Call the C-Go Islet verify function
-    m, err := isletverify.IsletVerify(am.WhatWasSaid, am.ReportedAttestation)
-    if err != nil {
-        fmt.Printf("VerifyIsletAttestation: IsletVerify() failed\n")
-        return nil
-    }
-    return m
+	// Call the C-Go Islet verify function
+	m, err := isletverify.IsletVerify(am.WhatWasSaid, am.ReportedAttestation)
+	if err != nil {
+		fmt.Printf("VerifyIsletAttestation: IsletVerify() failed\n")
+		return nil
+	}
+	return m
 }
 
 //	Returns measurement
@@ -1326,7 +1322,7 @@ func VerifyKeystoneAttestation(serialized []byte, k *certprotos.KeyMessage) []by
 
 	// Get public key so we can check the attestation
 	_, PK, err := GetEccKeysFromInternal(k)
-	if err!= nil || PK == nil {
+	if err != nil || PK == nil {
 		fmt.Printf("VerifyKeystoneAttestation: Can't extract key.\n")
 		return nil
 	}
@@ -1336,16 +1332,16 @@ func VerifyKeystoneAttestation(serialized []byte, k *certprotos.KeyMessage) []by
 		return nil
 	}
 	hashedWhatWasSaid := sha256.Sum256(am.WhatWasSaid)
-        reportData := ptr[72:104]
+	reportData := ptr[72:104]
 	if !bytes.Equal(reportData[:], hashedWhatWasSaid[:]) {
 		fmt.Printf("VerifyKeystoneAttestation: WhatWasSaid hash does not match data.\n")
 		return nil
 	}
 
-	measurement := ptr[0: 32]
+	measurement := ptr[0:32]
 	byteSize := ptr[248:252]
-	sigSize := int(byteSize[0]) + 256 * int(byteSize[1]) + 256 * 256 * int(byteSize[2]) +256 * 256 * 256 * int(byteSize[3])
-	sig := ptr[104:(104+sigSize)]
+	sigSize := int(byteSize[0]) + 256*int(byteSize[1]) + 256*256*int(byteSize[2]) + 256*256*256*int(byteSize[3])
+	sig := ptr[104:(104 + sigSize)]
 
 	// Compute hash of hash, datalen, data in enclave report
 	// This is what was signed
@@ -1370,11 +1366,11 @@ func VerifyKeystoneAttestation(serialized []byte, k *certprotos.KeyMessage) []by
 	// check signature
 	if !ecdsa.VerifyASN1(PK, signedHash[:], sig[:]) {
 		fmt.Printf("VerifyKeystoneAttestation: ecdsa.Verify failed\n")
-                // Todo: why does this fail?
+		// Todo: why does this fail?
 		// return nil
 	} else {
 		fmt.Printf("VerifyKeystoneAttestation: ecdsa.Verify succeeded\n")
-        }
+	}
 
 	// return measurement, if successful
 	return measurement
@@ -1397,11 +1393,11 @@ func VerifyRule1(tree *PredicateDominance, c1 *certprotos.VseClause, c2 *certpro
 		if c2.GetVerb() != "speaks-for" {
 			return false
 		}
-		if (!SameEntity(c1.Subject, c2.Object)) {
+		if !SameEntity(c1.Subject, c2.Object) {
 			return false
 		}
 
-		if c.Subject == nil || c.Verb == nil || c.Object != nil  || c.Clause != nil {
+		if c.Subject == nil || c.Verb == nil || c.Object != nil || c.Clause != nil {
 			return false
 		}
 		if c.GetVerb() != "is-trusted-for-authentication" {
@@ -1498,7 +1494,7 @@ func VerifyRule5(tree *PredicateDominance, c1 *certprotos.VseClause, c2 *certpro
 // R6: if key1 is-trustedXXX
 //	 and
 //		key1 says key2 speaks-for measurement then
-//		key2 speaks-for measurement provided is-trustedXXX dominates is-trusted-for-attestation 
+//		key2 speaks-for measurement provided is-trustedXXX dominates is-trusted-for-attestation
 //	 OR
 //		key1 says key2 speaks-for environment then key2 speaks-for environment provided is-trustedXXX dominates is-trusted-for-attestation
 //	 OR
@@ -1571,11 +1567,11 @@ func VerifyRule7(tree *PredicateDominance, c1 *certprotos.VseClause, c2 *certpro
 	if c2.GetVerb() != "speaks-for" {
 		return false
 	}
-	if (!SameEntity(c1.Subject, c2.Object)) {
+	if !SameEntity(c1.Subject, c2.Object) {
 		return false
 	}
 
-	if c.Subject == nil || c.Verb == nil || c.Object != nil  || c.Clause != nil {
+	if c.Subject == nil || c.Verb == nil || c.Object != nil || c.Clause != nil {
 		return false
 	}
 	if c.GetVerb() != "is-trusted-for-attestation" {
@@ -1585,7 +1581,7 @@ func VerifyRule7(tree *PredicateDominance, c1 *certprotos.VseClause, c2 *certpro
 }
 
 // R8: If environment[platform, measurement] is-environment AND platform-template
-//	has-trusted-platform-property then environment[platform, measurement] 
+//	has-trusted-platform-property then environment[platform, measurement]
 func VerifyRule8(tree *PredicateDominance, c1 *certprotos.VseClause, c2 *certprotos.VseClause, c *certprotos.VseClause) bool {
 	if c1.Subject == nil || c1.Verb == nil || c1.Object != nil || c1.Clause != nil {
 		return false
@@ -1609,7 +1605,7 @@ func VerifyRule8(tree *PredicateDominance, c1 *certprotos.VseClause, c2 *certpro
 		return false
 	}
 	// Does c1.EnvironmentEnt.ThePlatform.Props satisfy c2.PlatformEnt.Props
-	if !SatisfyingProperties( c2.Subject.PlatformEnt.Props, c1.Subject.EnvironmentEnt.ThePlatform.Props,) {
+	if !SatisfyingProperties(c2.Subject.PlatformEnt.Props, c1.Subject.EnvironmentEnt.ThePlatform.Props) {
 		fmt.Printf("Env: ")
 		PrintProperties(c1.Subject.EnvironmentEnt.ThePlatform.Props)
 		fmt.Printf("\nPlat: ")
@@ -1644,7 +1640,7 @@ func VerifyRule9(tree *PredicateDominance, c1 *certprotos.VseClause, c2 *certpro
 	if c.GetVerb() != "environment-measurement-is-trusted" {
 		return false
 	}
-	if (!bytes.Equal(c2.Subject.Measurement, c1.Subject.EnvironmentEnt.TheMeasurement)) {
+	if !bytes.Equal(c2.Subject.Measurement, c1.Subject.EnvironmentEnt.TheMeasurement) {
 		return false
 	}
 	return true
@@ -1672,7 +1668,6 @@ func VerifyRule10(tree *PredicateDominance, c1 *certprotos.VseClause, c2 *certpr
 	return SameEntity(c.Subject, c1.Subject) && SameEntity(c.Subject, c2.Subject)
 }
 
-
 func StatementAlreadyProved(c1 *certprotos.VseClause, ps *certprotos.ProvedStatements) bool {
 	for i := 0; i < len(ps.Proved); i++ {
 		if SameVseClause(c1, ps.Proved[i]) {
@@ -1683,10 +1678,10 @@ func StatementAlreadyProved(c1 *certprotos.VseClause, ps *certprotos.ProvedState
 }
 
 func VerifyInternalProofStep(tree *PredicateDominance, c1 *certprotos.VseClause, c2 *certprotos.VseClause,
-		c *certprotos.VseClause, rule int) bool {
+	c *certprotos.VseClause, rule int) bool {
 
 	// vse_clause s1, vse_clause s2, vse_clause conclude, int rule_to_apply
-	switch(rule) {
+	switch rule {
 	case 1:
 		return VerifyRule1(tree, c1, c2, c)
 	case 2:
@@ -1724,17 +1719,17 @@ func VerifyExternalProofStep(tree *PredicateDominance, step *certprotos.ProofSte
 }
 
 func VerifyProof(policyKey *certprotos.KeyMessage, toProve *certprotos.VseClause,
-		p *certprotos.Proof, ps *certprotos.ProvedStatements) bool {
+	p *certprotos.Proof, ps *certprotos.ProvedStatements) bool {
 
-	tree := PredicateDominance {
-		Predicate: "is-trusted",
+	tree := PredicateDominance{
+		Predicate:  "is-trusted",
 		FirstChild: nil,
-		Next: nil,
+		Next:       nil,
 	}
 
 	if !InitDominance(&tree) {
-		fmt.Printf("Can't init Dominance tree\n");
-		return false;
+		fmt.Printf("Can't init Dominance tree\n")
+		return false
 	}
 
 	for i := 0; i < len(p.Steps); i++ {
@@ -1743,12 +1738,12 @@ func VerifyProof(policyKey *certprotos.KeyMessage, toProve *certprotos.VseClause
 		c := p.Steps[i].Conclusion
 		if s1 == nil || s2 == nil || c == nil {
 			fmt.Printf("Bad proof step\n")
-			return false;
+			return false
 		}
-		if !StatementAlreadyProved(s1, ps)  {
+		if !StatementAlreadyProved(s1, ps) {
 			continue
 		}
-		if !StatementAlreadyProved(s2, ps)  {
+		if !StatementAlreadyProved(s2, ps) {
 			continue
 		}
 		if VerifyExternalProofStep(&tree, p.Steps[i]) {
@@ -1766,33 +1761,33 @@ func VerifyProof(policyKey *certprotos.KeyMessage, toProve *certprotos.VseClause
 	return false
 }
 
-func ConstructProofFromOeEvidenceWithoutEndorsement(publicPolicyKey *certprotos.KeyMessage, purpose string, alreadyProved *certprotos.ProvedStatements)  (*certprotos.VseClause, *certprotos.Proof) {
+func ConstructProofFromOeEvidenceWithoutEndorsement(publicPolicyKey *certprotos.KeyMessage, purpose string, alreadyProved *certprotos.ProvedStatements) (*certprotos.VseClause, *certprotos.Proof) {
 	if len(alreadyProved.Proved) < 3 {
 		fmt.Printf("ConstructProofFromOeEvidence: too few statements\n")
 		return nil, nil
 	}
 
-	policyKeyIsTrusted :=  alreadyProved.Proved[0]
+	policyKeyIsTrusted := alreadyProved.Proved[0]
 	policyKeySaysMeasurementIsTrusted := alreadyProved.Proved[1]
-	enclaveKeySpeaksForMeasurement :=  alreadyProved.Proved[2]
+	enclaveKeySpeaksForMeasurement := alreadyProved.Proved[2]
 
 	if policyKeyIsTrusted == nil || enclaveKeySpeaksForMeasurement == nil ||
-			policyKeySaysMeasurementIsTrusted == nil {
+		policyKeySaysMeasurementIsTrusted == nil {
 		fmt.Printf("ConstructProofFromOeEvidence: Clauses absent\n")
 		return nil, nil
 	}
 
-        proof := &certprotos.Proof{}
-        r1 := int32(1)
-        r3 := int32(3)
-        r7 := int32(7)
+	proof := &certprotos.Proof{}
+	r1 := int32(1)
+	r3 := int32(3)
+	r7 := int32(7)
 
 	enclaveKey := enclaveKeySpeaksForMeasurement.Subject
 	if enclaveKey == nil || enclaveKey.GetEntityType() != "key" {
 		fmt.Printf("ConstructProofFromOeEvidence: Bad enclave key\n")
 		return nil, nil
 	}
-        var toProve *certprotos.VseClause = nil
+	var toProve *certprotos.VseClause = nil
 	if purpose == "authentication" {
 		verb := "is-trusted-for-authentication"
 		toProve = MakeUnaryVseClause(enclaveKey, &verb)
@@ -1806,10 +1801,10 @@ func ConstructProofFromOeEvidenceWithoutEndorsement(publicPolicyKey *certprotos.
 		fmt.Printf("ConstructProofFromOeEvidence: Can't get measurement\n")
 		return nil, nil
 	}
-	ps1 := certprotos.ProofStep {
-		S1: policyKeyIsTrusted,
-		S2: policyKeySaysMeasurementIsTrusted,
-		Conclusion: measurementIsTrusted,
+	ps1 := certprotos.ProofStep{
+		S1:          policyKeyIsTrusted,
+		S2:          policyKeySaysMeasurementIsTrusted,
+		Conclusion:  measurementIsTrusted,
 		RuleApplied: &r3,
 	}
 	proof.Steps = append(proof.Steps, &ps1)
@@ -1818,45 +1813,45 @@ func ConstructProofFromOeEvidenceWithoutEndorsement(publicPolicyKey *certprotos.
 	//	enclaveKey is-trusted-for-authentication (r1) or
 	//	enclaveKey is-trusted-for-attestation (r7)
 	if purpose == "authentication" {
-		ps2 := certprotos.ProofStep {
-			S1: measurementIsTrusted,
-			S2: enclaveKeySpeaksForMeasurement,
-			Conclusion: toProve,
+		ps2 := certprotos.ProofStep{
+			S1:          measurementIsTrusted,
+			S2:          enclaveKeySpeaksForMeasurement,
+			Conclusion:  toProve,
 			RuleApplied: &r1,
 		}
 		proof.Steps = append(proof.Steps, &ps2)
 	} else {
-		ps2 := certprotos.ProofStep {
-			S1: measurementIsTrusted,
-			S2: enclaveKeySpeaksForMeasurement,
-			Conclusion: toProve,
+		ps2 := certprotos.ProofStep{
+			S1:          measurementIsTrusted,
+			S2:          enclaveKeySpeaksForMeasurement,
+			Conclusion:  toProve,
 			RuleApplied: &r7,
 		}
 		proof.Steps = append(proof.Steps, &ps2)
 	}
 
-        return toProve, proof
+	return toProve, proof
 
 }
 
-func ConstructProofFromOeEvidenceWithEndorsement(publicPolicyKey *certprotos.KeyMessage, purpose string, alreadyProved *certprotos.ProvedStatements)  (*certprotos.VseClause, *certprotos.Proof) {
+func ConstructProofFromOeEvidenceWithEndorsement(publicPolicyKey *certprotos.KeyMessage, purpose string, alreadyProved *certprotos.ProvedStatements) (*certprotos.VseClause, *certprotos.Proof) {
 	if len(alreadyProved.Proved) < 4 {
 		fmt.Printf("ConstructProofFromOeEvidence: too few statements\n")
 		return nil, nil
 	}
 
-	policyKeyIsTrusted :=  alreadyProved.Proved[0]
+	policyKeyIsTrusted := alreadyProved.Proved[0]
 	policyKeySaysPlatformKeyIsTrustedForAttestation := alreadyProved.Proved[1]
 	policyKeySaysMeasurementIsTrusted := alreadyProved.Proved[2]
-	platformSaysEnclaveKeySpeaksForMeasurement :=  alreadyProved.Proved[3]
+	platformSaysEnclaveKeySpeaksForMeasurement := alreadyProved.Proved[3]
 
 	if platformSaysEnclaveKeySpeaksForMeasurement.Clause == nil {
 		fmt.Printf("ConstructProofFromOeEvidence: can't get enclaveKeySpeaksForMeasurement\n")
 		return nil, nil
 	}
-	enclaveKeySpeaksForMeasurement :=  platformSaysEnclaveKeySpeaksForMeasurement.Clause
+	enclaveKeySpeaksForMeasurement := platformSaysEnclaveKeySpeaksForMeasurement.Clause
 	if policyKeyIsTrusted == nil || enclaveKeySpeaksForMeasurement == nil ||
-			policyKeySaysMeasurementIsTrusted == nil {
+		policyKeySaysMeasurementIsTrusted == nil {
 		fmt.Printf("ConstructProofFromOeEvidence: clauses absent\n")
 		return nil, nil
 	}
@@ -1867,18 +1862,18 @@ func ConstructProofFromOeEvidenceWithEndorsement(publicPolicyKey *certprotos.Key
 	}
 	platformKeyIsTrustedForAttestation := policyKeySaysPlatformKeyIsTrustedForAttestation.Clause
 
-        proof := &certprotos.Proof{}
-        r1 := int32(1)
-        r3 := int32(3)
-        r6 := int32(6)
-        r7 := int32(7)
+	proof := &certprotos.Proof{}
+	r1 := int32(1)
+	r3 := int32(3)
+	r6 := int32(6)
+	r7 := int32(7)
 
 	enclaveKey := enclaveKeySpeaksForMeasurement.Subject
 	if enclaveKey == nil || enclaveKey.GetEntityType() != "key" {
 		fmt.Printf("ConstructProofFromOeEvidence: Bad enclave key\n")
 		return nil, nil
 	}
-        var toProve *certprotos.VseClause = nil
+	var toProve *certprotos.VseClause = nil
 	if purpose == "authentication" {
 		verb := "is-trusted-for-authentication"
 		toProve = MakeUnaryVseClause(enclaveKey, &verb)
@@ -1892,26 +1887,26 @@ func ConstructProofFromOeEvidenceWithEndorsement(publicPolicyKey *certprotos.Key
 		fmt.Printf("ConstructProofFromOeEvidence: Can't get measurement\n")
 		return nil, nil
 	}
-	ps1 := certprotos.ProofStep {
-		S1: policyKeyIsTrusted,
-		S2: policyKeySaysMeasurementIsTrusted,
-		Conclusion: measurementIsTrusted,
+	ps1 := certprotos.ProofStep{
+		S1:          policyKeyIsTrusted,
+		S2:          policyKeySaysMeasurementIsTrusted,
+		Conclusion:  measurementIsTrusted,
 		RuleApplied: &r3,
 	}
 	proof.Steps = append(proof.Steps, &ps1)
 
-	ps2 := certprotos.ProofStep {
-		S1: policyKeyIsTrusted,
-		S2: policyKeySaysPlatformKeyIsTrustedForAttestation,
-		Conclusion: platformKeyIsTrustedForAttestation,
+	ps2 := certprotos.ProofStep{
+		S1:          policyKeyIsTrusted,
+		S2:          policyKeySaysPlatformKeyIsTrustedForAttestation,
+		Conclusion:  platformKeyIsTrustedForAttestation,
 		RuleApplied: &r3,
 	}
 	proof.Steps = append(proof.Steps, &ps2)
 
-	ps3 := certprotos.ProofStep {
-		S1: platformKeyIsTrustedForAttestation,
-		S2: platformSaysEnclaveKeySpeaksForMeasurement,
-		Conclusion: enclaveKeySpeaksForMeasurement,
+	ps3 := certprotos.ProofStep{
+		S1:          platformKeyIsTrustedForAttestation,
+		S2:          platformSaysEnclaveKeySpeaksForMeasurement,
+		Conclusion:  enclaveKeySpeaksForMeasurement,
 		RuleApplied: &r6,
 	}
 	proof.Steps = append(proof.Steps, &ps3)
@@ -1920,43 +1915,42 @@ func ConstructProofFromOeEvidenceWithEndorsement(publicPolicyKey *certprotos.Key
 	//	enclaveKey is-trusted-for-authentication (r1) or
 	//	enclaveKey is-trusted-for-attestation (r7)
 	if purpose == "authentication" {
-		ps4 := certprotos.ProofStep {
-			S1: measurementIsTrusted,
-			S2: enclaveKeySpeaksForMeasurement,
-			Conclusion: toProve,
+		ps4 := certprotos.ProofStep{
+			S1:          measurementIsTrusted,
+			S2:          enclaveKeySpeaksForMeasurement,
+			Conclusion:  toProve,
 			RuleApplied: &r1,
 		}
 		proof.Steps = append(proof.Steps, &ps4)
 	} else {
-		ps4 := certprotos.ProofStep {
-			S1: measurementIsTrusted,
-			S2: enclaveKeySpeaksForMeasurement,
-			Conclusion: toProve,
+		ps4 := certprotos.ProofStep{
+			S1:          measurementIsTrusted,
+			S2:          enclaveKeySpeaksForMeasurement,
+			Conclusion:  toProve,
 			RuleApplied: &r7,
 		}
 		proof.Steps = append(proof.Steps, &ps4)
 	}
 
-        return toProve, proof
+	return toProve, proof
 }
 
-func ConstructProofFromOeEvidence(publicPolicyKey *certprotos.KeyMessage, purpose string, alreadyProved *certprotos.ProvedStatements)  (*certprotos.VseClause, *certprotos.Proof) {
-        // At this point, the evidence should be
-        //      00: "policyKey is-trusted"
-        //      01: "Key[rsa, policyKey, f2663e9ca042fcd261ab051b3a4e3ac83d79afdd] says
+func ConstructProofFromOeEvidence(publicPolicyKey *certprotos.KeyMessage, purpose string, alreadyProved *certprotos.ProvedStatements) (*certprotos.VseClause, *certprotos.Proof) {
+	// At this point, the evidence should be
+	//      00: "policyKey is-trusted"
+	//      01: "Key[rsa, policyKey, f2663e9ca042fcd261ab051b3a4e3ac83d79afdd] says
 	//		Key[rsa, VSE, cbfced04cfc0f1f55df8cbe437c3aba79af1657a] is-trusted-for-attestation"
-        //      02: "policyKey says measurement is-trusted"
+	//      02: "policyKey says measurement is-trusted"
 	//	03: "Key[rsa, VSE, cbfced04cfc0f1f55df8cbe437c3aba79af1657a] says
 	//		Key[rsa, auth-key, b1d19c10ec7782660191d7ee4e3a2511fad8f882] speaks-for Measurement[4204...]
 	// Or:
-        //      00: "policyKey is-trusted"
-        //      01: "policyKey says measurement is-trusted"
+	//      00: "policyKey is-trusted"
+	//      01: "policyKey says measurement is-trusted"
 	//      02: "Key[rsa, auth-key, b1d19c10ec7782660191d7ee4e3a2511fad8f882] speaks-for Measurement[4204...]"
-
 
 	// Debug
 	fmt.Printf("ConstructProofFromOeEvidence, %d statements\n", len(alreadyProved.Proved))
-	for i := 0; i < len(alreadyProved.Proved);  i++ {
+	for i := 0; i < len(alreadyProved.Proved); i++ {
 		PrintVseClause(alreadyProved.Proved[i])
 		fmt.Printf("\n")
 	}
@@ -1969,102 +1963,101 @@ func ConstructProofFromOeEvidence(publicPolicyKey *certprotos.KeyMessage, purpos
 }
 
 // This is used for simulated enclave and the application enclave
-func ConstructProofFromInternalPlatformEvidence(publicPolicyKey *certprotos.KeyMessage, purpose string, alreadyProved *certprotos.ProvedStatements)  (*certprotos.VseClause, *certprotos.Proof) {
-        // At this point, the evidence should be
-        //      0: "policyKey is-trusted"
-        //      1: "policyKey says platformKey is-trusted-for-attestation"
-        //      2: "policyKey says measurement is-trusted"
-        //      3: "platformKey says the attestationKey is-trusted-for-attestation
-        //      4: "attestationKey says enclaveKey speaks-for measurement
-        // Debug
-        fmt.Printf("ConstructProofFromInternalPlatformEvidence entries %d\n", len(alreadyProved.Proved))
+func ConstructProofFromInternalPlatformEvidence(publicPolicyKey *certprotos.KeyMessage, purpose string, alreadyProved *certprotos.ProvedStatements) (*certprotos.VseClause, *certprotos.Proof) {
+	// At this point, the evidence should be
+	//      0: "policyKey is-trusted"
+	//      1: "policyKey says platformKey is-trusted-for-attestation"
+	//      2: "policyKey says measurement is-trusted"
+	//      3: "platformKey says the attestationKey is-trusted-for-attestation
+	//      4: "attestationKey says enclaveKey speaks-for measurement
+	// Debug
+	fmt.Printf("ConstructProofFromInternalPlatformEvidence entries %d\n", len(alreadyProved.Proved))
 
-        if len(alreadyProved.Proved) < 5 {
-            fmt.Printf("ConstructProofFromInternalPlatformEvidence: too few proved statements\n")
+	if len(alreadyProved.Proved) < 5 {
+		fmt.Printf("ConstructProofFromInternalPlatformEvidence: too few proved statements\n")
 
-            fmt.Printf("\nProved statements (Check for missing statements here):\n")
-            PrintProvedStatements(alreadyProved);
+		fmt.Printf("\nProved statements (Check for missing statements here):\n")
+		PrintProvedStatements(alreadyProved)
 
-            return nil, nil
-        }
+		return nil, nil
+	}
 
-        proof := &certprotos.Proof{}
-        r1 := int32(1)
-        r3 := int32(3)
-        r5 := int32(5)
-        r6 := int32(6)
-        r7 := int32(7)
+	proof := &certprotos.Proof{}
+	r1 := int32(1)
+	r3 := int32(3)
+	r5 := int32(5)
+	r6 := int32(6)
+	r7 := int32(7)
 
-        policyKeyIsTrusted := alreadyProved.Proved[0]
+	policyKeyIsTrusted := alreadyProved.Proved[0]
 
-        policyKeySaysPlatformKeyIsTrusted := alreadyProved.Proved[1]
-        platformKeyIsTrusted := policyKeySaysPlatformKeyIsTrusted.Clause
-        ps1 := certprotos.ProofStep {
-                S1: policyKeyIsTrusted,
-                S2: policyKeySaysPlatformKeyIsTrusted,
-                Conclusion: platformKeyIsTrusted,
-                RuleApplied: &r5,
-        }
-        proof.Steps = append(proof.Steps, &ps1)
+	policyKeySaysPlatformKeyIsTrusted := alreadyProved.Proved[1]
+	platformKeyIsTrusted := policyKeySaysPlatformKeyIsTrusted.Clause
+	ps1 := certprotos.ProofStep{
+		S1:          policyKeyIsTrusted,
+		S2:          policyKeySaysPlatformKeyIsTrusted,
+		Conclusion:  platformKeyIsTrusted,
+		RuleApplied: &r5,
+	}
+	proof.Steps = append(proof.Steps, &ps1)
 
-        policyKeySaysMeasurementIsTrusted := alreadyProved.Proved[2]
-        measurementIsTrusted := policyKeySaysMeasurementIsTrusted.Clause
-        ps2 := certprotos.ProofStep {
-                S1: policyKeyIsTrusted,
-                S2: policyKeySaysMeasurementIsTrusted,
-                Conclusion: measurementIsTrusted,
-                RuleApplied: &r3,
-        }
-        proof.Steps = append(proof.Steps, &ps2)
+	policyKeySaysMeasurementIsTrusted := alreadyProved.Proved[2]
+	measurementIsTrusted := policyKeySaysMeasurementIsTrusted.Clause
+	ps2 := certprotos.ProofStep{
+		S1:          policyKeyIsTrusted,
+		S2:          policyKeySaysMeasurementIsTrusted,
+		Conclusion:  measurementIsTrusted,
+		RuleApplied: &r3,
+	}
+	proof.Steps = append(proof.Steps, &ps2)
 
-        platformKeySaysAttestKeyIsTrusted := alreadyProved.Proved[3]
-        attestKeyIsTrusted := platformKeySaysAttestKeyIsTrusted.Clause
-        ps3 := certprotos.ProofStep {
-                S1: platformKeyIsTrusted,
-                S2: platformKeySaysAttestKeyIsTrusted,
-                Conclusion: attestKeyIsTrusted,
-                RuleApplied: &r5,
-        }
-        proof.Steps = append(proof.Steps, &ps3)
+	platformKeySaysAttestKeyIsTrusted := alreadyProved.Proved[3]
+	attestKeyIsTrusted := platformKeySaysAttestKeyIsTrusted.Clause
+	ps3 := certprotos.ProofStep{
+		S1:          platformKeyIsTrusted,
+		S2:          platformKeySaysAttestKeyIsTrusted,
+		Conclusion:  attestKeyIsTrusted,
+		RuleApplied: &r5,
+	}
+	proof.Steps = append(proof.Steps, &ps3)
 
-        attestKeySaysEnclaveKeySpeaksForMeasurement := alreadyProved.Proved[4]
-        enclaveKeySpeaksForMeasurement := attestKeySaysEnclaveKeySpeaksForMeasurement.Clause
-        ps4 := certprotos.ProofStep {
-        S1: attestKeyIsTrusted,
-        S2: attestKeySaysEnclaveKeySpeaksForMeasurement,
-        Conclusion: enclaveKeySpeaksForMeasurement,
-        RuleApplied: &r6,
-        }
-        proof.Steps = append(proof.Steps, &ps4)
+	attestKeySaysEnclaveKeySpeaksForMeasurement := alreadyProved.Proved[4]
+	enclaveKeySpeaksForMeasurement := attestKeySaysEnclaveKeySpeaksForMeasurement.Clause
+	ps4 := certprotos.ProofStep{
+		S1:          attestKeyIsTrusted,
+		S2:          attestKeySaysEnclaveKeySpeaksForMeasurement,
+		Conclusion:  enclaveKeySpeaksForMeasurement,
+		RuleApplied: &r6,
+	}
+	proof.Steps = append(proof.Steps, &ps4)
 
-        var toProve *certprotos.VseClause = nil
-        isTrustedForAuth := "is-trusted-for-authentication"
-        isTrustedForAttest:= "is-trusted-for-attestation"
-        if  purpose == "attestation" {
-                toProve =  MakeUnaryVseClause(enclaveKeySpeaksForMeasurement.Subject,
-                        &isTrustedForAttest)
-                ps5 := certprotos.ProofStep {
-                S1: measurementIsTrusted,
-                S2: enclaveKeySpeaksForMeasurement,
-                Conclusion: toProve,
-                RuleApplied: &r7,
-                }
-                proof.Steps = append(proof.Steps, &ps5)
-        } else {
-                toProve =  MakeUnaryVseClause(enclaveKeySpeaksForMeasurement.Subject,
-                        &isTrustedForAuth)
-                ps5 := certprotos.ProofStep {
-                S1: measurementIsTrusted,
-                S2: enclaveKeySpeaksForMeasurement,
-                Conclusion: toProve,
-                RuleApplied: &r1,
-                }
-                proof.Steps = append(proof.Steps, &ps5)
-        }
+	var toProve *certprotos.VseClause = nil
+	isTrustedForAuth := "is-trusted-for-authentication"
+	isTrustedForAttest := "is-trusted-for-attestation"
+	if purpose == "attestation" {
+		toProve = MakeUnaryVseClause(enclaveKeySpeaksForMeasurement.Subject,
+			&isTrustedForAttest)
+		ps5 := certprotos.ProofStep{
+			S1:          measurementIsTrusted,
+			S2:          enclaveKeySpeaksForMeasurement,
+			Conclusion:  toProve,
+			RuleApplied: &r7,
+		}
+		proof.Steps = append(proof.Steps, &ps5)
+	} else {
+		toProve = MakeUnaryVseClause(enclaveKeySpeaksForMeasurement.Subject,
+			&isTrustedForAuth)
+		ps5 := certprotos.ProofStep{
+			S1:          measurementIsTrusted,
+			S2:          enclaveKeySpeaksForMeasurement,
+			Conclusion:  toProve,
+			RuleApplied: &r1,
+		}
+		proof.Steps = append(proof.Steps, &ps5)
+	}
 
-        return toProve, proof
+	return toProve, proof
 }
-
 
 /*
 	Rules
@@ -2087,9 +2080,9 @@ func ConstructProofFromInternalPlatformEvidence(publicPolicyKey *certprotos.KeyM
 		rule 10 (R10): If environment[platform, measurement] environment-platform-is-trusted AND
 			environment[platform, measurement] environment-measurement-is-trusted then
 			environment[platform, measurement] is-trusted
- */
+*/
 
-func ConstructProofFromSevPlatformEvidence(publicPolicyKey *certprotos.KeyMessage, purpose string, alreadyProved *certprotos.ProvedStatements)  (*certprotos.VseClause, *certprotos.Proof) {
+func ConstructProofFromSevPlatformEvidence(publicPolicyKey *certprotos.KeyMessage, purpose string, alreadyProved *certprotos.ProvedStatements) (*certprotos.VseClause, *certprotos.Proof) {
 
 	// There should be 9 statements in already proved
 	if len(alreadyProved.Proved) < 9 {
@@ -2108,17 +2101,17 @@ func ConstructProofFromSevPlatformEvidence(publicPolicyKey *certprotos.KeyMessag
 
 	// "policyKey is-trusted" AND policyKey says measurement is-trusted" -->
 	//        "measurement is-trusted" (R3)  [0, 2]
-	policyKeyIsTrusted :=  alreadyProved.Proved[0]
-	policyKeySaysMeasurementIsTrusted :=  alreadyProved.Proved[2]
+	policyKeyIsTrusted := alreadyProved.Proved[0]
+	policyKeySaysMeasurementIsTrusted := alreadyProved.Proved[2]
 	if policyKeySaysMeasurementIsTrusted.Clause == nil {
 		fmt.Printf("ConstructProofFromPlatformEvidence: Policy key says measurement is-trusted is malformed\n")
 		return nil, nil
 	}
-	measurementIsTrusted :=  policyKeySaysMeasurementIsTrusted.Clause
-	ps1 := certprotos.ProofStep {
-		S1: policyKeyIsTrusted,
-		S2: policyKeySaysMeasurementIsTrusted,
-		Conclusion: measurementIsTrusted,
+	measurementIsTrusted := policyKeySaysMeasurementIsTrusted.Clause
+	ps1 := certprotos.ProofStep{
+		S1:          policyKeyIsTrusted,
+		S2:          policyKeySaysMeasurementIsTrusted,
+		Conclusion:  measurementIsTrusted,
 		RuleApplied: &r3,
 	}
 	proof.Steps = append(proof.Steps, &ps1)
@@ -2132,10 +2125,10 @@ func ConstructProofFromSevPlatformEvidence(publicPolicyKey *certprotos.KeyMessag
 		return nil, nil
 	}
 	arkKeyIsTrusted := policyKeySaysArkKeyIsTrusted.Clause
-	ps2 := certprotos.ProofStep {
-		S1: policyKeyIsTrusted,
-		S2: policyKeySaysArkKeyIsTrusted,
-		Conclusion: arkKeyIsTrusted,
+	ps2 := certprotos.ProofStep{
+		S1:          policyKeyIsTrusted,
+		S2:          policyKeySaysArkKeyIsTrusted,
+		Conclusion:  arkKeyIsTrusted,
 		RuleApplied: &r3,
 	}
 	proof.Steps = append(proof.Steps, &ps2)
@@ -2149,10 +2142,10 @@ func ConstructProofFromSevPlatformEvidence(publicPolicyKey *certprotos.KeyMessag
 		return nil, nil
 	}
 	askKeyIsTrusted := arkKeySaysAskKeyIsTrusted.Clause
-	ps3 := certprotos.ProofStep {
-		S1: arkKeyIsTrusted,
-		S2: arkKeySaysAskKeyIsTrusted,
-		Conclusion: askKeyIsTrusted,
+	ps3 := certprotos.ProofStep{
+		S1:          arkKeyIsTrusted,
+		S2:          arkKeySaysAskKeyIsTrusted,
+		Conclusion:  askKeyIsTrusted,
 		RuleApplied: &r5,
 	}
 	proof.Steps = append(proof.Steps, &ps3)
@@ -2166,10 +2159,10 @@ func ConstructProofFromSevPlatformEvidence(publicPolicyKey *certprotos.KeyMessag
 		return nil, nil
 	}
 	vcekKeyIsTrusted := askKeySaysVcekKeyIsTrusted.Clause
-	ps4 := certprotos.ProofStep {
-		S1: askKeyIsTrusted,
-		S2: askKeySaysVcekKeyIsTrusted,
-		Conclusion: vcekKeyIsTrusted,
+	ps4 := certprotos.ProofStep{
+		S1:          askKeyIsTrusted,
+		S2:          askKeySaysVcekKeyIsTrusted,
+		Conclusion:  vcekKeyIsTrusted,
 		RuleApplied: &r5,
 	}
 	proof.Steps = append(proof.Steps, &ps4)
@@ -2183,10 +2176,10 @@ func ConstructProofFromSevPlatformEvidence(publicPolicyKey *certprotos.KeyMessag
 		return nil, nil
 	}
 	isEnvironment := vcekSaysIsEnvironment.Clause
-	ps5 := certprotos.ProofStep {
-		S1: vcekKeyIsTrusted,
-		S2: vcekSaysIsEnvironment,
-		Conclusion: isEnvironment,
+	ps5 := certprotos.ProofStep{
+		S1:          vcekKeyIsTrusted,
+		S2:          vcekSaysIsEnvironment,
+		Conclusion:  isEnvironment,
 		RuleApplied: &r6,
 	}
 	proof.Steps = append(proof.Steps, &ps5)
@@ -2199,10 +2192,10 @@ func ConstructProofFromSevPlatformEvidence(publicPolicyKey *certprotos.KeyMessag
 		return nil, nil
 	}
 	platformHasTrustedPlatformProperty := policyKeySaysPlatformHasTrustedPlatformProperty.Clause
-	ps6 := certprotos.ProofStep {
-		S1: policyKeyIsTrusted,
-		S2: policyKeySaysPlatformHasTrustedPlatformProperty,
-		Conclusion: platformHasTrustedPlatformProperty,
+	ps6 := certprotos.ProofStep{
+		S1:          policyKeyIsTrusted,
+		S2:          policyKeySaysPlatformHasTrustedPlatformProperty,
+		Conclusion:  platformHasTrustedPlatformProperty,
 		RuleApplied: &r3,
 	}
 	proof.Steps = append(proof.Steps, &ps6)
@@ -2211,14 +2204,14 @@ func ConstructProofFromSevPlatformEvidence(publicPolicyKey *certprotos.KeyMessag
 	//        "platform[amd-sev-snp, no-debug,...] has-trusted-platform-property" -->
 	//        "environment(platform, measurement) environment-platform-is-trusted" [3, ]
 	pitVerb := "environment-platform-is-trusted"
-	environmentPlatformIsTrusted := &certprotos.VseClause {
+	environmentPlatformIsTrusted := &certprotos.VseClause{
 		Subject: isEnvironment.Subject,
-		Verb: &pitVerb,
+		Verb:    &pitVerb,
 	}
-	ps8 := certprotos.ProofStep {
-		S1: isEnvironment,
-		S2: platformHasTrustedPlatformProperty,
-		Conclusion: environmentPlatformIsTrusted,
+	ps8 := certprotos.ProofStep{
+		S1:          isEnvironment,
+		S2:          platformHasTrustedPlatformProperty,
+		Conclusion:  environmentPlatformIsTrusted,
 		RuleApplied: &r8,
 	}
 	proof.Steps = append(proof.Steps, &ps8)
@@ -2227,35 +2220,33 @@ func ConstructProofFromSevPlatformEvidence(publicPolicyKey *certprotos.KeyMessag
 	//        "measurement is-trusted" -->
 	//        "environment(platform, measurement) environment-measurement-is-trusted"
 	emitVerb := "environment-measurement-is-trusted"
-	environmentMeasurementIsTrusted := &certprotos.VseClause {
+	environmentMeasurementIsTrusted := &certprotos.VseClause{
 		Subject: isEnvironment.Subject,
-		Verb: &emitVerb,
+		Verb:    &emitVerb,
 	}
-	ps9 := certprotos.ProofStep {
-		S1: isEnvironment,
-		S2: measurementIsTrusted,
-		Conclusion: environmentMeasurementIsTrusted,
+	ps9 := certprotos.ProofStep{
+		S1:          isEnvironment,
+		S2:          measurementIsTrusted,
+		Conclusion:  environmentMeasurementIsTrusted,
 		RuleApplied: &r9,
 	}
 	proof.Steps = append(proof.Steps, &ps9)
-
 
 	//    "environment(platform, measurement) environment-platform-is-trusted" AND
 	//        "environment(platform, measurement) environment-measurement-is-trusted"  -->
 	//        "environment(platform, measurement) is-trusted
 	eitVerb := "is-trusted"
-	environmentIsTrusted := &certprotos.VseClause {
+	environmentIsTrusted := &certprotos.VseClause{
 		Subject: isEnvironment.Subject,
-		Verb: &eitVerb,
+		Verb:    &eitVerb,
 	}
-	ps10 := certprotos.ProofStep {
-		S1: environmentMeasurementIsTrusted,
-		S2: environmentPlatformIsTrusted,
-		Conclusion: environmentIsTrusted,
+	ps10 := certprotos.ProofStep{
+		S1:          environmentMeasurementIsTrusted,
+		S2:          environmentPlatformIsTrusted,
+		Conclusion:  environmentIsTrusted,
 		RuleApplied: &r10,
 	}
 	proof.Steps = append(proof.Steps, &ps10)
-
 
 	//    "VCEK-key is-trusted-for-attestation" AND
 	//      "VCEK-key says the enclave-key speaks-for the environment()" -->
@@ -2266,24 +2257,24 @@ func ConstructProofFromSevPlatformEvidence(publicPolicyKey *certprotos.KeyMessag
 		return nil, nil
 	}
 	enclaveKeySpeaksForEnvironment := vcekSaysEnclaveKeySpeaksForEnvironment.Clause
-	ps11 := certprotos.ProofStep {
-		S1: vcekKeyIsTrusted,
-		S2: vcekSaysEnclaveKeySpeaksForEnvironment,
-		Conclusion: enclaveKeySpeaksForEnvironment,
+	ps11 := certprotos.ProofStep{
+		S1:          vcekKeyIsTrusted,
+		S2:          vcekSaysEnclaveKeySpeaksForEnvironment,
+		Conclusion:  enclaveKeySpeaksForEnvironment,
 		RuleApplied: &r6,
 	}
 	proof.Steps = append(proof.Steps, &ps11)
 
 	if purpose == "attestation" {
 		itfaVerb := "is-trusted-for-attestation"
-		enclaveKeyIsTrusted := &certprotos.VseClause {
+		enclaveKeyIsTrusted := &certprotos.VseClause{
 			Subject: enclaveKeySpeaksForEnvironment.Subject,
-			Verb: &itfaVerb,
+			Verb:    &itfaVerb,
 		}
-		ps12 := certprotos.ProofStep {
-			S1: environmentIsTrusted,
-			S2: enclaveKeySpeaksForEnvironment,
-			Conclusion: enclaveKeyIsTrusted,
+		ps12 := certprotos.ProofStep{
+			S1:          environmentIsTrusted,
+			S2:          enclaveKeySpeaksForEnvironment,
+			Conclusion:  enclaveKeyIsTrusted,
 			RuleApplied: &r6,
 		}
 		proof.Steps = append(proof.Steps, &ps12)
@@ -2292,14 +2283,14 @@ func ConstructProofFromSevPlatformEvidence(publicPolicyKey *certprotos.KeyMessag
 		return toProve, proof
 	} else {
 		itfaVerb := "is-trusted-for-authentication"
-		enclaveKeyIsTrusted := &certprotos.VseClause {
+		enclaveKeyIsTrusted := &certprotos.VseClause{
 			Subject: enclaveKeySpeaksForEnvironment.Subject,
-			Verb: &itfaVerb,
+			Verb:    &itfaVerb,
 		}
-		ps12 := certprotos.ProofStep {
-			S1: environmentIsTrusted,
-			S2: enclaveKeySpeaksForEnvironment,
-			Conclusion: enclaveKeyIsTrusted,
+		ps12 := certprotos.ProofStep{
+			S1:          environmentIsTrusted,
+			S2:          enclaveKeySpeaksForEnvironment,
+			Conclusion:  enclaveKeyIsTrusted,
 			RuleApplied: &r1,
 		}
 		proof.Steps = append(proof.Steps, &ps12)
@@ -2313,8 +2304,8 @@ func ConstructProofFromSevPlatformEvidence(publicPolicyKey *certprotos.KeyMessag
 
 // returns success, toProve, measurement
 func ValidateInternalEvidence(pubPolicyKey *certprotos.KeyMessage, evp *certprotos.EvidencePackage,
-		originalPolicy *certprotos.ProvedStatements, purpose string) (bool,
-                *certprotos.VseClause, []byte) {
+	originalPolicy *certprotos.ProvedStatements, purpose string) (bool,
+	*certprotos.VseClause, []byte) {
 
 	// Debug
 	fmt.Printf("\nValidateInternalEvidence: original policy:\n")
@@ -2322,9 +2313,9 @@ func ValidateInternalEvidence(pubPolicyKey *certprotos.KeyMessage, evp *certprot
 
 	alreadyProved := FilterInternalPolicy(pubPolicyKey, evp, originalPolicy)
 	if alreadyProved == nil {
-                fmt.Printf("ValidateInternalEvidence: Can't filterpolicy\n")
+		fmt.Printf("ValidateInternalEvidence: Can't filterpolicy\n")
 		return false, nil, nil
-        }
+	}
 
 	// Debug
 	fmt.Printf("\nValidateInternalEvidence: filtered policy:\n")
@@ -2332,25 +2323,25 @@ func ValidateInternalEvidence(pubPolicyKey *certprotos.KeyMessage, evp *certprot
 	fmt.Printf("\n")
 
 	if !InitProvedStatements(*pubPolicyKey, evp.FactAssertion, alreadyProved) {
-                fmt.Printf("ValidateInternalEvidence: Can't InitProvedStatements\n")
+		fmt.Printf("ValidateInternalEvidence: Can't InitProvedStatements\n")
 		return false, nil, nil
 	}
 
 	// After InitProvedStatements already proved will be:
-        //    00 Key[rsa, policyKey, a5fc2b7e629fbbfb04b056a993a473af3540bbfe] is-trusted
-        //    01 Key[rsa, policyKey, a5fc2b7e629fbbfb04b056a993a473af3540bbfe] says Key[rsa, platformKey, c1c06db41296c2dc3ecb2e4a1290f39925699d4d] is-trusted-for-attestation
-        //    02 Key[rsa, policyKey, a5fc2b7e629fbbfb04b056a993a473af3540bbfe] says Measurement[617ac0a68393b4c0b359a76d0fab9015af0801273e13bd366fca57a7af4fe6cc] is-trusted
-        //    03 Key[rsa, platformKey, c1c06db41296c2dc3ecb2e4a1290f39925699d4d] says Key[rsa, attestKey, f19938982e3f7e16f524de5f7b47d3e39e32df07] is-trusted-for-attestation
-        //    04 Key[rsa, attestKey, f19938982e3f7e16f524de5f7b47d3e39e32df07] says Key[rsa, auth-key, ce3c7cc9b6e7bc733a95434bda226ef4d74e620f] speaks-for Measurement[617ac0a68393b4c0b359a76d0fab9015af0801273e13bd366fca57a7af4fe6cc]
+	//    00 Key[rsa, policyKey, a5fc2b7e629fbbfb04b056a993a473af3540bbfe] is-trusted
+	//    01 Key[rsa, policyKey, a5fc2b7e629fbbfb04b056a993a473af3540bbfe] says Key[rsa, platformKey, c1c06db41296c2dc3ecb2e4a1290f39925699d4d] is-trusted-for-attestation
+	//    02 Key[rsa, policyKey, a5fc2b7e629fbbfb04b056a993a473af3540bbfe] says Measurement[617ac0a68393b4c0b359a76d0fab9015af0801273e13bd366fca57a7af4fe6cc] is-trusted
+	//    03 Key[rsa, platformKey, c1c06db41296c2dc3ecb2e4a1290f39925699d4d] says Key[rsa, attestKey, f19938982e3f7e16f524de5f7b47d3e39e32df07] is-trusted-for-attestation
+	//    04 Key[rsa, attestKey, f19938982e3f7e16f524de5f7b47d3e39e32df07] says Key[rsa, auth-key, ce3c7cc9b6e7bc733a95434bda226ef4d74e620f] speaks-for Measurement[617ac0a68393b4c0b359a76d0fab9015af0801273e13bd366fca57a7af4fe6cc]
 
 	// Debug
 	fmt.Printf("\nValidateInternalEvidence: after InitProved:\n")
 	PrintProvedStatements(alreadyProved)
 
-        // ConstructProofFromInternalPlatformEvidence()
+	// ConstructProofFromInternalPlatformEvidence()
 	toProve, proof := ConstructProofFromInternalPlatformEvidence(pubPolicyKey, purpose, alreadyProved)
 	if toProve == nil || proof == nil {
-                fmt.Printf("ValidateInternalEvidence: Can't construct proof\n")
+		fmt.Printf("ValidateInternalEvidence: Can't construct proof\n")
 		return false, nil, nil
 	}
 
@@ -2362,18 +2353,18 @@ func ValidateInternalEvidence(pubPolicyKey *certprotos.KeyMessage, evp *certprot
 	PrintProof(proof)
 	fmt.Printf("\n")
 
-        if !VerifyProof(pubPolicyKey, toProve, proof, alreadyProved) {
-                fmt.Printf("ValidateInternalEvidence: Proof does not verify\n")
+	if !VerifyProof(pubPolicyKey, toProve, proof, alreadyProved) {
+		fmt.Printf("ValidateInternalEvidence: Proof does not verify\n")
 		return false, nil, nil
-        }
+	}
 
 	// Debug
 	fmt.Printf("ValidateInternalEvidence: Proof verifies\n")
 
 	me := alreadyProved.Proved[2]
 	if me.Clause == nil || me.Clause.Subject == nil ||
-			me.Clause.Subject.GetEntityType() != "measurement" {
-                fmt.Printf("ValidateInternalEvidence: Proof does not verify\n")
+		me.Clause.Subject.GetEntityType() != "measurement" {
+		fmt.Printf("ValidateInternalEvidence: Proof does not verify\n")
 		return false, nil, nil
 	}
 
@@ -2382,8 +2373,8 @@ func ValidateInternalEvidence(pubPolicyKey *certprotos.KeyMessage, evp *certprot
 
 // returns success, toProve, measurement
 func ValidateOeEvidence(pubPolicyKey *certprotos.KeyMessage, evp *certprotos.EvidencePackage,
-		originalPolicy *certprotos.ProvedStatements, purpose string) (bool,
-                *certprotos.VseClause, []byte) {
+	originalPolicy *certprotos.ProvedStatements, purpose string) (bool,
+	*certprotos.VseClause, []byte) {
 
 	// Debug
 	fmt.Printf("\nValidateOeEvidence, Original policy:\n")
@@ -2391,9 +2382,9 @@ func ValidateOeEvidence(pubPolicyKey *certprotos.KeyMessage, evp *certprotos.Evi
 
 	alreadyProved := FilterOePolicy(pubPolicyKey, evp, originalPolicy)
 	if alreadyProved == nil {
-                fmt.Printf("ValidateOeEvidence: Can't filterpolicy\n")
+		fmt.Printf("ValidateOeEvidence: Can't filterpolicy\n")
 		return false, nil, nil
-        }
+	}
 
 	// Debug
 	fmt.Printf("\nfiltered policy:\n")
@@ -2401,7 +2392,7 @@ func ValidateOeEvidence(pubPolicyKey *certprotos.KeyMessage, evp *certprotos.Evi
 	fmt.Printf("\n")
 
 	if !InitProvedStatements(*pubPolicyKey, evp.FactAssertion, alreadyProved) {
-                fmt.Printf("ValidateOeEvidence: Can't InitProvedStatements\n")
+		fmt.Printf("ValidateOeEvidence: Can't InitProvedStatements\n")
 		return false, nil, nil
 	}
 
@@ -2409,10 +2400,10 @@ func ValidateOeEvidence(pubPolicyKey *certprotos.KeyMessage, evp *certprotos.Evi
 	fmt.Printf("\nValidateOeEvidence, after InitProved:\n")
 	PrintProvedStatements(alreadyProved)
 
-        // ConstructProofFromSevPlatformEvidence()
+	// ConstructProofFromSevPlatformEvidence()
 	toProve, proof := ConstructProofFromOeEvidence(pubPolicyKey, purpose, alreadyProved)
 	if toProve == nil || proof == nil {
-                fmt.Printf("ValidateOeEvidence: Can't construct proof\n")
+		fmt.Printf("ValidateOeEvidence: Can't construct proof\n")
 		return false, nil, nil
 	}
 
@@ -2424,21 +2415,21 @@ func ValidateOeEvidence(pubPolicyKey *certprotos.KeyMessage, evp *certprotos.Evi
 	PrintProof(proof)
 	fmt.Printf("\n")
 
-        if !VerifyProof(pubPolicyKey, toProve, proof, alreadyProved) {
-                fmt.Printf("ValidateOeEvidence: Proof does not verify\n")
+	if !VerifyProof(pubPolicyKey, toProve, proof, alreadyProved) {
+		fmt.Printf("ValidateOeEvidence: Proof does not verify\n")
 		return false, nil, nil
-        }
+	}
 
 	// Debug
 	fmt.Printf("ValidateOeEvidence: Proof verifies\n")
 	fmt.Printf("\nProved statements\n")
-        PrintProvedStatements(alreadyProved);
+	PrintProvedStatements(alreadyProved)
 
 	var me *certprotos.VseClause
-	for i := 1; i <= len(alreadyProved.Proved);  i++ {
+	for i := 1; i <= len(alreadyProved.Proved); i++ {
 		me = alreadyProved.Proved[i]
 		if me.Clause != nil && me.Clause.Subject != nil &&
-				me.Clause.Subject.GetEntityType() == "measurement" {
+			me.Clause.Subject.GetEntityType() == "measurement" {
 			return true, toProve, me.Clause.Subject.Measurement
 		}
 	}
@@ -2449,8 +2440,8 @@ func ValidateOeEvidence(pubPolicyKey *certprotos.KeyMessage, evp *certprotos.Evi
 
 // returns success, toProve, measurement
 func ValidateSevEvidence(pubPolicyKey *certprotos.KeyMessage, evp *certprotos.EvidencePackage,
-		originalPolicy *certprotos.ProvedStatements, purpose string) (bool,
-                *certprotos.VseClause, []byte) {
+	originalPolicy *certprotos.ProvedStatements, purpose string) (bool,
+	*certprotos.VseClause, []byte) {
 
 	// Debug
 	fmt.Printf("\nValidateSevEvidence, Original policy:\n")
@@ -2458,9 +2449,9 @@ func ValidateSevEvidence(pubPolicyKey *certprotos.KeyMessage, evp *certprotos.Ev
 
 	alreadyProved := FilterSevPolicy(pubPolicyKey, evp, originalPolicy)
 	if alreadyProved == nil {
-                fmt.Printf("Can't filterpolicy\n")
+		fmt.Printf("Can't filterpolicy\n")
 		return false, nil, nil
-        }
+	}
 
 	// Debug
 	fmt.Printf("\nfiltered policy:\n")
@@ -2468,34 +2459,34 @@ func ValidateSevEvidence(pubPolicyKey *certprotos.KeyMessage, evp *certprotos.Ev
 	fmt.Printf("\n")
 
 	if !InitProvedStatements(*pubPolicyKey, evp.FactAssertion, alreadyProved) {
-                fmt.Printf("ValidateSevEvidence: Can't InitProvedStatements\n")
+		fmt.Printf("ValidateSevEvidence: Can't InitProvedStatements\n")
 		return false, nil, nil
 	}
 
 	// After InitProved alreadyProved should be:
 	//
-	//  00 Key[rsa, policyKey, f91d6331b1fd99b3fa8641fd16dcd4c272a92b8a] is-trusted 
+	//  00 Key[rsa, policyKey, f91d6331b1fd99b3fa8641fd16dcd4c272a92b8a] is-trusted
 	//  01 Key[rsa, policyKey, f91d6331b1fd99b3fa8641fd16dcd4c272a92b8a] says
-	//	Key[rsa, ARKKey, c36d3343d69d9d8000d32d0979adff876e98ec79] is-trusted-for-attestation 
+	//	Key[rsa, ARKKey, c36d3343d69d9d8000d32d0979adff876e98ec79] is-trusted-for-attestation
 	//  02 Key[rsa, policyKey, f91d6331b1fd99b3fa8641fd16dcd4c272a92b8a] says
-	//      Measurement[010203040506070801020304050607080102030405060708010203040506070801020304050607080102030405060708] is-trusted 
+	//      Measurement[010203040506070801020304050607080102030405060708010203040506070801020304050607080102030405060708] is-trusted
 	//  03 Key[rsa, policyKey, f91d6331b1fd99b3fa8641fd16dcd4c272a92b8a] says
 	//	platform[amd-sev-snp, debug: no, migrate: no, api-major: >=0, api-minor: >=0, key-share: no,
-	//		tcb-version: >=0] has-trusted-platform-property 
+	//		tcb-version: >=0] has-trusted-platform-property
 	//  04 Key[rsa, ARKKey, c36d3343d69d9d8000d32d0979adff876e98ec79] says
-	//	Key[rsa, ARKKey, c36d3343d69d9d8000d32d0979adff876e98ec79] is-trusted-for-attestation 
+	//	Key[rsa, ARKKey, c36d3343d69d9d8000d32d0979adff876e98ec79] is-trusted-for-attestation
 	//  05 Key[rsa, ARKKey, c36d3343d69d9d8000d32d0979adff876e98ec79] says
-	//	Key[rsa, ASKKey, c87c716e16df326f58c5fe026eb55133d57239ff] is-trusted-for-attestation 
+	//	Key[rsa, ASKKey, c87c716e16df326f58c5fe026eb55133d57239ff] is-trusted-for-attestation
 	//  06 Key[rsa, ASKKey, c87c716e16df326f58c5fe026eb55133d57239ff] says
 	//	Key[ecc-P-384, VCEKKey,
 	//	d8a35da4a4780fe58fe5a02e5aec7d40fa7452ca89ca4c6620181228b3e4e9c41ab9a200875a2b6e044ae73936408d27]
-	//	is-trusted-for-attestation 
+	//	is-trusted-for-attestation
 	//  07 Key[ecc-P-384, VCEKKey,
 	//	d8a35da4a4780fe58fe5a02e5aec7d40fa7452ca89ca4c6620181228b3e4e9c41ab9a200875a2b6e044ae73936408d27]
 	//	says environment[platform[amd-sev-snp, debug: no, smt: no, migrate: no, api-major: =0,
 	//	api-minor: =0, tcb-version: =0],
 	//	measurement: 010203040506070801020304050607080102030405060708010203040506070801020304050607080102030405060708]
-	//	is-environment 
+	//	is-environment
 	//  08 Key[ecc-P-384, VCEKKey,
 	//	d8a35da4a4780fe58fe5a02e5aec7d40fa7452ca89ca4c6620181228b3e4e9c41ab9a200875a2b6e044ae73936408d27] says
 	//	Key[rsa, policyKey, f91d6331b1fd99b3fa8641fd16dcd4c272a92b8a] speaks-for
@@ -2507,10 +2498,10 @@ func ValidateSevEvidence(pubPolicyKey *certprotos.KeyMessage, evp *certprotos.Ev
 	fmt.Printf("\nValidateSevEvidence, after InitProved:\n")
 	PrintProvedStatements(alreadyProved)
 
-        // ConstructProofFromSevPlatformEvidence()
+	// ConstructProofFromSevPlatformEvidence()
 	toProve, proof := ConstructProofFromSevPlatformEvidence(pubPolicyKey, purpose, alreadyProved)
 	if toProve == nil || proof == nil {
-                fmt.Printf("ValidateSevEvidence: Can't construct proof\n")
+		fmt.Printf("ValidateSevEvidence: Can't construct proof\n")
 		return false, nil, nil
 	}
 
@@ -2522,20 +2513,20 @@ func ValidateSevEvidence(pubPolicyKey *certprotos.KeyMessage, evp *certprotos.Ev
 	PrintProof(proof)
 	fmt.Printf("\n")
 
-        if !VerifyProof(pubPolicyKey, toProve, proof, alreadyProved) {
-                fmt.Printf("ValidateSevEvidence: Proof does not verify\n")
+	if !VerifyProof(pubPolicyKey, toProve, proof, alreadyProved) {
+		fmt.Printf("ValidateSevEvidence: Proof does not verify\n")
 		return false, nil, nil
-        }
+	}
 
 	// Debug
 	fmt.Printf("ValidateSevEvidence: Proof verifies\n")
 	fmt.Printf("\nProved statements\n")
-        PrintProvedStatements(alreadyProved);
+	PrintProvedStatements(alreadyProved)
 
 	me := alreadyProved.Proved[2]
 	if me.Clause == nil || me.Clause.Subject == nil ||
-			me.Clause.Subject.GetEntityType() != "measurement" {
-                fmt.Printf("ValidateSevEvidence: Proof does not verify\n")
+		me.Clause.Subject.GetEntityType() != "measurement" {
+		fmt.Printf("ValidateSevEvidence: Proof does not verify\n")
 		return false, nil, nil
 	}
 
@@ -2543,7 +2534,7 @@ func ValidateSevEvidence(pubPolicyKey *certprotos.KeyMessage, evp *certprotos.Ev
 }
 
 func ConstructGramineClaim(enclaveKey *certprotos.KeyMessage,
-		measurement []byte) *certprotos.VseClause {
+	measurement []byte) *certprotos.VseClause {
 
 	em := MakeKeyEntity(enclaveKey)
 	if em == nil {
@@ -2577,25 +2568,23 @@ func VerifyGramineAttestation(serializedEvidence []byte) (bool, []byte, []byte, 
 	return true, ga.WhatWasSaid, m, nil
 }
 
-
 func FilterGraminePolicy(policyKey *certprotos.KeyMessage, evp *certprotos.EvidencePackage,
-		original *certprotos.ProvedStatements) *certprotos.ProvedStatements {
+	original *certprotos.ProvedStatements) *certprotos.ProvedStatements {
 
 	// Todo: Fix
-        filtered :=  &certprotos.ProvedStatements {}
+	filtered := &certprotos.ProvedStatements{}
 	for i := 0; i < len(original.Proved); i++ {
 		from := original.Proved[i]
-		to :=  proto.Clone(from).(*certprotos.VseClause)
+		to := proto.Clone(from).(*certprotos.VseClause)
 		filtered.Proved = append(filtered.Proved, to)
 	}
 
 	return filtered
 }
 
-
 func ConstructProofFromGramineEvidence(publicPolicyKey *certprotos.KeyMessage, purpose string,
-		alreadyProved *certprotos.ProvedStatements)  (*certprotos.VseClause, *certprotos.Proof) {
-        // At this point, the evidence should be
+	alreadyProved *certprotos.ProvedStatements) (*certprotos.VseClause, *certprotos.Proof) {
+	// At this point, the evidence should be
 	//	Key[rsa, policyKey, d240a7e9489e8adc4eb5261166a0b080f4f5f4d0] is-trusted
 	//	Key[rsa, policyKey, d240a7e9489e8adc4eb5261166a0b080f4f5f4d0] says
 	//		Key[rsa, ARKKey, cdc8112d97fce6767143811f0ed5fb6c21aee424] is-trusted-for-attestation
@@ -2607,7 +2596,7 @@ func ConstructProofFromGramineEvidence(publicPolicyKey *certprotos.KeyMessage, p
 
 	// Debug
 	fmt.Printf("ConstructProofFromGramineEvidence, %d statements\n", len(alreadyProved.Proved))
-	for i := 0; i < len(alreadyProved.Proved);  i++ {
+	for i := 0; i < len(alreadyProved.Proved); i++ {
 		PrintVseClause(alreadyProved.Proved[i])
 		fmt.Printf("\n")
 	}
@@ -2617,13 +2606,13 @@ func ConstructProofFromGramineEvidence(publicPolicyKey *certprotos.KeyMessage, p
 		return nil, nil
 	}
 
-	policyKeyIsTrusted :=  alreadyProved.Proved[0]
+	policyKeyIsTrusted := alreadyProved.Proved[0]
 	policyKeySaysPlatformKeyIsTrustedForAttestation := alreadyProved.Proved[1]
 	policyKeySaysMeasurementIsTrusted := alreadyProved.Proved[2]
-	enclaveKeySpeaksForMeasurement :=  alreadyProved.Proved[4]
+	enclaveKeySpeaksForMeasurement := alreadyProved.Proved[4]
 
 	if policyKeyIsTrusted == nil || enclaveKeySpeaksForMeasurement == nil ||
-			policyKeySaysMeasurementIsTrusted == nil {
+		policyKeySaysMeasurementIsTrusted == nil {
 		fmt.Printf("ConstructProofFromGramineEvidence: evidence missing\n")
 		return nil, nil
 	}
@@ -2634,17 +2623,17 @@ func ConstructProofFromGramineEvidence(publicPolicyKey *certprotos.KeyMessage, p
 	}
 	// platformKeyIsTrustedForAttestation := policyKeySaysPlatformKeyIsTrustedForAttestation.Clause
 
-        proof := &certprotos.Proof{}
-        r1 := int32(1)
-        r3 := int32(3)
-        r7 := int32(7)
+	proof := &certprotos.Proof{}
+	r1 := int32(1)
+	r3 := int32(3)
+	r7 := int32(7)
 
 	enclaveKey := enclaveKeySpeaksForMeasurement.Subject
 	if enclaveKey == nil || enclaveKey.GetEntityType() != "key" {
 		fmt.Printf("ConstructProofFromGramineEvidence: Bad enclave key\n")
 		return nil, nil
 	}
-        var toProve *certprotos.VseClause = nil
+	var toProve *certprotos.VseClause = nil
 	if purpose == "authentication" {
 		verb := "is-trusted-for-authentication"
 		toProve = MakeUnaryVseClause(enclaveKey, &verb)
@@ -2658,10 +2647,10 @@ func ConstructProofFromGramineEvidence(publicPolicyKey *certprotos.KeyMessage, p
 		fmt.Printf("ConstructProofFromGramineEvidence: Can't get measurement\n")
 		return nil, nil
 	}
-	ps1 := certprotos.ProofStep {
-		S1: policyKeyIsTrusted,
-		S2: policyKeySaysMeasurementIsTrusted,
-		Conclusion: measurementIsTrusted,
+	ps1 := certprotos.ProofStep{
+		S1:          policyKeyIsTrusted,
+		S2:          policyKeySaysMeasurementIsTrusted,
+		Conclusion:  measurementIsTrusted,
 		RuleApplied: &r3,
 	}
 	proof.Steps = append(proof.Steps, &ps1)
@@ -2670,30 +2659,30 @@ func ConstructProofFromGramineEvidence(publicPolicyKey *certprotos.KeyMessage, p
 	//	enclaveKey is-trusted-for-authentication (r1) or
 	//	enclaveKey is-trusted-for-attestation (r7)
 	if purpose == "authentication" {
-		ps4 := certprotos.ProofStep {
-			S1: measurementIsTrusted,
-			S2: enclaveKeySpeaksForMeasurement,
-			Conclusion: toProve,
+		ps4 := certprotos.ProofStep{
+			S1:          measurementIsTrusted,
+			S2:          enclaveKeySpeaksForMeasurement,
+			Conclusion:  toProve,
 			RuleApplied: &r1,
 		}
 		proof.Steps = append(proof.Steps, &ps4)
 	} else {
-		ps4 := certprotos.ProofStep {
-			S1: measurementIsTrusted,
-			S2: enclaveKeySpeaksForMeasurement,
-			Conclusion: toProve,
+		ps4 := certprotos.ProofStep{
+			S1:          measurementIsTrusted,
+			S2:          enclaveKeySpeaksForMeasurement,
+			Conclusion:  toProve,
 			RuleApplied: &r7,
 		}
 		proof.Steps = append(proof.Steps, &ps4)
 	}
 
-        return toProve, proof
+	return toProve, proof
 }
 
 // returns success, toProve, measurement
 func ValidateGramineEvidence(pubPolicyKey *certprotos.KeyMessage, evp *certprotos.EvidencePackage,
-		originalPolicy *certprotos.ProvedStatements, purpose string) (bool,
-                *certprotos.VseClause, []byte) {
+	originalPolicy *certprotos.ProvedStatements, purpose string) (bool,
+	*certprotos.VseClause, []byte) {
 
 	// Debug
 	fmt.Printf("\nValidateGramineEvidence, Original policy:\n")
@@ -2701,9 +2690,9 @@ func ValidateGramineEvidence(pubPolicyKey *certprotos.KeyMessage, evp *certproto
 
 	alreadyProved := FilterGraminePolicy(pubPolicyKey, evp, originalPolicy)
 	if alreadyProved == nil {
-                fmt.Printf("ValidateGramineEvidence: Can't filterpolicy\n")
+		fmt.Printf("ValidateGramineEvidence: Can't filterpolicy\n")
 		return false, nil, nil
-        }
+	}
 
 	// Debug
 	fmt.Printf("\nfiltered policy:\n")
@@ -2711,7 +2700,7 @@ func ValidateGramineEvidence(pubPolicyKey *certprotos.KeyMessage, evp *certproto
 	fmt.Printf("\n")
 
 	if !InitProvedStatements(*pubPolicyKey, evp.FactAssertion, alreadyProved) {
-                fmt.Printf("ValidateGramineEvidence: Can't InitProvedStatements\n")
+		fmt.Printf("ValidateGramineEvidence: Can't InitProvedStatements\n")
 		return false, nil, nil
 	}
 
@@ -2719,10 +2708,10 @@ func ValidateGramineEvidence(pubPolicyKey *certprotos.KeyMessage, evp *certproto
 	fmt.Printf("\nValidateGramineEvidence, after InitProved:\n")
 	PrintProvedStatements(alreadyProved)
 
-        // ConstructProofFromSevPlatformEvidence()
+	// ConstructProofFromSevPlatformEvidence()
 	toProve, proof := ConstructProofFromGramineEvidence(pubPolicyKey, purpose, alreadyProved)
 	if toProve == nil || proof == nil {
-                fmt.Printf("ValidateGramineEvidence: Can't construct proof\n")
+		fmt.Printf("ValidateGramineEvidence: Can't construct proof\n")
 		return false, nil, nil
 	}
 
@@ -2734,45 +2723,43 @@ func ValidateGramineEvidence(pubPolicyKey *certprotos.KeyMessage, evp *certproto
 	PrintProof(proof)
 	fmt.Printf("\n")
 
-        if !VerifyProof(pubPolicyKey, toProve, proof, alreadyProved) {
-                fmt.Printf("ValidateGramineEvidence: Proof does not verify\n")
+	if !VerifyProof(pubPolicyKey, toProve, proof, alreadyProved) {
+		fmt.Printf("ValidateGramineEvidence: Proof does not verify\n")
 		return false, nil, nil
-        }
+	}
 
 	// Debug
 	fmt.Printf("ValidateGramineEvidence: Proof verifies\n")
 	fmt.Printf("\nProved statements\n")
-        PrintProvedStatements(alreadyProved);
+	PrintProvedStatements(alreadyProved)
 
 	me := alreadyProved.Proved[2]
 	if me.Clause == nil || me.Clause.Subject == nil ||
-			me.Clause.Subject.GetEntityType() != "measurement" {
-                fmt.Printf("ValidateGramineEvidence: Proof does not verify\n")
+		me.Clause.Subject.GetEntityType() != "measurement" {
+		fmt.Printf("ValidateGramineEvidence: Proof does not verify\n")
 		return false, nil, nil
 	}
 
 	return true, toProve, me.Clause.Subject.Measurement
 }
 
-
 func FilterKeystonePolicy(policyKey *certprotos.KeyMessage, evp *certprotos.EvidencePackage,
-		original *certprotos.ProvedStatements) *certprotos.ProvedStatements {
+	original *certprotos.ProvedStatements) *certprotos.ProvedStatements {
 
 	// Todo: Fix when we import new filter framework
-        filtered :=  &certprotos.ProvedStatements {}
+	filtered := &certprotos.ProvedStatements{}
 	for i := 0; i < len(original.Proved); i++ {
 		from := original.Proved[i]
-		to :=  proto.Clone(from).(*certprotos.VseClause)
+		to := proto.Clone(from).(*certprotos.VseClause)
 		filtered.Proved = append(filtered.Proved, to)
 	}
 
 	return filtered
 }
 
-
 func ConstructProofFromKeystoneEvidence(publicPolicyKey *certprotos.KeyMessage, purpose string,
-		alreadyProved *certprotos.ProvedStatements)  (*certprotos.VseClause, *certprotos.Proof) {
-        // At this point, the evidence should be
+	alreadyProved *certprotos.ProvedStatements) (*certprotos.VseClause, *certprotos.Proof) {
+	// At this point, the evidence should be
 	//	Key[rsa, policyKey, d240a7e9489e8adc4eb5261166a0b080f4f5f4d0] is-trusted
 	//	Key[rsa, policyKey, d240a7e9489e8adc4eb5261166a0b080f4f5f4d0] says
 	//		Key[rsa, AttestKey, cdc8112d97fce6767143811f0ed5fb6c21aee424] is-trusted-for-attestation
@@ -2782,7 +2769,7 @@ func ConstructProofFromKeystoneEvidence(publicPolicyKey *certprotos.KeyMessage, 
 
 	// Debug
 	fmt.Printf("ConstructProofFromKeystoneEvidence, %d statements\n", len(alreadyProved.Proved))
-	for i := 0; i < len(alreadyProved.Proved);  i++ {
+	for i := 0; i < len(alreadyProved.Proved); i++ {
 		PrintVseClause(alreadyProved.Proved[i])
 		fmt.Printf("\n")
 	}
@@ -2792,7 +2779,7 @@ func ConstructProofFromKeystoneEvidence(publicPolicyKey *certprotos.KeyMessage, 
 		return nil, nil
 	}
 
-	policyKeyIsTrusted :=  alreadyProved.Proved[0]
+	policyKeyIsTrusted := alreadyProved.Proved[0]
 	policyKeySaysAttestKeyIsTrustedForAttestation := alreadyProved.Proved[1]
 	policyKeySaysMeasurementIsTrusted := alreadyProved.Proved[2]
 	if alreadyProved.Proved[3].Clause == nil {
@@ -2800,10 +2787,10 @@ func ConstructProofFromKeystoneEvidence(publicPolicyKey *certprotos.KeyMessage, 
 		return nil, nil
 	}
 	attestKeySaysEnclaveKeySpeaksForMeasurement := alreadyProved.Proved[3]
-	enclaveKeySpeaksForMeasurement :=  alreadyProved.Proved[3].Clause
+	enclaveKeySpeaksForMeasurement := alreadyProved.Proved[3].Clause
 
 	if policyKeyIsTrusted == nil || enclaveKeySpeaksForMeasurement == nil ||
-			policyKeySaysMeasurementIsTrusted == nil {
+		policyKeySaysMeasurementIsTrusted == nil {
 		fmt.Printf("ConstructProofFromKeystoneEvidence: evidence missing\n")
 		return nil, nil
 	}
@@ -2813,18 +2800,18 @@ func ConstructProofFromKeystoneEvidence(publicPolicyKey *certprotos.KeyMessage, 
 		return nil, nil
 	}
 
-        proof := &certprotos.Proof{}
-        r1 := int32(1)
-        r3 := int32(3)
-        r6 := int32(6)
-        r7 := int32(7)
+	proof := &certprotos.Proof{}
+	r1 := int32(1)
+	r3 := int32(3)
+	r6 := int32(6)
+	r7 := int32(7)
 
 	enclaveKey := enclaveKeySpeaksForMeasurement.Subject
 	if enclaveKey == nil || enclaveKey.GetEntityType() != "key" {
 		fmt.Printf("ConstructProofFromKeystoneEvidence: Bad enclave key\n")
 		return nil, nil
 	}
-        var toProve *certprotos.VseClause = nil
+	var toProve *certprotos.VseClause = nil
 	if purpose == "authentication" {
 		verb := "is-trusted-for-authentication"
 		toProve = MakeUnaryVseClause(enclaveKey, &verb)
@@ -2838,10 +2825,10 @@ func ConstructProofFromKeystoneEvidence(publicPolicyKey *certprotos.KeyMessage, 
 		fmt.Printf("ConstructProofFromKeystoneEvidence: Can't get measurement\n")
 		return nil, nil
 	}
-	ps1 := certprotos.ProofStep {
-		S1: policyKeyIsTrusted,
-		S2: policyKeySaysMeasurementIsTrusted,
-		Conclusion: measurementIsTrusted,
+	ps1 := certprotos.ProofStep{
+		S1:          policyKeyIsTrusted,
+		S2:          policyKeySaysMeasurementIsTrusted,
+		Conclusion:  measurementIsTrusted,
 		RuleApplied: &r3,
 	}
 	proof.Steps = append(proof.Steps, &ps1)
@@ -2854,10 +2841,10 @@ func ConstructProofFromKeystoneEvidence(publicPolicyKey *certprotos.KeyMessage, 
 		return nil, nil
 	}
 	attestKeyIsTrustedForAttestation := policyKeySaysAttestKeyIsTrustedForAttestation.Clause
-	ps2 := certprotos.ProofStep {
-		S1: policyKeyIsTrusted,
-		S2: policyKeySaysAttestKeyIsTrustedForAttestation,
-		Conclusion: attestKeyIsTrustedForAttestation,
+	ps2 := certprotos.ProofStep{
+		S1:          policyKeyIsTrusted,
+		S2:          policyKeySaysAttestKeyIsTrustedForAttestation,
+		Conclusion:  attestKeyIsTrustedForAttestation,
 		RuleApplied: &r3,
 	}
 	proof.Steps = append(proof.Steps, &ps2)
@@ -2865,10 +2852,10 @@ func ConstructProofFromKeystoneEvidence(publicPolicyKey *certprotos.KeyMessage, 
 	// add attestKey is-trusted-for-attestation AND
 	// attestKey says enclaveKey speaks-for measurement -->
 	// enclaveKey speaks-for measurement
-	ps3 := certprotos.ProofStep {
-		S1: attestKeyIsTrustedForAttestation,
-		S2: attestKeySaysEnclaveKeySpeaksForMeasurement,
-		Conclusion: enclaveKeySpeaksForMeasurement,
+	ps3 := certprotos.ProofStep{
+		S1:          attestKeyIsTrustedForAttestation,
+		S2:          attestKeySaysEnclaveKeySpeaksForMeasurement,
+		Conclusion:  enclaveKeySpeaksForMeasurement,
 		RuleApplied: &r6,
 	}
 	proof.Steps = append(proof.Steps, &ps3)
@@ -2877,30 +2864,30 @@ func ConstructProofFromKeystoneEvidence(publicPolicyKey *certprotos.KeyMessage, 
 	//	enclaveKey is-trusted-for-authentication (r1) or
 	//	enclaveKey is-trusted-for-attestation (r7)
 	if purpose == "authentication" {
-		ps4 := certprotos.ProofStep {
-			S1: measurementIsTrusted,
-			S2: enclaveKeySpeaksForMeasurement,
-			Conclusion: toProve,
+		ps4 := certprotos.ProofStep{
+			S1:          measurementIsTrusted,
+			S2:          enclaveKeySpeaksForMeasurement,
+			Conclusion:  toProve,
 			RuleApplied: &r1,
 		}
 		proof.Steps = append(proof.Steps, &ps4)
 	} else {
-		ps4 := certprotos.ProofStep {
-			S1: measurementIsTrusted,
-			S2: enclaveKeySpeaksForMeasurement,
-			Conclusion: toProve,
+		ps4 := certprotos.ProofStep{
+			S1:          measurementIsTrusted,
+			S2:          enclaveKeySpeaksForMeasurement,
+			Conclusion:  toProve,
 			RuleApplied: &r7,
 		}
 		proof.Steps = append(proof.Steps, &ps4)
 	}
 
-        return toProve, proof
+	return toProve, proof
 }
 
 // returns success, toProve, measurement
 func ValidateKeystoneEvidence(pubPolicyKey *certprotos.KeyMessage, evp *certprotos.EvidencePackage,
-		originalPolicy *certprotos.ProvedStatements, purpose string) (bool,
-                *certprotos.VseClause, []byte) {
+	originalPolicy *certprotos.ProvedStatements, purpose string) (bool,
+	*certprotos.VseClause, []byte) {
 
 	// Debug
 	fmt.Printf("\nValidateKeystoneEvidence, Original policy:\n")
@@ -2908,9 +2895,9 @@ func ValidateKeystoneEvidence(pubPolicyKey *certprotos.KeyMessage, evp *certprot
 
 	alreadyProved := FilterKeystonePolicy(pubPolicyKey, evp, originalPolicy)
 	if alreadyProved == nil {
-                fmt.Printf("ValidateKeystoneEvidence: Can't filterpolicy\n")
+		fmt.Printf("ValidateKeystoneEvidence: Can't filterpolicy\n")
 		return false, nil, nil
-        }
+	}
 
 	// Debug
 	fmt.Printf("\nfiltered policy:\n")
@@ -2918,7 +2905,7 @@ func ValidateKeystoneEvidence(pubPolicyKey *certprotos.KeyMessage, evp *certprot
 	fmt.Printf("\n")
 
 	if !InitProvedStatements(*pubPolicyKey, evp.FactAssertion, alreadyProved) {
-                fmt.Printf("ValidateKeystoneEvidence: Can't InitProvedStatements\n")
+		fmt.Printf("ValidateKeystoneEvidence: Can't InitProvedStatements\n")
 		return false, nil, nil
 	}
 
@@ -2926,10 +2913,10 @@ func ValidateKeystoneEvidence(pubPolicyKey *certprotos.KeyMessage, evp *certprot
 	fmt.Printf("\nValidateKeystoneEvidence, after InitProved:\n")
 	PrintProvedStatements(alreadyProved)
 
-        // ConstructProofFromSevPlatformEvidence()
+	// ConstructProofFromSevPlatformEvidence()
 	toProve, proof := ConstructProofFromKeystoneEvidence(pubPolicyKey, purpose, alreadyProved)
 	if toProve == nil || proof == nil {
-                fmt.Printf("ValidateKeystoneEvidence: Can't construct proof\n")
+		fmt.Printf("ValidateKeystoneEvidence: Can't construct proof\n")
 		return false, nil, nil
 	}
 
@@ -2941,45 +2928,43 @@ func ValidateKeystoneEvidence(pubPolicyKey *certprotos.KeyMessage, evp *certprot
 	PrintProof(proof)
 	fmt.Printf("\n")
 
-        if !VerifyProof(pubPolicyKey, toProve, proof, alreadyProved) {
-                fmt.Printf("ValidateKeystoneEvidence: Proof does not verify\n")
+	if !VerifyProof(pubPolicyKey, toProve, proof, alreadyProved) {
+		fmt.Printf("ValidateKeystoneEvidence: Proof does not verify\n")
 		return false, nil, nil
-        }
+	}
 
 	// Debug
 	fmt.Printf("ValidateKeystoneEvidence: Proof verifies\n")
 	fmt.Printf("\nProved statements\n")
-        PrintProvedStatements(alreadyProved);
+	PrintProvedStatements(alreadyProved)
 
 	me := alreadyProved.Proved[2]
 	if me.Clause == nil || me.Clause.Subject == nil ||
-			me.Clause.Subject.GetEntityType() != "measurement" {
-                fmt.Printf("ValidateKeystoneEvidence: Proof does not verify\n")
+		me.Clause.Subject.GetEntityType() != "measurement" {
+		fmt.Printf("ValidateKeystoneEvidence: Proof does not verify\n")
 		return false, nil, nil
 	}
 
 	return true, toProve, me.Clause.Subject.Measurement
 }
 
-
 func FilterIsletPolicy(policyKey *certprotos.KeyMessage, evp *certprotos.EvidencePackage,
-		original *certprotos.ProvedStatements) *certprotos.ProvedStatements {
+	original *certprotos.ProvedStatements) *certprotos.ProvedStatements {
 
 	// Todo: Fix when we import new filter framework
-        filtered :=  &certprotos.ProvedStatements {}
+	filtered := &certprotos.ProvedStatements{}
 	for i := 0; i < len(original.Proved); i++ {
 		from := original.Proved[i]
-		to :=  proto.Clone(from).(*certprotos.VseClause)
+		to := proto.Clone(from).(*certprotos.VseClause)
 		filtered.Proved = append(filtered.Proved, to)
 	}
 
 	return filtered
 }
 
-
 func ConstructProofFromIsletEvidence(publicPolicyKey *certprotos.KeyMessage, purpose string,
-		alreadyProved *certprotos.ProvedStatements)  (*certprotos.VseClause, *certprotos.Proof) {
-        // At this point, the evidence should be
+	alreadyProved *certprotos.ProvedStatements) (*certprotos.VseClause, *certprotos.Proof) {
+	// At this point, the evidence should be
 	//	Key[rsa, policyKey, d240a7e9489e8adc4eb5261166a0b080f4f5f4d0] is-trusted
 	//	Key[rsa, policyKey, d240a7e9489e8adc4eb5261166a0b080f4f5f4d0] says
 	//		Key[rsa, AttestKey, cdc8112d97fce6767143811f0ed5fb6c21aee424] is-trusted-for-attestation
@@ -2989,7 +2974,7 @@ func ConstructProofFromIsletEvidence(publicPolicyKey *certprotos.KeyMessage, pur
 
 	// Debug
 	fmt.Printf("ConstructProofFromIsletEvidence, %d statements\n", len(alreadyProved.Proved))
-	for i := 0; i < len(alreadyProved.Proved);  i++ {
+	for i := 0; i < len(alreadyProved.Proved); i++ {
 		PrintVseClause(alreadyProved.Proved[i])
 		fmt.Printf("\n")
 	}
@@ -2999,7 +2984,7 @@ func ConstructProofFromIsletEvidence(publicPolicyKey *certprotos.KeyMessage, pur
 		return nil, nil
 	}
 
-	policyKeyIsTrusted :=  alreadyProved.Proved[0]
+	policyKeyIsTrusted := alreadyProved.Proved[0]
 	policyKeySaysAttestKeyIsTrustedForAttestation := alreadyProved.Proved[1]
 	policyKeySaysMeasurementIsTrusted := alreadyProved.Proved[2]
 	if alreadyProved.Proved[3].Clause == nil {
@@ -3007,10 +2992,10 @@ func ConstructProofFromIsletEvidence(publicPolicyKey *certprotos.KeyMessage, pur
 		return nil, nil
 	}
 	attestKeySaysEnclaveKeySpeaksForMeasurement := alreadyProved.Proved[3]
-	enclaveKeySpeaksForMeasurement :=  alreadyProved.Proved[3].Clause
+	enclaveKeySpeaksForMeasurement := alreadyProved.Proved[3].Clause
 
 	if policyKeyIsTrusted == nil || enclaveKeySpeaksForMeasurement == nil ||
-			policyKeySaysMeasurementIsTrusted == nil {
+		policyKeySaysMeasurementIsTrusted == nil {
 		fmt.Printf("ConstructProofFromIsletEvidence: evidence missing\n")
 		return nil, nil
 	}
@@ -3020,18 +3005,18 @@ func ConstructProofFromIsletEvidence(publicPolicyKey *certprotos.KeyMessage, pur
 		return nil, nil
 	}
 
-        proof := &certprotos.Proof{}
-        r1 := int32(1)
-        r3 := int32(3)
-        r6 := int32(6)
-        r7 := int32(7)
+	proof := &certprotos.Proof{}
+	r1 := int32(1)
+	r3 := int32(3)
+	r6 := int32(6)
+	r7 := int32(7)
 
 	enclaveKey := enclaveKeySpeaksForMeasurement.Subject
 	if enclaveKey == nil || enclaveKey.GetEntityType() != "key" {
 		fmt.Printf("ConstructProofFromIsletEvidence: Bad enclave key\n")
 		return nil, nil
 	}
-        var toProve *certprotos.VseClause = nil
+	var toProve *certprotos.VseClause = nil
 	if purpose == "authentication" {
 		verb := "is-trusted-for-authentication"
 		toProve = MakeUnaryVseClause(enclaveKey, &verb)
@@ -3045,10 +3030,10 @@ func ConstructProofFromIsletEvidence(publicPolicyKey *certprotos.KeyMessage, pur
 		fmt.Printf("ConstructProofFromIsletEvidence: Can't get measurement\n")
 		return nil, nil
 	}
-	ps1 := certprotos.ProofStep {
-		S1: policyKeyIsTrusted,
-		S2: policyKeySaysMeasurementIsTrusted,
-		Conclusion: measurementIsTrusted,
+	ps1 := certprotos.ProofStep{
+		S1:          policyKeyIsTrusted,
+		S2:          policyKeySaysMeasurementIsTrusted,
+		Conclusion:  measurementIsTrusted,
 		RuleApplied: &r3,
 	}
 	proof.Steps = append(proof.Steps, &ps1)
@@ -3061,10 +3046,10 @@ func ConstructProofFromIsletEvidence(publicPolicyKey *certprotos.KeyMessage, pur
 		return nil, nil
 	}
 	attestKeyIsTrustedForAttestation := policyKeySaysAttestKeyIsTrustedForAttestation.Clause
-	ps2 := certprotos.ProofStep {
-		S1: policyKeyIsTrusted,
-		S2: policyKeySaysAttestKeyIsTrustedForAttestation,
-		Conclusion: attestKeyIsTrustedForAttestation,
+	ps2 := certprotos.ProofStep{
+		S1:          policyKeyIsTrusted,
+		S2:          policyKeySaysAttestKeyIsTrustedForAttestation,
+		Conclusion:  attestKeyIsTrustedForAttestation,
 		RuleApplied: &r3,
 	}
 	proof.Steps = append(proof.Steps, &ps2)
@@ -3072,10 +3057,10 @@ func ConstructProofFromIsletEvidence(publicPolicyKey *certprotos.KeyMessage, pur
 	// add attestKey is-trusted-for-attestation AND
 	// attestKey says enclaveKey speaks-for measurement -->
 	// enclaveKey speaks-for measurement
-	ps3 := certprotos.ProofStep {
-		S1: attestKeyIsTrustedForAttestation,
-		S2: attestKeySaysEnclaveKeySpeaksForMeasurement,
-		Conclusion: enclaveKeySpeaksForMeasurement,
+	ps3 := certprotos.ProofStep{
+		S1:          attestKeyIsTrustedForAttestation,
+		S2:          attestKeySaysEnclaveKeySpeaksForMeasurement,
+		Conclusion:  enclaveKeySpeaksForMeasurement,
 		RuleApplied: &r6,
 	}
 	proof.Steps = append(proof.Steps, &ps3)
@@ -3084,30 +3069,30 @@ func ConstructProofFromIsletEvidence(publicPolicyKey *certprotos.KeyMessage, pur
 	//	enclaveKey is-trusted-for-authentication (r1) or
 	//	enclaveKey is-trusted-for-attestation (r7)
 	if purpose == "authentication" {
-		ps4 := certprotos.ProofStep {
-			S1: measurementIsTrusted,
-			S2: enclaveKeySpeaksForMeasurement,
-			Conclusion: toProve,
+		ps4 := certprotos.ProofStep{
+			S1:          measurementIsTrusted,
+			S2:          enclaveKeySpeaksForMeasurement,
+			Conclusion:  toProve,
 			RuleApplied: &r1,
 		}
 		proof.Steps = append(proof.Steps, &ps4)
 	} else {
-		ps4 := certprotos.ProofStep {
-			S1: measurementIsTrusted,
-			S2: enclaveKeySpeaksForMeasurement,
-			Conclusion: toProve,
+		ps4 := certprotos.ProofStep{
+			S1:          measurementIsTrusted,
+			S2:          enclaveKeySpeaksForMeasurement,
+			Conclusion:  toProve,
 			RuleApplied: &r7,
 		}
 		proof.Steps = append(proof.Steps, &ps4)
 	}
 
-        return toProve, proof
+	return toProve, proof
 }
 
 // returns success, toProve, measurement
 func ValidateIsletEvidence(pubPolicyKey *certprotos.KeyMessage, evp *certprotos.EvidencePackage,
-		originalPolicy *certprotos.ProvedStatements, purpose string) (bool,
-                *certprotos.VseClause, []byte) {
+	originalPolicy *certprotos.ProvedStatements, purpose string) (bool,
+	*certprotos.VseClause, []byte) {
 
 	// Debug
 	fmt.Printf("\nValidateIsletEvidence, Original policy:\n")
@@ -3115,9 +3100,9 @@ func ValidateIsletEvidence(pubPolicyKey *certprotos.KeyMessage, evp *certprotos.
 
 	alreadyProved := FilterIsletPolicy(pubPolicyKey, evp, originalPolicy)
 	if alreadyProved == nil {
-                fmt.Printf("ValidateIsletEvidence: Can't filterpolicy\n")
+		fmt.Printf("ValidateIsletEvidence: Can't filterpolicy\n")
 		return false, nil, nil
-        }
+	}
 
 	// Debug
 	fmt.Printf("\nfiltered policy:\n")
@@ -3125,7 +3110,7 @@ func ValidateIsletEvidence(pubPolicyKey *certprotos.KeyMessage, evp *certprotos.
 	fmt.Printf("\n")
 
 	if !InitProvedStatements(*pubPolicyKey, evp.FactAssertion, alreadyProved) {
-                fmt.Printf("ValidateIsletEvidence: Can't InitProvedStatements\n")
+		fmt.Printf("ValidateIsletEvidence: Can't InitProvedStatements\n")
 		return false, nil, nil
 	}
 
@@ -3135,7 +3120,7 @@ func ValidateIsletEvidence(pubPolicyKey *certprotos.KeyMessage, evp *certprotos.
 
 	toProve, proof := ConstructProofFromIsletEvidence(pubPolicyKey, purpose, alreadyProved)
 	if toProve == nil || proof == nil {
-                fmt.Printf("ValidateKeystoneEvidence: Can't construct proof\n")
+		fmt.Printf("ValidateKeystoneEvidence: Can't construct proof\n")
 		return false, nil, nil
 	}
 
@@ -3155,11 +3140,11 @@ func ValidateIsletEvidence(pubPolicyKey *certprotos.KeyMessage, evp *certprotos.
 	// Debug
 	fmt.Printf("ValidateIsletEvidence: Proof verifies\n")
 	fmt.Printf("\nProved statements\n")
-	PrintProvedStatements(alreadyProved);
+	PrintProvedStatements(alreadyProved)
 
 	me := alreadyProved.Proved[2]
 	if me.Clause == nil || me.Clause.Subject == nil ||
-			me.Clause.Subject.GetEntityType() != "measurement" {
+		me.Clause.Subject.GetEntityType() != "measurement" {
 		fmt.Printf("ValidateIsletEvidence: Proof does not verify\n")
 		return false, nil, nil
 	}

--- a/certifier_service/certlib/certlib_support.go
+++ b/certifier_service/certlib/certlib_support.go
@@ -16,36 +16,36 @@ package certlib
 
 import (
 	"bytes"
-	"encoding/asn1"
-	"fmt"
-	"math/big"
 	"crypto"
 	"crypto/aes"
+	"crypto/cipher"
 	"crypto/ecdsa"
 	"crypto/elliptic"
-	"crypto/cipher"
 	"crypto/hmac"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/sha256"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/asn1"
 	b64 "encoding/base64"
 	"errors"
+	"fmt"
+	certprotos "github.com/vmware-research/certifier-framework-for-confidential-computing/certifier_service/certprotos"
+	"google.golang.org/protobuf/proto"
+	"math/big"
 	"net"
 	"strings"
 	"time"
-	"google.golang.org/protobuf/proto"
-	certprotos "github.com/vmware-research/certifier-framework-for-confidential-computing/certifier_service/certprotos"
 	// oeverify   "github.com/vmware-research/certifier-framework-for-confidential-computing/certifier_service/oeverify"
 )
 
 //  --------------------------------------------------------------------
 
 type PredicateDominance struct {
-	Predicate string
+	Predicate  string
 	FirstChild *PredicateDominance
-	Next *PredicateDominance
+	Next       *PredicateDominance
 }
 
 func Spaces(i int) {
@@ -54,7 +54,7 @@ func Spaces(i int) {
 	}
 }
 
-func PrintDominanceNode (ind int, node *PredicateDominance) {
+func PrintDominanceNode(ind int, node *PredicateDominance) {
 	if node == nil {
 		fmt.Printf("\n")
 		return
@@ -64,9 +64,9 @@ func PrintDominanceNode (ind int, node *PredicateDominance) {
 }
 
 func PrintDominanceTree(ind int, tree *PredicateDominance) {
-	PrintDominanceNode (ind, tree)
+	PrintDominanceNode(ind, tree)
 	for n := tree.FirstChild; n != nil; n = n.Next {
-		PrintDominanceTree(ind + 2, n)
+		PrintDominanceTree(ind+2, n)
 	}
 }
 
@@ -76,7 +76,7 @@ func FindNode(node *PredicateDominance, pred string) *PredicateDominance {
 	}
 	for n := node.FirstChild; n != nil; n = n.Next {
 		ret := FindNode(n, pred)
-		if ret !=  nil {
+		if ret != nil {
 			return ret
 		}
 		n = n.Next
@@ -90,15 +90,15 @@ func Insert(r *PredicateDominance, parent string, descendant string) bool {
 		return false
 	}
 
-	ret :=  FindNode(r, parent)
+	ret := FindNode(r, parent)
 	if ret == nil {
 		return false
 	}
-	oldFirst :=  ret.FirstChild
-	pd := &PredicateDominance {
-		Predicate: descendant,
+	oldFirst := ret.FirstChild
+	pd := &PredicateDominance{
+		Predicate:  descendant,
 		FirstChild: nil,
-		Next: oldFirst,
+		Next:       oldFirst,
 	}
 	ret.FirstChild = pd
 	return true
@@ -136,13 +136,13 @@ func InitDominance(root *PredicateDominance) bool {
 	root.Next = nil
 
 	if !Insert(root, "is-trusted", "is-trusted-for-attestation") {
-		return false;
+		return false
 	}
 	if !Insert(root, "is-trusted", "is-trusted-for-authentication") {
-		return false;
+		return false
 	}
 
-	return true;
+	return true
 }
 
 func PrintTimePoint(tp *certprotos.TimePoint) {
@@ -171,12 +171,12 @@ func TimePointNow() *certprotos.TimePoint {
 	h := int32(t.Hour())
 	mi := int32(t.Minute())
 	sec := float64(t.Second())
-	tp := certprotos.TimePoint {
-		Year: &y,
-		Month: &mo,
-		Day: &d,
-		Hour: &h,
-		Minute: &mi,
+	tp := certprotos.TimePoint{
+		Year:    &y,
+		Month:   &mo,
+		Day:     &d,
+		Hour:    &h,
+		Minute:  &mi,
 		Seconds: &sec,
 	}
 	return &tp
@@ -186,40 +186,40 @@ func TimePointNow() *certprotos.TimePoint {
 // if t1 the same as t2, return 0
 // if t1 is earlier than t2, return -1
 func CompareTimePoints(t1 *certprotos.TimePoint, t2 *certprotos.TimePoint) int {
-	if (t1.GetYear() > t2.GetYear()) {
+	if t1.GetYear() > t2.GetYear() {
 		return 1
 	}
-	if (t1.GetYear() < t2.GetYear()) {
+	if t1.GetYear() < t2.GetYear() {
 		return -1
 	}
-	if (t1.GetMonth() > t2.GetMonth()) {
+	if t1.GetMonth() > t2.GetMonth() {
 		return 1
 	}
-	if (t1.GetMonth() < t2.GetMonth()) {
+	if t1.GetMonth() < t2.GetMonth() {
 		return -1
 	}
-	if (t1.GetDay() > t2.GetDay()) {
+	if t1.GetDay() > t2.GetDay() {
 		return 1
 	}
-	if (t1.GetDay() < t2.GetDay()) {
+	if t1.GetDay() < t2.GetDay() {
 		return -1
 	}
-	if (t1.GetHour() > t2.GetHour()) {
+	if t1.GetHour() > t2.GetHour() {
 		return 1
 	}
-	if (t1.GetHour() < t2.GetHour()) {
+	if t1.GetHour() < t2.GetHour() {
 		return -1
 	}
-	if (t1.GetMinute() > t2.GetMinute()) {
+	if t1.GetMinute() > t2.GetMinute() {
 		return 1
 	}
-	if (t1.GetMinute() < t2.GetMinute()) {
+	if t1.GetMinute() < t2.GetMinute() {
 		return -1
 	}
-	if (t1.GetSeconds() > t2.GetSeconds()) {
+	if t1.GetSeconds() > t2.GetSeconds() {
 		return 1
 	}
-	if (t1.GetSeconds() < t2.GetSeconds()) {
+	if t1.GetSeconds() < t2.GetSeconds() {
 		return -1
 	}
 	return 0
@@ -236,11 +236,11 @@ func TimePointPlus(t *certprotos.TimePoint, d float64) *certprotos.TimePoint {
 	tp.Year = &yy
 	tp.Month = &mm
 	tp.Day = &dd
-	tp.Hour= &hh
+	tp.Hour = &hh
 	tp.Minute = &mmi
 	tp.Seconds = &ss
 
-	ns := t.GetSeconds() + d;
+	ns := t.GetSeconds() + d
 	ny := int32(ns / (365.0 * 86400))
 	*tp.Year += ny
 	ns -= float64(ny) * 365.0 * 86400
@@ -252,19 +252,19 @@ func TimePointPlus(t *certprotos.TimePoint, d float64) *certprotos.TimePoint {
 	ns -= float64(nm * 60)
 	*tp.Seconds = ns
 	nm += *tp.Minute
-	i:= int32(nm / 60)
-	*tp.Minute = nm - 60 * i
+	i := int32(nm / 60)
+	*tp.Minute = nm - 60*i
 	nh += i + *tp.Hour
 	i = int32(nh / 24)
-	*tp.Hour = nh - 24 * i
+	*tp.Hour = nh - 24*i
 	nd += i + *tp.Day
 	var exitFlag = false
-	mo:= *tp.Month
+	mo := *tp.Month
 	for {
 		if exitFlag {
 			break
 		}
-		switch(1 + ((mo - 1) % 12)) {
+		switch 1 + ((mo - 1) % 12) {
 		case 2:
 			if nd <= 28 {
 				exitFlag = true
@@ -291,9 +291,9 @@ func TimePointPlus(t *certprotos.TimePoint, d float64) *certprotos.TimePoint {
 			}
 		}
 	}
-	ny =  (mo - 1) / 12
+	ny = (mo - 1) / 12
 	*tp.Year += ny
-	*tp.Month =  mo  -  ny * 12
+	*tp.Month = mo - ny*12
 	return &tp
 }
 
@@ -309,21 +309,21 @@ func StringToTimePoint(s string) *certprotos.TimePoint {
 	tp.Year = &y
 	tp.Month = &m
 	tp.Day = &d
-	tp.Hour= &h
+	tp.Hour = &h
 	tp.Minute = &mi
 	tp.Seconds = &sec
 	return &tp
 }
 
 func SamePoint(p1 *certprotos.PointMessage, p2 *certprotos.PointMessage) bool {
-	if p1.X == nil || p1.Y == nil || p2.X == nil || p2.Y ==nil {
+	if p1.X == nil || p1.Y == nil || p2.X == nil || p2.Y == nil {
 		return false
 	}
 	return bytes.Equal(p1.X, p2.X) && bytes.Equal(p1.Y, p2.Y)
 }
 
 func GetEccKeysFromInternal(k *certprotos.KeyMessage) (*ecdsa.PrivateKey, *ecdsa.PublicKey, error) {
-	if  k == nil || k.EccKey == nil {
+	if k == nil || k.EccKey == nil {
 		fmt.Printf("GetEccKeysFromInternal: no ecc key\n")
 		return nil, nil, errors.New("EccKey")
 	}
@@ -331,7 +331,7 @@ func GetEccKeysFromInternal(k *certprotos.KeyMessage) (*ecdsa.PrivateKey, *ecdsa
 		fmt.Printf("GetEccKeysFromInternal: no public point\n")
 		return nil, nil, errors.New("EccKey")
 	}
-	if k.EccKey.BasePoint == nil  {
+	if k.EccKey.BasePoint == nil {
 		fmt.Printf("GetEccKeysFromInternal: no base\n")
 		return nil, nil, errors.New("no base point")
 	}
@@ -340,41 +340,41 @@ func GetEccKeysFromInternal(k *certprotos.KeyMessage) (*ecdsa.PrivateKey, *ecdsa
 	tY := new(big.Int).SetBytes(k.EccKey.PublicPoint.Y)
 
 	if k.GetKeyType() == "ecc-384-public" {
-		PK := &ecdsa.PublicKey {
+		PK := &ecdsa.PublicKey{
 			Curve: elliptic.P384(),
-			X: tX,
-			Y: tY,
+			X:     tX,
+			Y:     tY,
 		}
 		return nil, PK, nil
 	} else if k.GetKeyType() == "ecc-384-private" {
-		PK := &ecdsa.PublicKey {
+		PK := &ecdsa.PublicKey{
 			Curve: elliptic.P384(),
-			X: tX,
-			Y: tY,
+			X:     tX,
+			Y:     tY,
 		}
 		D := new(big.Int).SetBytes(k.EccKey.PrivateMultiplier)
-		pK := &ecdsa.PrivateKey {
+		pK := &ecdsa.PrivateKey{
 			PublicKey: *PK,
-			D: D,
+			D:         D,
 		}
 		return pK, PK, nil
 	} else if k.GetKeyType() == "ecc-256-public" {
-		PK := &ecdsa.PublicKey {
+		PK := &ecdsa.PublicKey{
 			Curve: elliptic.P256(),
-			X: tX,
-			Y: tY,
+			X:     tX,
+			Y:     tY,
 		}
 		return nil, PK, nil
 	} else if k.GetKeyType() == "ecc-256-private" {
-		PK := &ecdsa.PublicKey {
+		PK := &ecdsa.PublicKey{
 			Curve: elliptic.P256(),
-			X: tX,
-			Y: tY,
+			X:     tX,
+			Y:     tY,
 		}
 		D := new(big.Int).SetBytes(k.EccKey.PrivateMultiplier)
-		pK := &ecdsa.PrivateKey {
+		pK := &ecdsa.PrivateKey{
 			PublicKey: *PK,
-			D: D,
+			D:         D,
 		}
 		return pK, PK, nil
 	} else {
@@ -396,7 +396,7 @@ func GetInternalKeyFromEccPublicKey(name string, PK *ecdsa.PublicKey, km *certpr
 		return false
 	}
 
-	byteSize := 1 + p.BitSize / 8
+	byteSize := 1 + p.BitSize/8
 	if p.BitSize == 256 {
 		nm = "P-256"
 		ktype = "ecc-256-public"
@@ -408,7 +408,7 @@ func GetInternalKeyFromEccPublicKey(name string, PK *ecdsa.PublicKey, km *certpr
 		return false
 	}
 	km.KeyType = &ktype
-	if p.P == nil  || p.B == nil || p.Gx == nil || p.Gy == nil || PK.X == nil || PK.Y == nil {
+	if p.P == nil || p.B == nil || p.Gx == nil || p.Gy == nil || PK.X == nil || PK.Y == nil {
 		return false
 	}
 	km.EccKey = new(certprotos.EccMessage)
@@ -417,13 +417,13 @@ func GetInternalKeyFromEccPublicKey(name string, PK *ecdsa.PublicKey, km *certpr
 	km.EccKey.CurveP = make([]byte, byteSize)
 	km.EccKey.CurveP = p.P.FillBytes(km.EccKey.CurveP)
 
-        // A is -3
-        t := new(big.Int)
-        t.SetInt64(-3)
-        a := new(big.Int)
-        a.Add(t, p.P)
+	// A is -3
+	t := new(big.Int)
+	t.SetInt64(-3)
+	a := new(big.Int)
+	a.Add(t, p.P)
 
-        km.EccKey.CurveA = make([]byte, byteSize)
+	km.EccKey.CurveA = make([]byte, byteSize)
 	km.EccKey.CurveA = a.FillBytes(km.EccKey.CurveA)
 
 	km.EccKey.CurveB = make([]byte, byteSize)
@@ -477,17 +477,17 @@ func GetInternalKeyFromRsaPublicKey(name string, PK *rsa.PublicKey, km *certprot
 	km.GetRsaKey().PublicModulus = PK.N.Bytes()
 	e := big.Int{}
 	e.SetUint64(uint64(PK.E))
-	km.GetRsaKey().PublicExponent= e.Bytes()
+	km.GetRsaKey().PublicExponent = e.Bytes()
 	return true
 }
 
 func GetInternalKeyFromRsaPrivateKey(name string, pK *rsa.PrivateKey, km *certprotos.KeyMessage) bool {
 	km.RsaKey = &certprotos.RsaMessage{}
-	km.GetRsaKey().PublicModulus =  pK.PublicKey.N.Bytes()
+	km.GetRsaKey().PublicModulus = pK.PublicKey.N.Bytes()
 	e := big.Int{}
 	e.SetUint64(uint64(pK.PublicKey.E))
-	km.GetRsaKey().PublicExponent=  e.Bytes()
-	km.GetRsaKey().PrivateExponent =  pK.D.Bytes()
+	km.GetRsaKey().PublicExponent = e.Bytes()
+	km.GetRsaKey().PrivateExponent = pK.D.Bytes()
 	return true
 }
 
@@ -509,7 +509,7 @@ func InternalPublicFromPrivateKey(privateKey *certprotos.KeyMessage) *certprotos
 	publicKey.KeyType = &kt
 	publicKey.KeyName = privateKey.KeyName
 	publicKey.KeyFormat = privateKey.KeyFormat
-	r := certprotos.RsaMessage {}
+	r := certprotos.RsaMessage{}
 	publicKey.RsaKey = &r
 	r.PublicModulus = privateKey.GetRsaKey().PublicModulus
 	r.PublicExponent = privateKey.GetRsaKey().PublicExponent
@@ -529,13 +529,13 @@ func MakeRsaKey(n int) *rsa.PrivateKey {
 }
 
 func MakeVseRsaKey(n int) *certprotos.KeyMessage {
-	pK :=  MakeRsaKey(n)
+	pK := MakeRsaKey(n)
 	if pK == nil {
 		return nil
 	}
-	km := certprotos.KeyMessage {}
+	km := certprotos.KeyMessage{}
 	var kf string
-	if  n == 1024 {
+	if n == 1024 {
 		kf = "rsa-1024-private"
 	} else if n == 2048 {
 		kf = "rsa-2048-private"
@@ -544,7 +544,7 @@ func MakeVseRsaKey(n int) *certprotos.KeyMessage {
 	} else {
 		return nil
 	}
-	km.KeyType  = &kf
+	km.KeyType = &kf
 	if GetInternalKeyFromRsaPrivateKey("generatedKey", pK, &km) == false {
 		return nil
 	}
@@ -561,7 +561,7 @@ func RsaPrivateDecrypt(r *rsa.PrivateKey, in []byte) []byte {
 
 func RsaSha256Verify(r *rsa.PublicKey, in []byte, sig []byte) bool {
 	hashed := sha256.Sum256(in)
-	err:= rsa.VerifyPKCS1v15(r, crypto.SHA256, hashed[0:32], sig)
+	err := rsa.VerifyPKCS1v15(r, crypto.SHA256, hashed[0:32], sig)
 	if err == nil {
 		return true
 	}
@@ -593,7 +593,6 @@ func FakeRsaSha256Verify(r *rsa.PublicKey, in []byte, sig []byte) bool {
 	return false
 }
 
-
 func Digest(in []byte) [32]byte {
 	return sha256.Sum256(in)
 }
@@ -601,16 +600,16 @@ func Digest(in []byte) [32]byte {
 func Pad(in []byte) []byte {
 	var inLen int = len(in)
 	var outLen int
-	if inLen %  aes.BlockSize != 0 {
+	if inLen%aes.BlockSize != 0 {
 		outLen = ((inLen + aes.BlockSize - 1) / aes.BlockSize) * aes.BlockSize
 	} else {
 		outLen = inLen + aes.BlockSize
 	}
-	out:= make([]byte, outLen)
+	out := make([]byte, outLen)
 	for i := 0; i < inLen; i++ {
 		out[i] = in[i]
 	}
-	out[inLen] = 0x80;
+	out[inLen] = 0x80
 	for i := inLen + 1; i < outLen; i++ {
 		out[i] = 0
 	}
@@ -633,7 +632,7 @@ func Encrypt(in []byte, key []byte, iv []byte) []byte {
 		return nil
 	}
 	padded := Pad(in)
-	out :=  make([]byte, aes.BlockSize+len(padded))
+	out := make([]byte, aes.BlockSize+len(padded))
 	for i := 0; i < aes.BlockSize; i++ {
 		out[i] = iv[i]
 	}
@@ -648,7 +647,7 @@ func Decrypt(in []byte, key []byte) []byte {
 		return nil
 	}
 	iv := in[0:aes.BlockSize]
-	out :=  make([]byte, len(in))
+	out := make([]byte, len(in))
 	mode := cipher.NewCBCDecrypter(c, iv)
 	mode.CryptBlocks(out, in[16:])
 	return Depad(out)
@@ -665,7 +664,7 @@ func AuthenticatedEncrypt(in []byte, key []byte, iv []byte) []byte {
 		out[i] = cip[i]
 	}
 	for i := 0; i < len(computedMac); i++ {
-		out[i + len(cip)] = computedMac[i]
+		out[i+len(cip)] = computedMac[i]
 	}
 	return out
 }
@@ -673,7 +672,7 @@ func AuthenticatedEncrypt(in []byte, key []byte, iv []byte) []byte {
 func AuthenticatedDecrypt(in []byte, key []byte) []byte {
 	// check hmac and decrypt
 	mac := hmac.New(sha256.New, key[32:])
-	n:= len(in) - 32
+	n := len(in) - 32
 	fmt.Printf("n= %d\n", n)
 	_, _ = mac.Write(in[0:n])
 	computedMac := mac.Sum(nil)
@@ -689,17 +688,17 @@ func SameMeasurement(m1 []byte, m2 []byte) bool {
 }
 
 func SameKey(k1 *certprotos.KeyMessage, k2 *certprotos.KeyMessage) bool {
-	if (k1.GetKeyType() != k2.GetKeyType()) {
+	if k1.GetKeyType() != k2.GetKeyType() {
 		return false
 	}
-	if k1.GetKeyType() == "rsa-2048-private"  || k1.GetKeyType() == "rsa-2048-public" ||
-		k1.GetKeyType() == "rsa-4096-private"  || k1.GetKeyType() == "rsa-4096-public" ||
-		k1.GetKeyType() == "rsa-1024-private"  || k1.GetKeyType() == "rsa-1024-public" {
+	if k1.GetKeyType() == "rsa-2048-private" || k1.GetKeyType() == "rsa-2048-public" ||
+		k1.GetKeyType() == "rsa-4096-private" || k1.GetKeyType() == "rsa-4096-public" ||
+		k1.GetKeyType() == "rsa-1024-private" || k1.GetKeyType() == "rsa-1024-public" {
 		return bytes.Equal(k1.RsaKey.PublicModulus, k2.RsaKey.PublicModulus) &&
 			bytes.Equal(k1.RsaKey.PublicExponent, k2.RsaKey.PublicExponent)
 	}
-	if k1.GetKeyType() == "ecc-384-private"  || k1.GetKeyType() == "ecc-384-public"  ||
-			k1.GetKeyType() == "ecc-256-private"  || k1.GetKeyType() == "ecc-256-public" {
+	if k1.GetKeyType() == "ecc-384-private" || k1.GetKeyType() == "ecc-384-public" ||
+		k1.GetKeyType() == "ecc-256-private" || k1.GetKeyType() == "ecc-256-public" {
 		if k1.EccKey == nil || k2.EccKey == nil {
 			return false
 		}
@@ -710,7 +709,7 @@ func SameKey(k1 *certprotos.KeyMessage, k2 *certprotos.KeyMessage) bool {
 			return false
 		}
 		if k1.EccKey.CurveName == nil || k2.EccKey.CurveName == nil ||
-				*k1.EccKey.CurveName != *k2.EccKey.CurveName {
+			*k1.EccKey.CurveName != *k2.EccKey.CurveName {
 			return false
 		}
 		return SamePoint(k1.EccKey.BasePoint, k2.EccKey.BasePoint) &&
@@ -723,23 +722,23 @@ func SameEntity(e1 *certprotos.EntityMessage, e2 *certprotos.EntityMessage) bool
 	if e1.GetEntityType() != e2.GetEntityType() {
 		return false
 	}
-	if  e1.GetEntityType() == "measurement" {
+	if e1.GetEntityType() == "measurement" {
 		return SameMeasurement(e1.GetMeasurement(), e2.GetMeasurement())
 	}
-	if  e1.GetEntityType() == "key" {
+	if e1.GetEntityType() == "key" {
 		return SameKey(e1.GetKey(), e2.GetKey())
 	}
-	if  e1.GetEntityType() == "platform" {
+	if e1.GetEntityType() == "platform" {
 		return SamePlatform(e1.GetPlatformEnt(), e2.GetPlatformEnt())
 	}
-	if  e1.GetEntityType() == "environment" {
+	if e1.GetEntityType() == "environment" {
 		return SameEnvironment(e1.GetEnvironmentEnt(), e2.GetEnvironmentEnt())
 	}
 	return false
 }
 
 func SameVseClause(c1 *certprotos.VseClause, c2 *certprotos.VseClause) bool {
-	if c1.Subject == nil ||  c2.Subject == nil {
+	if c1.Subject == nil || c2.Subject == nil {
 		return false
 	}
 	if !SameEntity(c1.GetSubject(), c2.GetSubject()) {
@@ -748,8 +747,8 @@ func SameVseClause(c1 *certprotos.VseClause, c2 *certprotos.VseClause) bool {
 	if c1.GetVerb() != c2.GetVerb() {
 		return false
 	}
-	if (c1.Object == nil && c2.Object != nil)  ||
-		(c1.Object != nil &&  c2.Object == nil) {
+	if (c1.Object == nil && c2.Object != nil) ||
+		(c1.Object != nil && c2.Object == nil) {
 		return false
 	}
 	if c1.Object != nil {
@@ -757,9 +756,9 @@ func SameVseClause(c1 *certprotos.VseClause, c2 *certprotos.VseClause) bool {
 			return false
 		}
 	}
-	if (c1.GetClause() == nil  && c2.GetClause() != nil ) ||
-		(c1.GetClause() != nil  && c2.GetClause() == nil) {
-			return false
+	if (c1.GetClause() == nil && c2.GetClause() != nil) ||
+		(c1.GetClause() != nil && c2.GetClause() == nil) {
+		return false
 	}
 	if c1.GetClause() != nil {
 		return SameVseClause(c1.GetClause(), c2.GetClause())
@@ -768,7 +767,7 @@ func SameVseClause(c1 *certprotos.VseClause, c2 *certprotos.VseClause) bool {
 }
 
 func MakeKeyEntity(k *certprotos.KeyMessage) *certprotos.EntityMessage {
-	keye := certprotos.EntityMessage {}
+	keye := certprotos.EntityMessage{}
 	var kn string = "key"
 	keye.EntityType = &kn
 	keye.Key = k
@@ -776,7 +775,7 @@ func MakeKeyEntity(k *certprotos.KeyMessage) *certprotos.EntityMessage {
 }
 
 func MakeMeasurementEntity(m []byte) *certprotos.EntityMessage {
-	me := certprotos.EntityMessage {}
+	me := certprotos.EntityMessage{}
 	measName := "measurement"
 	me.EntityType = &measName
 	me.Measurement = m
@@ -802,19 +801,19 @@ func MakeIndirectVseClause(subject *certprotos.EntityMessage, verb *string, cl *
 	vseClause := certprotos.VseClause{}
 	vseClause.Subject = subject
 	vseClause.Verb = verb
-	vseClause.Clause=cl
+	vseClause.Clause = cl
 	return &vseClause
 }
 
 func PrintBytes(b []byte) {
-	for i := 0; i < len(b); i++  {
+	for i := 0; i < len(b); i++ {
 		fmt.Printf("%02x", b[i])
 	}
 	return
 }
 
 func PrintEccKey(e *certprotos.EccMessage) {
-	fmt.Printf("curve: %s\n", e.GetCurveName());
+	fmt.Printf("curve: %s\n", e.GetCurveName())
 	if e.CurveP != nil {
 		fmt.Printf("P: ")
 		PrintBytes(e.CurveP)
@@ -850,7 +849,7 @@ func PrintEccKey(e *certprotos.EccMessage) {
 			fmt.Printf(")\n")
 		}
 	}
-	if e.OrderOfBasePoint!= nil {
+	if e.OrderOfBasePoint != nil {
 		fmt.Printf("Order of Base Point: ")
 		PrintBytes(e.OrderOfBasePoint)
 		fmt.Printf("\n")
@@ -909,19 +908,19 @@ func PrintKey(k *certprotos.KeyMessage) {
 	}
 
 	if k.GetKeyType() == "rsa-1024-public" || k.GetKeyType() == "rsa-2048-public" ||
-                k.GetKeyType() == "rsa-4096-public" || k.GetKeyType() == "rsa-1024-private" ||
-                k.GetKeyType() == "rsa-2048-private" || k.GetKeyType() == "rsa-4096-private" {
-	        if k.GetRsaKey() != nil {
-		        PrintRsaKey(k.GetRsaKey())
-                }
-        } else if k.GetKeyType() == "ecc-384-public" || k.GetKeyType() == "ecc-384-private" ||
-			k.GetKeyType() == "ecc-256-public" || k.GetKeyType() == "ecc-256-private" {
-	        if k.EccKey != nil {
-		        PrintEccKey(k.EccKey)
-                }
+		k.GetKeyType() == "rsa-4096-public" || k.GetKeyType() == "rsa-1024-private" ||
+		k.GetKeyType() == "rsa-2048-private" || k.GetKeyType() == "rsa-4096-private" {
+		if k.GetRsaKey() != nil {
+			PrintRsaKey(k.GetRsaKey())
+		}
+	} else if k.GetKeyType() == "ecc-384-public" || k.GetKeyType() == "ecc-384-private" ||
+		k.GetKeyType() == "ecc-256-public" || k.GetKeyType() == "ecc-256-private" {
+		if k.EccKey != nil {
+			PrintEccKey(k.EccKey)
+		}
 	} else {
-                 fmt.Printf("Unknown key type\n")
-        }
+		fmt.Printf("Unknown key type\n")
+	}
 	return
 }
 
@@ -943,7 +942,7 @@ func PrintKeyDescriptor(k *certprotos.KeyMessage) {
 		fmt.Printf("]")
 	}
 	if k.GetKeyType() == "ecc-384-private" || k.GetKeyType() == "ecc-384-public" ||
-			k.GetKeyType() == "ecc-256-private" || k.GetKeyType() == "ecc-256-public" {
+		k.GetKeyType() == "ecc-256-private" || k.GetKeyType() == "ecc-256-public" {
 		if k.GetEccKey() == nil {
 			fmt.Printf("Key[ecc] Bad key")
 			return
@@ -1019,20 +1018,20 @@ func PrintAttestationUserData(sr *certprotos.AttestationUserData) {
 	if sr.EnclaveType != nil {
 		fmt.Printf("Enclave type: %s\n", *sr.EnclaveType)
 	}
-	if sr.Time!= nil {
+	if sr.Time != nil {
 		fmt.Printf("Time signed : %s\n", *sr.Time)
 	}
 	if sr.EnclaveKey != nil {
-		fmt.Printf("Enclave key:\n");
+		fmt.Printf("Enclave key:\n")
 		PrintKey(sr.EnclaveKey)
 	} else {
-		fmt.Printf("No enclave key\n");
+		fmt.Printf("No enclave key\n")
 	}
 	if sr.PolicyKey != nil {
-		fmt.Printf("Policy key:\n");
+		fmt.Printf("Policy key:\n")
 		PrintKey(sr.PolicyKey)
 	} else {
-		fmt.Printf("No policy key\n");
+		fmt.Printf("No policy key\n")
 	}
 	return
 }
@@ -1045,10 +1044,10 @@ func PrintVseAttestationReportInfo(info *certprotos.VseAttestationReportInfo) {
 		fmt.Printf("Measurement : ")
 		PrintBytes(info.VerifiedMeasurement)
 	}
-	if info.NotBefore!= nil  && info.NotAfter != nil {
+	if info.NotBefore != nil && info.NotAfter != nil {
 		fmt.Printf("Valid between: %s and %s\n", *info.NotBefore, *info.NotAfter)
 	}
-	if info.UserData!= nil {
+	if info.UserData != nil {
 		fmt.Printf("User Data   : ")
 		PrintBytes(info.UserData)
 	}
@@ -1127,21 +1126,21 @@ func MakeSignedClaim(s *certprotos.ClaimMessage, k *certprotos.KeyMessage) *cert
 	if k.GetKeyType() == "" {
 		return nil
 	}
-	sm := certprotos.SignedClaimMessage {}
+	sm := certprotos.SignedClaimMessage{}
 	if k.GetKeyType() == "rsa-1024-private" {
 		var ss string = "rsa-1024-sha256-pkcs-sign"
-		sm.SigningAlgorithm =  &ss
+		sm.SigningAlgorithm = &ss
 	} else if k.GetKeyType() == "rsa-2048-private" {
 		var ss string = "rsa-2048-sha256-pkcs-sign"
-		sm.SigningAlgorithm =  &ss
+		sm.SigningAlgorithm = &ss
 	} else if k.GetKeyType() == "rsa-4096-private" {
 		var ss string = "rsa-4096-sha384-pkcs-sign"
-		sm.SigningAlgorithm =  &ss
+		sm.SigningAlgorithm = &ss
 	} else {
 		return nil
 	}
 
-	psk :=  InternalPublicFromPrivateKey(k)
+	psk := InternalPublicFromPrivateKey(k)
 	sm.SigningKey = psk
 
 	PK := rsa.PublicKey{}
@@ -1163,7 +1162,7 @@ func MakeSignedClaim(s *certprotos.ClaimMessage, k *certprotos.KeyMessage) *cert
 	return &sm
 }
 
-func SameProperty(p1 *certprotos.Property,  p2 *certprotos.Property) bool {
+func SameProperty(p1 *certprotos.Property, p2 *certprotos.Property) bool {
 	if p1 == nil || p2 == nil {
 		return false
 	}
@@ -1239,7 +1238,7 @@ func SatisfyingProperties(p1 *certprotos.Properties, p2 *certprotos.Properties) 
 			fmt.Printf("Can't find property %s\n", *p1.Props[i].PropertyName)
 			return false
 		}
-		if (!SatisfyingProperty(p1.Props[i], pp)) {
+		if !SatisfyingProperty(p1.Props[i], pp) {
 			return false
 		}
 	}
@@ -1261,7 +1260,7 @@ func SameProperties(p1 *certprotos.Properties, p2 *certprotos.Properties) bool {
 		if pp == nil {
 			return false
 		}
-		if (!SameProperty(p1.Props[i], pp)) {
+		if !SameProperty(p1.Props[i], pp) {
 			return false
 		}
 	}
@@ -1281,7 +1280,7 @@ func SameEnvironment(p1 *certprotos.Environment, p2 *certprotos.Environment) boo
 	if p1.ThePlatform == nil || p2.ThePlatform == nil {
 		return false
 	}
-	return SamePlatform(p1.ThePlatform,  p2.ThePlatform);
+	return SamePlatform(p1.ThePlatform, p2.ThePlatform)
 }
 
 func SamePlatform(p1 *certprotos.Platform, p2 *certprotos.Platform) bool {
@@ -1323,7 +1322,7 @@ func PrintPlatform(p *certprotos.Platform) {
 	if p == nil {
 		return
 	}
-	if (p.PlatformType == nil) {
+	if p.PlatformType == nil {
 		return
 	}
 	fmt.Printf("Platform:\n")
@@ -1333,18 +1332,18 @@ func PrintPlatform(p *certprotos.Platform) {
 	} else {
 		fmt.Printf("    NoKey\n")
 	}
-	if (p.AttestKey != nil) {
+	if p.AttestKey != nil {
 		fmt.Printf("   Key: \n")
 		PrintKey(p.AttestKey)
 	}
-	if (p.Props != nil) {
+	if p.Props != nil {
 		fmt.Printf("    Properties:\n")
 		PrintProperties(p.Props)
 	}
 }
 
 func PrintProperty(p *certprotos.Property) {
-	if p == nil  || p.PropertyName == nil {
+	if p == nil || p.PropertyName == nil {
 		return
 	}
 	fmt.Printf("        %s: ", *p.PropertyName)
@@ -1356,9 +1355,9 @@ func PrintProperty(p *certprotos.Property) {
 			return
 		}
 		fmt.Printf("%s\n", *p.StringValue)
-	} 
+	}
 	if *p.ValueType == "int" {
-		if p.IntValue == nil  || p.Comparator == nil {
+		if p.IntValue == nil || p.Comparator == nil {
 			return
 		}
 		fmt.Printf("%s %d\n", *p.Comparator, *p.IntValue)
@@ -1386,7 +1385,7 @@ func PrintEnvironmentDescriptor(e *certprotos.Environment) {
 }
 
 func PrintPlatformDescriptor(p *certprotos.Platform) {
-	if p == nil  || p.PlatformType == nil {
+	if p == nil || p.PlatformType == nil {
 		return
 	}
 	fmt.Printf("platform[%s, ", *p.PlatformType)
@@ -1406,7 +1405,7 @@ func PrintPlatformDescriptor(p *certprotos.Platform) {
 }
 
 func PrintPropertyDescriptor(p *certprotos.Property) {
-	if p == nil  || p.PropertyName == nil {
+	if p == nil || p.PropertyName == nil {
 		return
 	}
 	fmt.Printf("%s: ", *p.PropertyName)
@@ -1462,12 +1461,12 @@ func PrintTrustReponse(res *certprotos.TrustResponseMessage) {
 }
 
 func GetVseFromSignedClaim(sc *certprotos.SignedClaimMessage) *certprotos.VseClause {
-	claimMsg := certprotos.ClaimMessage {}
+	claimMsg := certprotos.ClaimMessage{}
 	err := proto.Unmarshal(sc.SerializedClaimMessage, &claimMsg)
 	if err != nil {
 		return nil
 	}
-	vseClause :=  certprotos.VseClause {}
+	vseClause := certprotos.VseClause{}
 	if claimMsg.GetClaimFormat() == "vse-clause" {
 		err = proto.Unmarshal(claimMsg.SerializedClaim, &vseClause)
 		if err != nil {
@@ -1486,10 +1485,10 @@ func SizedSocketRead(conn net.Conn) []byte {
 		fmt.Printf("SizedSocketRead, error: %d\n", n)
 		return nil
 	}
-	size := int(bsize[0]) +  256 * int(bsize[1]) + 256 * 256 * int(bsize[2])
+	size := int(bsize[0]) + 256*int(bsize[1]) + 256*256*int(bsize[2])
 	b := make([]byte, size)
 	total := 0
-	for ; total < size; {
+	for total < size {
 		n, err = conn.Read(b[total:])
 		if err != nil {
 			fmt.Printf("SizedSocketRead, error: %d\n", n)
@@ -1503,9 +1502,9 @@ func SizedSocketRead(conn net.Conn) []byte {
 func SizedSocketWrite(conn net.Conn, b []byte) bool {
 	size := len(b)
 	bs := make([]byte, 4)
-	bs[0] = byte(size&0xff)
-	bs[1] = byte((size>>8)&0xff)
-	bs[2] = byte((size>>16)&0xff)
+	bs[0] = byte(size & 0xff)
+	bs[1] = byte((size >> 8) & 0xff)
+	bs[2] = byte((size >> 16) & 0xff)
 	bs[3] = 0
 	_, err := conn.Write(bs)
 	if err != nil {
@@ -1522,9 +1521,9 @@ func SizedSocketWrite(conn net.Conn, b []byte) bool {
 }
 
 func MakeProperty(name string, t string, sv *string, c *string, iv *uint64) *certprotos.Property {
-	p := &certprotos.Property {
+	p := &certprotos.Property{
 		PropertyName: &name,
-		ValueType: &t,
+		ValueType:    &t,
 	}
 	if t == "string" {
 		p.StringValue = sv
@@ -1537,23 +1536,23 @@ func MakeProperty(name string, t string, sv *string, c *string, iv *uint64) *cer
 }
 
 func MakePlatform(t string, k *certprotos.KeyMessage, props *certprotos.Properties) *certprotos.Platform {
-	hk := false;
+	hk := false
 	if k != nil {
-		hk = true;
+		hk = true
 	}
-	plat := &certprotos.Platform {
+	plat := &certprotos.Platform{
 		PlatformType: &t,
-		AttestKey: k,
-		Props: props,
-		HasKey: &hk,
+		AttestKey:    k,
+		Props:        props,
+		HasKey:       &hk,
 	}
 	return plat
 }
 
 func MakePlatformEntity(pl *certprotos.Platform) *certprotos.EntityMessage {
 	plEnt := "platform"
-	pe := &certprotos.EntityMessage {
-		EntityType: &plEnt,
+	pe := &certprotos.EntityMessage{
+		EntityType:  &plEnt,
 		PlatformEnt: pl,
 	}
 	return pe
@@ -1561,16 +1560,16 @@ func MakePlatformEntity(pl *certprotos.Platform) *certprotos.EntityMessage {
 
 func MakeEnvironmentEntity(e *certprotos.Environment) *certprotos.EntityMessage {
 	eEnt := "environment"
-	ee := &certprotos.EntityMessage {
-		EntityType: &eEnt,
+	ee := &certprotos.EntityMessage{
+		EntityType:     &eEnt,
 		EnvironmentEnt: e,
 	}
 	return ee
 }
 
 func MakeEnvironment(pl *certprotos.Platform, measurement []byte) *certprotos.Environment {
-	e := &certprotos.Environment {
-		ThePlatform: pl,
+	e := &certprotos.Environment{
+		ThePlatform:    pl,
 		TheMeasurement: measurement,
 	}
 	return e
@@ -1617,7 +1616,7 @@ func VerifySignedClaim(c *certprotos.SignedClaimMessage, k *certprotos.KeyMessag
 func VerifySignedAssertion(scm certprotos.SignedClaimMessage, k *certprotos.KeyMessage, vseClause *certprotos.VseClause) bool {
 	// verify signed claim and extract vse clause
 	if !VerifySignedClaim(&scm, k) {
-		return false;
+		return false
 	}
 	// extract clause
 	cl_str := "vse-clause"
@@ -1645,12 +1644,12 @@ func PrintProvedStatements(ps *certprotos.ProvedStatements) {
 	for i := 0; i < len(ps.Proved); i++ {
 		fmt.Printf("\n%02d ", i)
 		v := ps.Proved[i]
-		PrintVseClause(v);
+		PrintVseClause(v)
 		fmt.Printf("\n")
 	}
 }
 
-func Asn1ToX509 (in []byte) *x509.Certificate {
+func Asn1ToX509(in []byte) *x509.Certificate {
 	cert, err := x509.ParseCertificate(in)
 	if err != nil {
 		return nil
@@ -1661,7 +1660,7 @@ func Asn1ToX509 (in []byte) *x509.Certificate {
 func X509ToAsn1(cert *x509.Certificate) []byte {
 	out, err := asn1.Marshal(cert)
 	if err != nil {
-                fmt.Printf("X509ToAsn1 error: %s\n", err.Error())
+		fmt.Printf("X509ToAsn1 error: %s\n", err.Error())
 		return nil
 	}
 	return out
@@ -1687,27 +1686,27 @@ func CheckTimeRange(nb *string, na *string) bool {
 func LittleToBigEndian(in []byte) []byte {
 	out := make([]byte, len(in))
 	for i := 0; i < len(in); i++ {
-		out[len(in) - 1 - i] = in[i]
+		out[len(in)-1-i] = in[i]
 	}
 	return out
 }
 
 func ProduceAdmissionCert(remoteIP string, issuerKey *certprotos.KeyMessage, issuerCert *x509.Certificate,
-		subjKey *certprotos.KeyMessage, subjName string, subjOrg string,
-		serialNumber uint64, durationSeconds float64) *x509.Certificate {
+	subjKey *certprotos.KeyMessage, subjName string, subjOrg string,
+	serialNumber uint64, durationSeconds float64) *x509.Certificate {
 
 	dur := int64(durationSeconds * 1000 * 1000 * 1000)
 	cert := x509.Certificate{
 		SerialNumber: big.NewInt(int64(serialNumber)),
-		Subject: pkix.Name {
-			CommonName: subjName,
+		Subject: pkix.Name{
+			CommonName:   subjName,
 			Organization: []string{subjOrg},
 		},
-		NotBefore:	     time.Now(),
-		NotAfter:	      time.Now().Add(time.Duration(dur)),
-		IsCA:		  false,
-		ExtKeyUsage:	   []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
-		KeyUsage:	      x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(time.Duration(dur)),
+		IsCA:                  false,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
 		BasicConstraintsValid: true,
 	}
 	if remoteIP != "" {
@@ -1761,7 +1760,7 @@ func GetSubjectKey(cert *x509.Certificate) *certprotos.KeyMessage {
 			fmt.Printf("GetSubjectKey: Can't internal rsa public key\n")
 			return nil
 		}
-		return  &k
+		return &k
 	}
 	PKecc, ok := cert.PublicKey.(*ecdsa.PublicKey)
 	if ok {
@@ -1770,12 +1769,12 @@ func GetSubjectKey(cert *x509.Certificate) *certprotos.KeyMessage {
 			fmt.Printf("GetSubjectKey: Can't internal ecc public key\n")
 			return nil
 		}
-		return  &k
+		return &k
 	}
 	return nil
 }
 
-func GetIssuerKey(cert *x509.Certificate) *certprotos.KeyMessage{
+func GetIssuerKey(cert *x509.Certificate) *certprotos.KeyMessage {
 	return nil
 }
 
@@ -1783,7 +1782,7 @@ func VerifyAdmissionCert(policyCert *x509.Certificate, cert *x509.Certificate) b
 	certPool := x509.NewCertPool()
 	certPool.AddCert(policyCert)
 	opts := x509.VerifyOptions{
-		Roots:   certPool,
+		Roots: certPool,
 	}
 
 	if _, err := cert.Verify(opts); err != nil {
@@ -1796,7 +1795,7 @@ func PrintEvidence(ev *certprotos.Evidence) {
 	fmt.Printf("Evidence type: %s\n", ev.GetEvidenceType())
 	if ev.GetEvidenceType() == "signed-claim" {
 		sc := certprotos.SignedClaimMessage{}
-		err:= proto.Unmarshal(ev.SerializedEvidence, &sc)
+		err := proto.Unmarshal(ev.SerializedEvidence, &sc)
 		if err != nil {
 			return
 		}
@@ -1804,7 +1803,7 @@ func PrintEvidence(ev *certprotos.Evidence) {
 		fmt.Printf("\n")
 	} else if ev.GetEvidenceType() == "signed-vse-attestation-report" {
 		sr := certprotos.SignedReport{}
-		err:= proto.Unmarshal(ev.SerializedEvidence, &sr)
+		err := proto.Unmarshal(ev.SerializedEvidence, &sr)
 		if err != nil {
 			return
 		}
@@ -1819,7 +1818,7 @@ func PrintEvidence(ev *certprotos.Evidence) {
 		PrintBytes(ev.SerializedEvidence)
 	} else if ev.GetEvidenceType() == "cert" {
 		cx509 := Asn1ToX509(ev.SerializedEvidence)
-		fmt.Printf("Issuer: %s, Subject: %s\n", GetIssuerNameFromCert(cx509),* GetSubjectNameFromCert(cx509))
+		fmt.Printf("Issuer: %s, Subject: %s\n", GetIssuerNameFromCert(cx509), *GetSubjectNameFromCert(cx509))
 		PrintBytes(ev.SerializedEvidence)
 		fmt.Printf("\n")
 	} else {
@@ -1829,7 +1828,7 @@ func PrintEvidence(ev *certprotos.Evidence) {
 
 func PrintEvidencePackage(evp *certprotos.EvidencePackage, printAll bool) {
 	fmt.Printf("\nProver type: %s\n", evp.GetProverType())
-	for i:= 0; i < len(evp.FactAssertion); i++ {
+	for i := 0; i < len(evp.FactAssertion); i++ {
 		ev := evp.FactAssertion[i]
 		if printAll {
 			PrintEvidence(ev)
@@ -1842,12 +1841,12 @@ func PrintEvidencePackage(evp *certprotos.EvidencePackage, printAll bool) {
 
 type CertKeysSeen struct {
 	name string
-	pk  certprotos.KeyMessage
+	pk   certprotos.KeyMessage
 }
 
 type CertSeenList struct {
-	maxSize int
-	size int
+	maxSize  int
+	size     int
 	keysSeen [30]CertKeysSeen
 }
 
@@ -1904,7 +1903,7 @@ func PrintX509Cert(cert *x509.Certificate) {
 		fmt.Printf("\tRoot cert\n")
 	} else {
 	}
-		fmt.Printf("\tSubordinate cert\n")
+	fmt.Printf("\tSubordinate cert\n")
 	fmt.Printf("\tDNS Names: %+v\n", cert.DNSNames)
 	fmt.Printf("\tEmailAddresses: %+v\n", cert.EmailAddresses)
 	fmt.Printf("\tIPAddresses: %+v\n", cert.IPAddresses)
@@ -1925,11 +1924,11 @@ var rsaPublicAttestKey rsa.PublicKey
 var rsaPrivateAttestKey rsa.PrivateKey
 var sealingKey [64]byte
 var sealIv [16]byte
-var simulatedInitialized  bool = false
+var simulatedInitialized bool = false
 
 func InitSimulatedEnclave() bool {
 	privateAttestKey = MakeVseRsaKey(2048)
-	var tk  string = "simulatedAttestKey"
+	var tk string = "simulatedAttestKey"
 	privateAttestKey.KeyName = &tk
 	publicAttestKey = InternalPublicFromPrivateKey(privateAttestKey)
 	if publicAttestKey == nil {
@@ -1977,7 +1976,7 @@ func simultatedAttest(eType string, toSay []byte) []byte {
 	}
 	// toSay is a serilized attestation, turn it into a signed claim
 	tn := TimePointNow()
-	tf := TimePointPlus(tn, 365 * 86400)
+	tf := TimePointPlus(tn, 365*86400)
 	nb := TimePointToString(tn)
 	na := TimePointToString(tf)
 	cl1 := MakeClaim(toSay, "vse-attestation", "attestation", nb, na)
@@ -1985,7 +1984,7 @@ func simultatedAttest(eType string, toSay []byte) []byte {
 	if err != nil {
 		return nil
 	}
-	sc := certprotos.SignedClaimMessage {}
+	sc := certprotos.SignedClaimMessage{}
 	sc.SerializedClaimMessage = serCl
 	sc.SigningKey = publicAttestKey
 	var ss string = "rsa-2048-sha256-pkcs-sign"
@@ -2026,4 +2025,3 @@ func Attest(eType string, toSay []byte) []byte {
 	}
 	return nil
 }
-

--- a/certifier_service/gramineverify/gramineverify.go
+++ b/certifier_service/gramineverify/gramineverify.go
@@ -37,7 +37,7 @@ func GramineVerify(what_to_say []byte, attestation []byte) ([]byte, error) {
 		C.int(len(attestation)), (*C.uchar)(attestation_ptr),
 		&measurementSize, (*C.uchar)(measurementOut))
 	if !ret {
-		return nil, fmt.Errorf("gramine_Verify failed");
+		return nil, fmt.Errorf("gramine_Verify failed")
 	}
 	outMeasurement := C.GoBytes(unsafe.Pointer(measurementOut),
 		C.int(measurementSize))

--- a/certifier_service/isletverify/isletverify.go
+++ b/certifier_service/isletverify/isletverify.go
@@ -34,13 +34,13 @@ func IsletVerify(what_to_say []byte, attestation []byte) ([]byte, error) {
 	measurementOut := C.malloc(C.ulong(measurementSize))
 	defer C.free(unsafe.Pointer(measurementOut))
 	ret := C.isletlib_Verify(C.int(len(what_to_say)), (*C.uchar)(what_to_say_ptr),
-		                     C.int(len(attestation)), (*C.uchar)(attestation_ptr),
-		                     &measurementSize, (*C.uchar)(measurementOut))
+		C.int(len(attestation)), (*C.uchar)(attestation_ptr),
+		&measurementSize, (*C.uchar)(measurementOut))
 	if !ret {
-		return nil, fmt.Errorf("IsletVerify failed");
+		return nil, fmt.Errorf("IsletVerify failed")
 	}
 	outMeasurement := C.GoBytes(unsafe.Pointer(measurementOut),
-		                        C.int(measurementSize))
+		C.int(measurementSize))
 	return outMeasurement, nil
 }
 

--- a/certifier_service/oeverify/oeverify.go
+++ b/certifier_service/oeverify/oeverify.go
@@ -49,7 +49,7 @@ func OEHostVerifyEvidence(evidence []byte, endorsements []byte, tcb bool) ([]byt
 		(*C.uchar)(measurementOut), &measurementSize, checkTCB)
 
 	if !ret {
-		return nil, nil, fmt.Errorf("oe_host_verify_evidence failed");
+		return nil, nil, fmt.Errorf("oe_host_verify_evidence failed")
 	}
 	outCustomClaims := C.GoBytes(unsafe.Pointer(customClaimOut),
 		C.int(customClaimOutSize))

--- a/certifier_service/simpleserver.go
+++ b/certifier_service/simpleserver.go
@@ -17,22 +17,22 @@
 package main
 
 import (
-        "crypto/x509"
-        "encoding/hex"
-        "flag"
-        "fmt"
-        "io/ioutil"
-        "log"
-        "net"
-        "os"
-        "strconv"
-        "time"
+	"crypto/x509"
+	"encoding/hex"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net"
+	"os"
+	"strconv"
+	"time"
 
-        "github.com/golang/protobuf/proto"
-        certprotos    "github.com/vmware-research/certifier-framework-for-confidential-computing/certifier_service/certprotos"
-        certlib       "github.com/vmware-research/certifier-framework-for-confidential-computing/certifier_service/certlib"
-     // NOTE: Enable this line when you enable the test-code in main().
-     // gramineverify "github.com/vmware-research/certifier-framework-for-confidential-computing/certifier_service/gramineverify"
+	"github.com/golang/protobuf/proto"
+	certlib "github.com/vmware-research/certifier-framework-for-confidential-computing/certifier_service/certlib"
+	certprotos "github.com/vmware-research/certifier-framework-for-confidential-computing/certifier_service/certprotos"
+	// NOTE: Enable this line when you enable the test-code in main().
+	// gramineverify "github.com/vmware-research/certifier-framework-for-confidential-computing/certifier_service/gramineverify"
 )
 
 var serverHost = flag.String("host", "localhost", "address for client/server")
@@ -43,7 +43,7 @@ var policyCertFile = flag.String("policy_cert_file", "policy_cert_file.bin", "ce
 var readPolicy = flag.Bool("readPolicy", true, "read policy")
 var policyFile = flag.String("policyFile", "./certlib/policy.bin", "policy file name")
 
-var loggingSequenceNumber = *flag.Int("loggingSequenceNumber", 1,  "sequence number for logging")
+var loggingSequenceNumber = *flag.Int("loggingSequenceNumber", 1, "sequence number for logging")
 var enableLog = flag.Bool("enableLog", false, "enable logging")
 var logDir = flag.String("logDir", ".", "log directory")
 var logFile = flag.String("logFile", "simpleserver.log", "log file name")
@@ -59,87 +59,86 @@ var duration float64 = 365.0 * 86400
 var logging bool = false
 var logger *log.Logger
 var dataPacketFileNum int = loggingSequenceNumber
+
 func initLog() bool {
-        name := *logDir + "/" + *logFile
-        logFiled, err := os.OpenFile(name, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0666)
-        if err != nil {
-                fmt.Printf("Can't open log file\n")
-                return false
-        }
-        logger = log.New(logFiled, "INFO: ", log.Ldate|log.Ltime|log.Lshortfile)
-        logger.Println("Starting simpleserver")
-        return true
+	name := *logDir + "/" + *logFile
+	logFiled, err := os.OpenFile(name, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0666)
+	if err != nil {
+		fmt.Printf("Can't open log file\n")
+		return false
+	}
+	logger = log.New(logFiled, "INFO: ", log.Ldate|log.Ltime|log.Lshortfile)
+	logger.Println("Starting simpleserver")
+	return true
 }
 
-
 var policyInitialized bool = false
-var signedPolicy *certprotos.SignedClaimSequence = &certprotos.SignedClaimSequence {}
-var originalPolicy *certprotos.ProvedStatements = &certprotos.ProvedStatements {}
-
+var signedPolicy *certprotos.SignedClaimSequence = &certprotos.SignedClaimSequence{}
+var originalPolicy *certprotos.ProvedStatements = &certprotos.ProvedStatements{}
 
 // At init, we retrieve the policy key and the rules to evaluate
 func initCertifierService() bool {
-        // Debug
-        fmt.Printf("Initializing CertifierService, Policy key file: %s, Policy cert file: %s, Policy file: %s\n",
-          *policyKeyFile, *policyCertFile, *policyFile)
+	// Debug
+	fmt.Printf("Initializing CertifierService, Policy key file: %s, Policy cert file: %s, Policy file: %s\n",
+		*policyKeyFile, *policyCertFile, *policyFile)
 
-        if *enableLog {
-                logging = initLog()
-        }
+	if *enableLog {
+		logging = initLog()
+	}
 
-        serializedKey, err := os.ReadFile(*policyKeyFile)
-        if err != nil {
-                fmt.Println("Simple_server: can't read key file, ", err)
-                return false
-        }
+	serializedKey, err := os.ReadFile(*policyKeyFile)
+	if err != nil {
+		fmt.Println("Simple_server: can't read key file, ", err)
+		return false
+	}
 
-        serializedPolicyCert, err := os.ReadFile(*policyCertFile)
-        if err != nil {
-                fmt.Println("Simpleserver: can't read policy cert file, ", err)
-                return false
-        }
-        policyCert, err = x509.ParseCertificate(serializedPolicyCert)
-        if err != nil {
-                fmt.Println("Simpleserver: Can't Parse policy cert, ", err)
-                return false
-        }
+	serializedPolicyCert, err := os.ReadFile(*policyCertFile)
+	if err != nil {
+		fmt.Println("Simpleserver: can't read policy cert file, ", err)
+		return false
+	}
+	policyCert, err = x509.ParseCertificate(serializedPolicyCert)
+	if err != nil {
+		fmt.Println("Simpleserver: Can't Parse policy cert, ", err)
+		return false
+	}
 
-	privatePolicyKey = &certprotos.KeyMessage {}
-        err = proto.Unmarshal(serializedKey, privatePolicyKey)
-        if err != nil {
-                fmt.Printf("SimpleServer: Can't unmarshal serialized policy key\n")
-                return false
-        }
+	privatePolicyKey = &certprotos.KeyMessage{}
+	err = proto.Unmarshal(serializedKey, privatePolicyKey)
+	if err != nil {
+		fmt.Printf("SimpleServer: Can't unmarshal serialized policy key\n")
+		return false
+	}
 
-        publicPolicyKey = certlib.InternalPublicFromPrivateKey(privatePolicyKey)
-        if publicPolicyKey == nil {
-                fmt.Printf("SimpleServer: Can't get public policy key\n")
-                return false
-        }
+	publicPolicyKey = certlib.InternalPublicFromPrivateKey(privatePolicyKey)
+	if publicPolicyKey == nil {
+		fmt.Printf("SimpleServer: Can't get public policy key\n")
+		return false
+	}
 
 	// This should change to an InitPolicy call
-        if policyFile == nil {
-	        fmt.Printf("SimpleServer: No policy file\n")
+	if policyFile == nil {
+		fmt.Printf("SimpleServer: No policy file\n")
 		return false
 	}
 
 	// Read policy
 	serializedPolicy, err := os.ReadFile(*policyFile)
 	if err != nil {
-	        fmt.Printf("SimpleServer: Can't read policy\n")
-	        return false
+		fmt.Printf("SimpleServer: Can't read policy\n")
+		return false
 	}
 
 	err = proto.Unmarshal(serializedPolicy, signedPolicy)
 	if err != nil {
-	        fmt.Printf("SimpleServer: Can't unmarshal signed policy\n")
-	        return false
+		fmt.Printf("SimpleServer: Can't unmarshal signed policy\n")
+		return false
 	}
 
 	if !certlib.InitAxiom(*publicPolicyKey, originalPolicy) {
-                fmt.Printf("SimpleServer: Can't InitAxiom\n")
-                return false
-        }
+		fmt.Printf("SimpleServer: Can't InitAxiom\n")
+		return false
+	}
 
 	policyInitialized = certlib.InitPolicy(publicPolicyKey, signedPolicy, originalPolicy)
 
@@ -148,119 +147,119 @@ func initCertifierService() bool {
 		return false
 	}
 
-        if !certlib.InitSimulatedEnclave() {
-                fmt.Printf("SimpleServer: Can't init simulated enclave\n")
-                return false
-        }
-        return true
+	if !certlib.InitSimulatedEnclave() {
+		fmt.Printf("SimpleServer: Can't init simulated enclave\n")
+		return false
+	}
+	return true
 }
 
 //	--------------------------------------------------------------------------------------
 
 func logRequest(b []byte) *string {
-        if b == nil {
-                return nil
-        }
-        s := strconv.Itoa(dataPacketFileNum)
-        dataPacketFileNum = dataPacketFileNum + 1
-        fileName := *logDir + "/" + "SSReq" + "-" + s
-        if ioutil.WriteFile(fileName, b, 0666)  != nil {
-                fmt.Printf("Can't write %s\n", fileName)
-                return nil
-        }
-        return &fileName
+	if b == nil {
+		return nil
+	}
+	s := strconv.Itoa(dataPacketFileNum)
+	dataPacketFileNum = dataPacketFileNum + 1
+	fileName := *logDir + "/" + "SSReq" + "-" + s
+	if ioutil.WriteFile(fileName, b, 0666) != nil {
+		fmt.Printf("Can't write %s\n", fileName)
+		return nil
+	}
+	return &fileName
 }
 
 func logResponse(b []byte) *string {
-        if b == nil {
-                return nil
-        }
-        s := strconv.Itoa(dataPacketFileNum)
-        dataPacketFileNum = dataPacketFileNum + 1
-        fileName := *logDir + "/" + "SSRsp" + "-" + s
-        if ioutil.WriteFile(fileName, b, 0666)  != nil {
-                fmt.Printf("Can't write %s\n", fileName)
-                return nil
-        }
-        return &fileName
+	if b == nil {
+		return nil
+	}
+	s := strconv.Itoa(dataPacketFileNum)
+	dataPacketFileNum = dataPacketFileNum + 1
+	fileName := *logDir + "/" + "SSRsp" + "-" + s
+	if ioutil.WriteFile(fileName, b, 0666) != nil {
+		fmt.Printf("Can't write %s\n", fileName)
+		return nil
+	}
+	return &fileName
 }
 
 // Todo: Consider logging the proof and IP address too.
 func logEvent(msg string, req []byte, resp []byte) {
-        if !logging {
-                return
-        }
-        reqName := logRequest(req)
-        respName := logResponse(resp)
-        logger.Printf("%s, ", msg)
-        if reqName != nil {
-                logger.Printf("%s ,", reqName)
-        } else {
-                logger.Printf("No request,")
-        }
-        if respName != nil {
-                logger.Printf("%s\n", respName)
-        } else {
-                logger.Printf("No response\n")
-        }
+	if !logging {
+		return
+	}
+	reqName := logRequest(req)
+	respName := logResponse(resp)
+	logger.Printf("%s, ", msg)
+	if reqName != nil {
+		logger.Printf("%s ,", reqName)
+	} else {
+		logger.Printf("No request,")
+	}
+	if respName != nil {
+		logger.Printf("%s\n", respName)
+	} else {
+		logger.Printf("No response\n")
+	}
 }
 
 func ValidateRequestAndObtainToken(remoteIP string, pubKey *certprotos.KeyMessage, privKey *certprotos.KeyMessage,
-		evType string, purpose string, ep *certprotos.EvidencePackage) (bool, []byte) {
+	evType string, purpose string, ep *certprotos.EvidencePackage) (bool, []byte) {
 
-        // evidenceType should be "vse-attestation-package", "gramine-evidence",
-        //      "oe-evidence" or "sev-platform-package"
+	// evidenceType should be "vse-attestation-package", "gramine-evidence",
+	//      "oe-evidence" or "sev-platform-package"
 	var toProve *certprotos.VseClause = nil
 	var measurement []byte = nil
 	var success bool
 
-        if evType == "vse-attestation-package" {
+	if evType == "vse-attestation-package" {
 		success, toProve, measurement = certlib.ValidateInternalEvidence(pubKey, ep, originalPolicy, purpose)
 		if !success {
 			fmt.Printf("ValidateRequestAndObtainToken: ValidateInternalEvidence failed\n")
 			return false, nil
 		}
-        } else if evType == "sev-platform-package" {
+	} else if evType == "sev-platform-package" {
 		success, toProve, measurement = certlib.ValidateSevEvidence(pubKey, ep, originalPolicy, purpose)
 		if !success {
 			fmt.Printf("ValidateRequestAndObtainToken: ValidateSevEvidence failed\n")
 			return false, nil
 		}
-        } else if evType == "oe-evidence" {
+	} else if evType == "oe-evidence" {
 		success, toProve, measurement = certlib.ValidateOeEvidence(pubKey, ep, originalPolicy, purpose)
 		if !success {
 			fmt.Printf("ValidateRequestAndObtainToken: ValidateOeEvidence failed\n")
 			return false, nil
 		}
-        } else if evType == "gramine-evidence" {
+	} else if evType == "gramine-evidence" {
 		success, toProve, measurement = certlib.ValidateGramineEvidence(pubKey, ep, originalPolicy, purpose)
 		if !success {
 			fmt.Printf("ValidateRequestAndObtainToken: ValidateGramineEvidence failed\n")
 			return false, nil
 		}
-        } else if evType == "keystone-evidence" {
+	} else if evType == "keystone-evidence" {
 		success, toProve, measurement = certlib.ValidateKeystoneEvidence(pubKey, ep, originalPolicy, purpose)
 		if !success {
 			fmt.Printf("ValidateRequestAndObtainToken: ValidateKeystoneEvidence failed\n")
 			return false, nil
 		}
-        } else if evType == "islet-evidence" {
+	} else if evType == "islet-evidence" {
 		success, toProve, measurement = certlib.ValidateIsletEvidence(pubKey, ep, originalPolicy, purpose)
 		if !success {
 			fmt.Printf("ValidateRequestAndObtainToken: ValidateIsletEvidence failed\n")
 			return false, nil
 		}
-        } else {
-                fmt.Printf("ValidateRequestAndObtainToken: Invalid Evidence type: %s\n", evType)
-                return false, nil
-        }
+	} else {
+		fmt.Printf("ValidateRequestAndObtainToken: Invalid Evidence type: %s\n", evType)
+		return false, nil
+	}
 
 	// Produce Artifact
 	var artifact []byte = nil
 	if toProve == nil || toProve.Subject == nil || toProve.Subject.Key == nil ||
-			toProve.Subject.Key.KeyName == nil {
+		toProve.Subject.Key.KeyName == nil {
 		fmt.Printf("ValidateRequestAndObtainToken: toProve check failed\n")
-                if toProve != nil {
+		if toProve != nil {
 			certlib.PrintVseClause(toProve)
 			fmt.Printf("\n")
 		}
@@ -293,7 +292,7 @@ func ValidateRequestAndObtainToken(remoteIP string, pubKey *certprotos.KeyMessag
 
 		// Debug
 		fmt.Printf("Enclave key is:\n")
-		certlib.PrintKey(toProve.Subject.Key);
+		certlib.PrintKey(toProve.Subject.Key)
 		fmt.Printf("\norg: %s, appOrgName: %s\n", org, appOrgName)
 
 		cert := certlib.ProduceAdmissionCert(remoteIP, privKey, policyCert,
@@ -337,29 +336,29 @@ func serviceThread(conn net.Conn, client string) {
 
 	b := certlib.SizedSocketRead(conn)
 	if b == nil {
-                logEvent("Can't read request", nil, nil)
-                return
+		logEvent("Can't read request", nil, nil)
+		return
 	}
 
-        request:= &certprotos.TrustRequestMessage{}
-        err := proto.Unmarshal(b, request)
-        if err != nil {
-                fmt.Println("serviceThread: Failed to decode request", err)
-                logEvent("Can't unmarshal request", nil, nil)
-                return
-        }
+	request := &certprotos.TrustRequestMessage{}
+	err := proto.Unmarshal(b, request)
+	if err != nil {
+		fmt.Println("serviceThread: Failed to decode request", err)
+		logEvent("Can't unmarshal request", nil, nil)
+		return
+	}
 
-        // Debug
-        fmt.Printf("serviceThread: Trust request received:\n")
-        certlib.PrintTrustRequest(request)
+	// Debug
+	fmt.Printf("serviceThread: Trust request received:\n")
+	certlib.PrintTrustRequest(request)
 
-        // Prepare response
-        succeeded := "succeeded"
-        failed := "failed"
+	// Prepare response
+	succeeded := "succeeded"
+	failed := "failed"
 
-        response := certprotos.TrustResponseMessage{}
-        response.RequestingEnclaveTag = request.RequestingEnclaveTag
-        response.ProvidingEnclaveTag = request.ProvidingEnclaveTag
+	response := certprotos.TrustResponseMessage{}
+	response.RequestingEnclaveTag = request.RequestingEnclaveTag
+	response.ProvidingEnclaveTag = request.ProvidingEnclaveTag
 
 	var remoteIP string
 	if remoteAddr, ok := conn.RemoteAddr().(*net.TCPAddr); ok {
@@ -376,93 +375,92 @@ func serviceThread(conn net.Conn, client string) {
 		response.Status = &failed
 	}
 
-        // Debug
-        fmt.Printf("Sending response\n")
-        certlib.PrintTrustReponse(&response)
-        fmt.Printf("\n")
+	// Debug
+	fmt.Printf("Sending response\n")
+	certlib.PrintTrustReponse(&response)
+	fmt.Printf("\n")
 
-        // send response
-        rb, err := proto.Marshal(&response)
-        if err != nil {
-                logEvent("Couldn't marshall request", b, nil)
-                return
-        }
-	if !certlib.SizedSocketWrite(conn, rb) {
-                fmt.Printf("SizedSocketWrite failed (2)\n")
-                return
+	// send response
+	rb, err := proto.Marshal(&response)
+	if err != nil {
+		logEvent("Couldn't marshall request", b, nil)
+		return
 	}
-        if response.Status != nil && *response.Status == "succeeded" {
-                logEvent("Successful request", b, rb)
-        } else {
-                logEvent("Failed request", b, rb)
-        }
-        return
+	if !certlib.SizedSocketWrite(conn, rb) {
+		fmt.Printf("SizedSocketWrite failed (2)\n")
+		return
+	}
+	if response.Status != nil && *response.Status == "succeeded" {
+		logEvent("Successful request", b, rb)
+	} else {
+		logEvent("Failed request", b, rb)
+	}
+	return
 }
 
 //	------------------------------------------------------------------------------------
 
-
 func server(serverAddr string, arg string) {
 
-        if !initCertifierService() {
-                fmt.Printf("server: failed to initialize server\n")
-                os.Exit(1)
-        }
+	if !initCertifierService() {
+		fmt.Printf("server: failed to initialize server\n")
+		os.Exit(1)
+	}
 
-        var sock net.Listener
-        var err error
-        var conn net.Conn
+	var sock net.Listener
+	var err error
+	var conn net.Conn
 
-        // Listen for clients.
-        fmt.Printf("server: listening\n")
-        sock, err = net.Listen("tcp", serverAddr)
-        if err != nil {
-                fmt.Printf("server, listen error: ", err, "\n")
-                return
-        }
+	// Listen for clients.
+	fmt.Printf("server: listening\n")
+	sock, err = net.Listen("tcp", serverAddr)
+	if err != nil {
+		fmt.Printf("server, listen error: ", err, "\n")
+		return
+	}
 
-        // Service client connections.
-        for {
-                fmt.Printf("server: at accept\n")
-                conn, err = sock.Accept()
-                if err != nil {
-                        fmt.Printf("server: can't accept connection: %s\n", err.Error())
-                        continue
-                }
-                // Todo: maybe get client name and client IP for logging.
-                var clientName string = "blah"
-                go serviceThread(conn, clientName)
-        }
+	// Service client connections.
+	for {
+		fmt.Printf("server: at accept\n")
+		conn, err = sock.Accept()
+		if err != nil {
+			fmt.Printf("server: can't accept connection: %s\n", err.Error())
+			continue
+		}
+		// Todo: maybe get client name and client IP for logging.
+		var clientName string = "blah"
+		go serviceThread(conn, clientName)
+	}
 }
 
 func main() {
 
-        flag.Parse()
+	flag.Parse()
 
-        var serverAddr string
-        serverAddr = *serverHost + ":" + *serverPort
-        var arg string = "something"
+	var serverAddr string
+	serverAddr = *serverHost + ":" + *serverPort
+	var arg string = "something"
 
-/*
-	REMOVE: This is a test
-        attestation, err := os.ReadFile("attestation.bin")
-        if err != nil {
-                fmt.Printf("Failed to read attestation file: %s\n", err.Error())
-        }
+	/*
+	   	REMOVE: This is a test
+	           attestation, err := os.ReadFile("attestation.bin")
+	           if err != nil {
+	                   fmt.Printf("Failed to read attestation file: %s\n", err.Error())
+	           }
 
-        var what_to_say []byte
-        what_to_say = make([]byte, 256)
-        for i := 0; i < 256; i++ {
-                what_to_say[i] = byte(i)
-        }
-        outMeasurement, err := gramineverify.GramineVerify(what_to_say, attestation)
-        if err != nil {
-                fmt.Printf("GramineVerify failed: %s\n", err.Error())
-        }
-        fmt.Printf("Measurement length: %d\n", len(outMeasurement));
- */
+	           var what_to_say []byte
+	           what_to_say = make([]byte, 256)
+	           for i := 0; i < 256; i++ {
+	                   what_to_say[i] = byte(i)
+	           }
+	           outMeasurement, err := gramineverify.GramineVerify(what_to_say, attestation)
+	           if err != nil {
+	                   fmt.Printf("GramineVerify failed: %s\n", err.Error())
+	           }
+	           fmt.Printf("Measurement length: %d\n", len(outMeasurement));
+	*/
 
-        // later this may turn into a TLS connection, we'll see
-        server(serverAddr, arg)
-        fmt.Printf("server: done\n")
+	// later this may turn into a TLS connection, we'll see
+	server(serverAddr, arg)
+	fmt.Printf("server: done\n")
 }

--- a/certifier_service/test_sized_client.go
+++ b/certifier_service/test_sized_client.go
@@ -3,12 +3,12 @@ package main
 import (
 	"bytes"
 	"fmt"
-        "net"
+	"net"
 
 	certlib "github.com/vmware-research/certifier-framework-for-confidential-computing/certifier_service/certlib"
 )
 
-func client (conn net.Conn) bool {
+func client(conn net.Conn) bool {
 	fmt.Printf("At client\n")
 	b := []byte{5, 6, 7, 8, 9, 10}
 	if !certlib.SizedSocketWrite(conn, b) {
@@ -24,7 +24,7 @@ func client (conn net.Conn) bool {
 	if !bytes.Equal(b, nb) {
 		return false
 	}
-        return true
+	return true
 }
 
 func Run() {
@@ -56,5 +56,5 @@ func Run() {
 
 func main() {
 
-        Run()
+	Run()
 }

--- a/certifier_service/test_sized_server.go
+++ b/certifier_service/test_sized_server.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-        "net"
+	"net"
 
 	certlib "github.com/vmware-research/certifier-framework-for-confidential-computing/certifier_service/certlib"
 )
@@ -14,7 +14,7 @@ func service(conn net.Conn) {
 		return
 	}
 	conn.Close()
-        return
+	return
 }
 
 func Run() {
@@ -46,4 +46,3 @@ func main() {
 
 	Run()
 }
-

--- a/third_party/asylo/asylo/grpc/auth/core/testdata/generate_test_vectors_test.go
+++ b/third_party/asylo/asylo/grpc/auth/core/testdata/generate_test_vectors_test.go
@@ -25,9 +25,9 @@ import (
 	"fmt"
 	"io"
 
-	"log"
 	"github.com/golang/crypto/curve25519"
 	"github.com/golang/crypto/hkdf"
+	"log"
 )
 
 var (


### PR DESCRIPTION
This commit does a one-time apply of default 'gofmt' formatting to all `.go` files in the Certifier repo.

To prevent future divergence, a new `CI/scripts/check-gofmt.sh` script is added, which gets invoked in early steps of `build.yml` . CI-builds will fail if any gofmt violations are seen.

---

**NOTE: To the reviewers**:

Some of the default `gofmt` rules takes out spaces. I think the old code is more readable ... but we'll have to just live with this no-space formatting for now.

I did investigate ways to profile gofmt-formatting, but didn't find anything very customizable.

I think in the longer-term we will need a way to specify format-rules, to make the code a bit more readable per out local styles.