### PR TITLE
(#146) Rework Makefile-rules to use auto-variables $@, $< more widely

### DIFF
--- a/application_service/app_service.mak
+++ b/application_service/app_service.mak
@@ -33,7 +33,6 @@ I= $(SRC_DIR)/include
 INCLUDE= -I$(I) -I$(LIBSRC)/sev-snp -I/usr/local/opt/openssl@1.1/include/
 
 CFLAGS=$(INCLUDE) -O3 -g -Wall -std=c++11 -Wno-unused-variable -D X64 -D DEBUG -Wno-deprecated-declarations
-CFLAGS1=$(INCLUDE) -O1 -g -Wall -std=c++11 -Wno-unused-variable -D X64 -D DEBUG -Wno-deprecated-declarations
 CC=g++
 LINK=g++
 # PROTO=/usr/local/bin/protoc
@@ -44,13 +43,18 @@ AR=ar
 #export LD_LIBRARY_PATH=/usr/local/lib
 LDFLAGS= -L $(LOCAL_LIB) -lprotobuf -lgtest -lgflags -lpthread -L/usr/local/opt/openssl@1.1/lib/ -lcrypto -lssl
 
-dobj=	$(O)/app_service.o $(O)/certifier.pb.o $(O)/certifier.o $(O)/certifier_proofs.o $(O)/support.o \
-$(O)/simulated_enclave.o $(O)/application_enclave.o $(O)/cc_helpers.o $(O)/cc_useful.o \
-$(O)/sev_support.o $(O)/sev_report.o
+dobj = $(O)/app_service.o $(O)/certifier.pb.o $(O)/certifier.o \
+       $(O)/certifier_proofs.o $(O)/support.o $(O)/simulated_enclave.o \
+       $(O)/application_enclave.o $(O)/cc_helpers.o $(O)/cc_useful.o \
+       $(O)/sev_support.o $(O)/sev_report.o
 
-user_dobj= $(O)/test_user.o $(O)/certifier.pb.o $(O)/certifier.o $(O)/certifier_proofs.o $(O)/support.o \
-$(O)/simulated_enclave.o $(O)/application_enclave.o $(O)/cc_helpers.o $(O)/cc_useful.o
+user_dobj = $(O)/test_user.o $(O)/certifier.pb.o $(O)/certifier.o \
+            $(O)/certifier_proofs.o $(O)/support.o $(O)/simulated_enclave.o \
+            $(O)/application_enclave.o $(O)/cc_helpers.o $(O)/cc_useful.o
 
+send_req_dobj = $(O)/send_request.o $(O)/certifier.pb.o $(O)/certifier.o \
+                $(O)/support.o $(O)/application_enclave.o \
+                $(O)/simulated_enclave.o $(O)/certifier_proofs.o
 
 all:	app_service.exe hello_world.exe send_request.exe test_user.exe
 
@@ -62,83 +66,82 @@ clean:
 	@echo "removing executable file"
 	rm -rf $(EXE_DIR)/app_service.exe
 
-hello_world.exe: hello_world.cc
-	@echo "hello_world.cc"
-	$(CC) $(CFLAGS) -o $(O)/hello_world.exe $(S)/hello_world.cc
+hello_world.exe: $(S)/hello_world.cc
+	@echo "compiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
-send_request.exe: $(O)/send_request.o $(O)/certifier.pb.o $(O)/certifier.o $(O)/support.o $(O)/application_enclave.o $(O)/simulated_enclave.o $(O)/certifier_proofs.o
-	@echo "send_request.exe"
-	$(LINK) -o $(EXE_DIR)/send_request.exe $(O)/send_request.o $(O)/certifier.pb.o \
-	$(O)/certifier.o $(O)/certifier_proofs.o $(O)/support.o $(O)/application_enclave.o $(O)/simulated_enclave.o $(LDFLAGS)
+$(EXE_DIR)/send_request.exe: $(send_req_dobj)
+	@echo "linking executable $@"
+	$(LINK) $(send_req_dobj) $(LDFLAGS) -o $(@D)/$@
 
 $(O)/send_request.o: $(S)/send_request.cc
-	@echo "send_request.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/send_request.o $(S)/send_request.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
-app_service.exe: $(dobj) 
-	@echo "linking executable files"
-	$(LINK) -o $(EXE_DIR)/app_service.exe $(dobj) $(LDFLAGS)
+$(EXE_DIR)/app_service.exe: $(dobj)
+	@echo "linking executable $@"
+	$(LINK) $(dobj) $(LDFLAGS) -o $(@D)/$@
 
-test_user.exe: $(user_dobj) 
-	@echo "linking executable files"
-	$(LINK) -o $(EXE_DIR)/test_user.exe $(user_dobj) $(LDFLAGS)
+$(EXE_DIR)/test_user.exe: $(user_dobj)
+	@echo "linking executable $@"
+	$(LINK) $(user_dobj) $(LDFLAGS) -o $(@D)/$@
 
 $(I)/certifier.pb.h: $(US)/certifier.pb.cc
 $(US)/certifier.pb.cc: $(CP)/certifier.proto
-	$(PROTO) --proto_path=$(CP) --cpp_out=$(US) $<
-	mv certifier.pb.h $(I)
+	$(PROTO) --proto_path=$(<D) --cpp_out=$(@D) $<
+	mv $(@D)/certifier.pb.h $(I)
 
 $(O)/app_service.o: $(S)/app_service.cc $(S)/certifier.pb.cc
-	@echo "compiling app_service.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/app_service.o $(S)/app_service.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/certifier.pb.o: $(US)/certifier.pb.cc $(I)/certifier.pb.h
-	@echo "compiling certifier.pb.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/certifier.pb.o $(US)/certifier.pb.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/certifier.o: $(LIBSRC)/certifier.cc $(I)/certifier.pb.h $(I)/certifier.h
-	@echo "compiling certifier.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/certifier.o $(LIBSRC)/certifier.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/certifier_proofs.o: $(LIBSRC)/certifier_proofs.cc $(I)/certifier.pb.h $(I)/certifier.h
-	@echo "compiling certifier_proofs.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/certifier_proofs.o $(LIBSRC)/certifier_proofs.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/support.o: $(LIBSRC)/support.cc $(I)/support.h
-	@echo "compiling support.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/support.o $(LIBSRC)/support.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/cc_helpers.o: $(LIBSRC)/cc_helpers.cc $(I)/cc_helpers.h
-	@echo "compiling cc_helpers.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/cc_helpers.o $(LIBSRC)/cc_helpers.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/cc_useful.o: $(LIBSRC)/cc_useful.cc $(I)/cc_useful.h
-	@echo "compiling cc_useful.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/cc_useful.o $(LIBSRC)/cc_useful.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/simulated_enclave.o: $(LIBSRC)/simulated_enclave.cc $(I)/simulated_enclave.h
-	@echo "compiling simulated_enclave.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/simulated_enclave.o $(LIBSRC)/simulated_enclave.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/application_enclave.o: $(LIBSRC)/application_enclave.cc $(I)/application_enclave.h
-	@echo "compiling application_enclave.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/application_enclave.o $(LIBSRC)/application_enclave.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/test_user.o: $(S)/test_user.cc $(S)/certifier.pb.cc
-	@echo "compiling test_user.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/test_user.o $(S)/test_user.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 SEV_S=$(LIBSRC)/sev-snp
 
 $(O)/sev_support.o: $(SEV_S)/sev_support.cc \
-$(I)/certifier.h $(I)/support.h $(SEV_S)/attestation.h  $(SEV_S)/sev_guest.h  \
-$(SEV_S)/snp_derive_key.h
-	@echo "compiling sev_support.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/sev_support.o $(SEV_S)/sev_support.cc
+                    $(I)/certifier.h $(I)/support.h \
+                    $(SEV_S)/attestation.h  $(SEV_S)/sev_guest.h \
+                    $(SEV_S)/snp_derive_key.h
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/sev_report.o: $(SEV_S)/sev_report.cc \
-$(I)/certifier.h $(I)/support.h $(SEV_S)/attestation.h  $(SEV_S)/sev_guest.h  \
-$(SEV_S)/snp_derive_key.h
-	@echo "compiling sev_report.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/sev_report.o $(SEV_S)/sev_report.cc
-
+                   $(I)/certifier.h $(I)/support.h $(SEV_S)/attestation.h \
+                   $(SEV_S)/sev_guest.h $(SEV_S)/snp_derive_key.h
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<

--- a/openenclave_test/enclave/oe_certifier.mak
+++ b/openenclave_test/enclave/oe_certifier.mak
@@ -46,7 +46,7 @@ clean:
 	rm -rf $(EXE_DIR)/oe_certifier.exe
 
 oe_certifier.exe: $(dobj) 
-	@echo "linking executable files"
+	@echo "linking executable $@"
 	$(LINK) -o $(EXE_DIR)/oe_certifier.exe $(dobj) $(LDFLAGS)
 
 certifier.pb.cc certifier.pb.h: $(S)/certifier.proto

--- a/sample_apps/analytics_example/enclave/oe_certifier.mak
+++ b/sample_apps/analytics_example/enclave/oe_certifier.mak
@@ -46,7 +46,7 @@ clean:
 	rm -rf $(EXE_DIR)/oe_certifier.exe
 
 oe_certifier.exe: $(dobj) 
-	@echo "linking executable files"
+	@echo "linking executable $@"
 	$(LINK) -o $(EXE_DIR)/oe_certifier.exe $(dobj) $(LDFLAGS)
 
 certifier.pb.h: certifier.pb.cc

--- a/sample_apps/simple_app/example_app.mak
+++ b/sample_apps/simple_app/example_app.mak
@@ -44,13 +44,13 @@ LDFLAGS= -L $(LOCAL_LIB) -lprotobuf -lgtest -lgflags -lpthread -L/usr/local/opt/
 
 # Note:  You can omit all the files below in d_obj except $(O)/example_app.o,
 #  if you link in the certifier library certifier.a.
-dobj=	$(O)/example_app.o $(O)/certifier.pb.o $(O)/certifier.o $(O)/certifier_proofs.o \
-      $(O)/support.o $(O)/simulated_enclave.o $(O)/application_enclave.o $(O)/cc_helpers.o \
-      $(O)/cc_useful.o
-robj=	$(O)/example_key_rotation.o $(O)/certifier.pb.o $(O)/certifier.o $(O)/certifier_proofs.o \
-      $(O)/support.o $(O)/simulated_enclave.o $(O)/application_enclave.o $(O)/cc_helpers.o \
-      $(O)/cc_useful.o
+dobj = $(O)/example_app.o $(O)/certifier.pb.o $(O)/certifier.o $(O)/certifier_proofs.o \
+       $(O)/support.o $(O)/simulated_enclave.o $(O)/application_enclave.o $(O)/cc_helpers.o \
+       $(O)/cc_useful.o
 
+robj = $(O)/example_key_rotation.o $(O)/certifier.pb.o $(O)/certifier.o $(O)/certifier_proofs.o \
+       $(O)/support.o $(O)/simulated_enclave.o $(O)/application_enclave.o $(O)/cc_helpers.o \
+       $(O)/cc_useful.o
 
 all:	example_app.exe example_key_rotation.exe
 clean:
@@ -61,55 +61,55 @@ clean:
 	@echo "removing executable file"
 	rm -rf $(EXE_DIR)/example_app.exe
 
-example_app.exe: $(dobj) 
-	@echo "linking executable files"
-	$(LINK) -o $(EXE_DIR)/example_app.exe $(dobj) $(LDFLAGS)
+$(EXE_DIR)/example_app.exe: $(dobj)
+	@echo "\nlinking executable $@"
+	$(LINK) $(dobj) $(LDFLAGS) -o $(@D)/$@
 
-example_key_rotation.exe: $(robj)
-	@echo "linking executable files"
-	$(LINK) -o $(EXE_DIR)/example_key_rotation.exe $(robj) $(LDFLAGS)
+$(EXE_DIR)/example_key_rotation.exe: $(robj)
+	@echo "\nlinking executable $@"
+	$(LINK) $(robj) $(LDFLAGS) -o $(@D)/$@
 
 $(I)/certifier.pb.h: $(US)/certifier.pb.cc
 $(US)/certifier.pb.cc: $(CP)/certifier.proto
-	$(PROTO) --proto_path=$(CP) --cpp_out=$(US) $<
-	mv $(US)/certifier.pb.h $(I)
+	$(PROTO) --proto_path=$(<D) --cpp_out=$(@D) $<
+	mv $(@D)/certifier.pb.h $(I)
 
 $(O)/certifier.pb.o: $(US)/certifier.pb.cc $(I)/certifier.pb.h
-	@echo "compiling certifier.pb.cc"
-	$(CC) $(CFLAGS_NOERROR) -c -o $(O)/certifier.pb.o $(US)/certifier.pb.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS_NOERROR) -o $(@D)/$@ -c $<
 
 $(O)/example_app.o: $(US)/example_app.cc $(I)/certifier.h $(US)/certifier.pb.cc
-	@echo "compiling example_app.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/example_app.o $(US)/example_app.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/example_key_rotation.o: $(US)/example_key_rotation.cc $(I)/certifier.h $(US)/certifier.pb.cc
-	@echo "compiling example_app.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/example_key_rotation.o $(US)/example_key_rotation.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/certifier.o: $(S)/certifier.cc $(I)/certifier.pb.h $(I)/certifier.h
-	@echo "compiling certifier.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/certifier.o $(S)/certifier.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/certifier_proofs.o: $(S)/certifier_proofs.cc $(I)/certifier.pb.h $(I)/certifier.h
-	@echo "compiling certifier_proofs.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/certifier_proofs.o $(S)/certifier_proofs.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/support.o: $(S)/support.cc $(I)/support.h
-	@echo "compiling support.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/support.o $(S)/support.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/simulated_enclave.o: $(S)/simulated_enclave.cc $(I)/simulated_enclave.h
-	@echo "compiling simulated_enclave.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/simulated_enclave.o $(S)/simulated_enclave.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/application_enclave.o: $(S)/application_enclave.cc $(I)/application_enclave.h
-	@echo "compiling application_enclave.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/application_enclave.o $(S)/application_enclave.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/cc_helpers.o: $(S)/cc_helpers.cc $(I)/certifier.h $(US)/certifier.pb.cc
-	@echo "compiling cc_helpers.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/cc_helpers.o $(S)/cc_helpers.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/cc_useful.o: $(S)/cc_useful.cc $(I)/cc_useful.h
-	@echo "compiling cc_useful.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/cc_useful.o $(S)/cc_useful.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<

--- a/sample_apps/simple_app_under_app_service/example_app.mak
+++ b/sample_apps/simple_app_under_app_service/example_app.mak
@@ -32,7 +32,6 @@ I= $(SRC_DIR)/include
 INCLUDE= -I$(I) -I/usr/local/opt/openssl@1.1/include/ -I$(S)/sev-snp/
 
 CFLAGS=$(INCLUDE) -O3 -g -Wall -std=c++11 -Wno-unused-variable -D X64 -Wno-deprecated-declarations
-CFLAGS1=$(INCLUDE) -O1 -g -Wall -std=c++11 -Wno-unused-variable -D X64 -Wno-deprecated-declarations
 CC=g++
 LINK=g++
 #PROTO=/usr/local/bin/protoc
@@ -43,12 +42,13 @@ LDFLAGS= -L $(LOCAL_LIB) -lprotobuf -lgtest -lgflags -lpthread -L/usr/local/opt/
 
 # Note:  You can omit all the files below in d_obj except $(O)/example_app.o,
 #  if you link in the certifier library certifier.a.
-dobj=	$(O)/service_example_app.o $(O)/certifier.pb.o $(O)/certifier.o $(O)/certifier_proofs.o \
-$(O)/support.o $(O)/simulated_enclave.o $(O)/application_enclave.o $(O)/cc_helpers.o $(O)/cc_useful.o
+dobj = $(O)/service_example_app.o $(O)/certifier.pb.o $(O)/certifier.o \
+       $(O)/certifier_proofs.o $(O)/support.o $(O)/simulated_enclave.o \
+       $(O)/application_enclave.o $(O)/cc_helpers.o $(O)/cc_useful.o
 
-sp_dobj=$(O)/start_program.o $(O)/certifier.pb.o $(O)/certifier.o $(O)/certifier_proofs.o $(O)/support.o \
-$(O)/simulated_enclave.o $(O)/application_enclave.o $(O)/cc_helpers.o $(O)/cc_useful.o
-
+sp_dobj = $(O)/start_program.o $(O)/certifier.pb.o $(O)/certifier.o \
+          $(O)/certifier_proofs.o $(O)/support.o $(O)/simulated_enclave.o \
+          $(O)/application_enclave.o $(O)/cc_helpers.o $(O)/cc_useful.o
 
 all:	service_example_app.exe start_program.exe
 clean:
@@ -59,56 +59,55 @@ clean:
 	@echo "removing executable file"
 	rm -rf $(EXE_DIR)/service_example_app.exe
 
-service_example_app.exe: $(dobj) 
-	@echo "linking executable files"
-	$(LINK) -o $(EXE_DIR)/service_example_app.exe $(dobj) $(LDFLAGS)
+$(EXE_DIR)/service_example_app.exe: $(dobj)
+	@echo "\nlinking executable $@"
+	$(LINK) $(dobj) $(LDFLAGS) -o $(@D)/$@
 
 $(I)/certifier.pb.h: $(US)/certifier.pb.cc
 $(US)/certifier.pb.cc: $(CP)/certifier.proto
-	$(PROTO) --proto_path=$(CP) --cpp_out=$(US) $<
-	mv $(US)/certifier.pb.h $(I)
+	$(PROTO) --proto_path=$(<D) --cpp_out=$(@D) $<
+	mv $(@D)/certifier.pb.h $(I)
 
 $(O)/certifier.pb.o: $(US)/certifier.pb.cc $(I)/certifier.pb.h
-	@echo "compiling certifier.pb.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/certifier.pb.o $(US)/certifier.pb.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
-start_program.exe: $(sp_dobj)
-	@echo "start_program.exe"
-	$(LINK) -o $(EXE_DIR)/start_program.exe $(sp_dobj) $(LDFLAGS)
+$(EXE_DIR)/start_program.exe: $(sp_dobj)
+	@echo "\nlinking executable $@"
+	$(LINK) $(sp_dobj) $(LDFLAGS) -o $(@D)/$@
 
 $(O)/start_program.o: start_program.cc
-	@echo "start_program.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/start_program.o $(US)/start_program.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/service_example_app.o: $(US)/service_example_app.cc $(I)/certifier.h $(US)/certifier.pb.cc
-	@echo "compiling service_example_app.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/service_example_app.o $(US)/service_example_app.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/certifier.o: $(S)/certifier.cc $(I)/certifier.pb.h $(I)/certifier.h
-	@echo "compiling certifier.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/certifier.o $(S)/certifier.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/certifier_proofs.o: $(S)/certifier_proofs.cc $(I)/certifier.pb.h $(I)/certifier.h
-	@echo "compiling certifier_proofs.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/certifier_proofs.o $(S)/certifier_proofs.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/support.o: $(S)/support.cc $(I)/support.h
-	@echo "compiling support.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/support.o $(S)/support.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/simulated_enclave.o: $(S)/simulated_enclave.cc $(I)/simulated_enclave.h
-	@echo "compiling simulated_enclave.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/simulated_enclave.o $(S)/simulated_enclave.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/application_enclave.o: $(S)/application_enclave.cc $(I)/application_enclave.h
-	@echo "compiling application_enclave.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/application_enclave.o $(S)/application_enclave.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/cc_helpers.o: $(S)/cc_helpers.cc $(I)/certifier.h $(US)/certifier.pb.cc
-	@echo "compiling cc_helpers.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/cc_helpers.o $(S)/cc_helpers.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/cc_useful.o: $(S)/cc_useful.cc $(I)/cc_useful.h
-	@echo "compiling cc_useful.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/cc_useful.o $(S)/cc_useful.cc
-
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<

--- a/sample_apps/simple_app_under_islet/islet_example_app.mak
+++ b/sample_apps/simple_app_under_islet/islet_example_app.mak
@@ -48,7 +48,7 @@ INCLUDE= $(ISLET_INCLUDE) -I$(I) -I/usr/local/opt/openssl@1.1/include/ -I$(S)/se
 # # -Werror for those targets
 CFLAGS_NOERROR=$(INCLUDE) -O3 -g -Wall -std=c++11 -Wno-unused-variable -D X64 -Wno-deprecated-declarations -D ISLET_CERTIFIER
 CFLAGS = $(CFLAGS_NOERROR) -Werror
-CFLAGS1=$(INCLUDE) -O1 -g -Wall -std=c++11 -Wno-unused-variable -D X64 -Wno-deprecated-declarations
+
 CC=g++
 LINK=g++
 #PROTO=/usr/local/bin/protoc
@@ -59,9 +59,10 @@ LDFLAGS= $(ISLET_LDFLAGS) -L $(LOCAL_LIB) -lprotobuf -lgtest -lgflags -lpthread 
 
 # Note:  You can omit all the files below in d_obj except $(O)/example_app.o,
 #  if you link in the certifier library certifier.a.
-dobj=	$(O)/islet_example_app.o $(O)/certifier.pb.o $(O)/certifier.o $(O)/certifier_proofs.o \
-      $(O)/support.o $(O)/simulated_enclave.o $(O)/application_enclave.o $(O)/cc_helpers.o \
-      $(O)/cc_useful.o $(O)/islet_shim.o
+dobj = $(O)/islet_example_app.o $(O)/certifier.pb.o $(O)/certifier.o \
+       $(O)/certifier_proofs.o $(O)/support.o $(O)/simulated_enclave.o \
+       $(O)/application_enclave.o $(O)/cc_helpers.o \
+       $(O)/cc_useful.o $(O)/islet_shim.o
 
 all:	islet_example_app.exe
 clean:
@@ -72,51 +73,51 @@ clean:
 	@echo "removing executable file"
 	rm -rf $(EXE_DIR)/islet_example_app.exe
 
-islet_example_app.exe: $(dobj)
-	@echo "linking executable files"
-	$(LINK) -o $(EXE_DIR)/islet_example_app.exe $(dobj) $(LDFLAGS)
+$(EXE_DIR)/islet_example_app.exe: $(dobj)
+	@echo "\nlinking executable $@$(dobj)"
+	$(LINK) $(dobj) $(LDFLAGS) -o $(@D)/$@
 
 $(I)/certifier.pb.h: $(US)/certifier.pb.cc
 $(US)/certifier.pb.cc: $(CP)/certifier.proto
-	$(PROTO) --proto_path=$(CP) --cpp_out=$(US) $<
-	mv $(US)/certifier.pb.h $(I)
+	$(PROTO) --proto_path=$(<D) --cpp_out=$(@D) $<
+	mv $(@D)/certifier.pb.h $(I)
 
 $(O)/certifier.pb.o: $(US)/certifier.pb.cc $(I)/certifier.pb.h
-	@echo "compiling certifier.pb.cc"
-	$(CC) $(CFLAGS_NOERROR) -c -o $(O)/certifier.pb.o $(US)/certifier.pb.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS_NOERROR) -o $(@D)/$@ -c $<
 
 $(O)/islet_example_app.o: $(US)/islet_example_app.cc $(I)/certifier.h $(US)/certifier.pb.cc
-	@echo "compiling islet_example_app.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/islet_example_app.o $(US)/islet_example_app.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/islet_shim.o: $(ISLET_S)/islet_shim.cc $(I)/certifier.h $(US)/certifier.pb.cc
-	@echo "compiling islet_shim.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/islet_shim.o $(ISLET_S)/islet_shim.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/certifier.o: $(S)/certifier.cc $(I)/certifier.pb.h $(I)/certifier.h
-	@echo "compiling certifier.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/certifier.o $(S)/certifier.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/certifier_proofs.o: $(S)/certifier_proofs.cc $(I)/certifier.pb.h $(I)/certifier.h
-	@echo "compiling certifier_proofs.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/certifier_proofs.o $(S)/certifier_proofs.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/support.o: $(S)/support.cc $(I)/support.h
-	@echo "compiling support.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/support.o $(S)/support.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/simulated_enclave.o: $(S)/simulated_enclave.cc $(I)/simulated_enclave.h
-	@echo "compiling simulated_enclave.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/simulated_enclave.o $(S)/simulated_enclave.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/application_enclave.o: $(S)/application_enclave.cc $(I)/application_enclave.h
-	@echo "compiling application_enclave.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/application_enclave.o $(S)/application_enclave.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/cc_helpers.o: $(S)/cc_helpers.cc $(I)/certifier.h $(US)/certifier.pb.cc
-	@echo "compiling cc_helpers.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/cc_helpers.o $(S)/cc_helpers.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/cc_useful.o: $(S)/cc_useful.cc $(I)/cc_useful.h
-	@echo "compiling cc_useful.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/cc_useful.o $(S)/cc_useful.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<

--- a/sample_apps/simple_app_under_keystone/keystone_example_app.mak
+++ b/sample_apps/simple_app_under_keystone/keystone_example_app.mak
@@ -36,7 +36,6 @@ INCLUDE= -I$(I) -I/usr/local/opt/openssl@1.1/include/ -I$(S)/sev-snp/ -I$(KS)
 # # -Werror for those targets
 CFLAGS_NOERROR=$(INCLUDE) -O3 -g -Wall -std=c++11 -Wno-unused-variable -D X64 -Wno-deprecated-declarations -D KEYSTONE_CERTIFIER
 CFLAGS = $(CFLAGS_NOERROR) -Werror
-CFLAGS1=$(INCLUDE) -O1 -g -Wall -std=c++11 -Wno-unused-variable -D X64 -Wno-deprecated-declarations
 CC=g++
 LINK=g++
 #PROTO=/usr/local/bin/protoc
@@ -47,9 +46,10 @@ LDFLAGS= -L $(LOCAL_LIB) -lprotobuf -lgtest -lgflags -lpthread -L/usr/local/opt/
 
 # Note:  You can omit all the files below in d_obj except $(O)/example_app.o,
 #  if you link in the certifier library certifier.a.
-dobj=	$(O)/keystone_example_app.o $(O)/certifier.pb.o $(O)/certifier.o $(O)/certifier_proofs.o \
-      $(O)/support.o $(O)/simulated_enclave.o $(O)/application_enclave.o $(O)/cc_helpers.o \
-      $(O)/cc_useful.o $(O)/keystone_shim.o
+dobj = $(O)/keystone_example_app.o $(O)/certifier.pb.o $(O)/certifier.o \
+       $(O)/certifier_proofs.o $(O)/support.o $(O)/simulated_enclave.o \
+       $(O)/application_enclave.o $(O)/cc_helpers.o \
+       $(O)/cc_useful.o $(O)/keystone_shim.o
 
 all:	keystone_example_app.exe
 clean:
@@ -60,51 +60,51 @@ clean:
 	@echo "removing executable file"
 	rm -rf $(EXE_DIR)/keystone_example_app.exe
 
-keystone_example_app.exe: $(dobj) 
-	@echo "linking executable files"
-	$(LINK) -o $(EXE_DIR)/keystone_example_app.exe $(dobj) $(LDFLAGS)
+$(EXE_DIR)/keystone_example_app.exe: $(dobj) 
+	@echo "\nlinking executable $@"
+	$(LINK) $(dobj) $(LDFLAGS) -o $(@D)/$@
 
 $(I)/certifier.pb.h: $(US)/certifier.pb.cc
 $(US)/certifier.pb.cc: $(CP)/certifier.proto
-	$(PROTO) --proto_path=$(CP) --cpp_out=$(US) $<
-	mv $(US)/certifier.pb.h $(I)
+	$(PROTO) --proto_path=$(<D) --cpp_out=$(@D) $<
+	mv $(@D)/certifier.pb.h $(I)
 
 $(O)/certifier.pb.o: $(US)/certifier.pb.cc $(I)/certifier.pb.h
-	@echo "compiling certifier.pb.cc"
-	$(CC) $(CFLAGS_NOERROR) -c -o $(O)/certifier.pb.o $(US)/certifier.pb.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS_NOERROR) -o $(@D)/$@ -c $<
 
 $(O)/keystone_example_app.o: $(US)/keystone_example_app.cc $(I)/certifier.h $(US)/certifier.pb.cc
-	@echo "compiling keystone_example_app.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/keystone_example_app.o $(US)/keystone_example_app.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/keystone_shim.o: $(KS)/keystone_shim.cc $(I)/certifier.h $(US)/certifier.pb.cc
-	@echo "compiling keystone_shim.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/keystone_shim.o $(KS)/keystone_shim.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/certifier.o: $(S)/certifier.cc $(I)/certifier.pb.h $(I)/certifier.h
-	@echo "compiling certifier.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/certifier.o $(S)/certifier.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/certifier_proofs.o: $(S)/certifier_proofs.cc $(I)/certifier.pb.h $(I)/certifier.h
-	@echo "compiling certifier_proofs.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/certifier_proofs.o $(S)/certifier_proofs.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/support.o: $(S)/support.cc $(I)/support.h
-	@echo "compiling support.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/support.o $(S)/support.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/simulated_enclave.o: $(S)/simulated_enclave.cc $(I)/simulated_enclave.h
-	@echo "compiling simulated_enclave.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/simulated_enclave.o $(S)/simulated_enclave.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/application_enclave.o: $(S)/application_enclave.cc $(I)/application_enclave.h
-	@echo "compiling application_enclave.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/application_enclave.o $(S)/application_enclave.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/cc_helpers.o: $(S)/cc_helpers.cc $(I)/certifier.h $(US)/certifier.pb.cc
-	@echo "compiling cc_helpers.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/cc_helpers.o $(S)/cc_helpers.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/cc_useful.o: $(S)/cc_useful.cc $(I)/cc_useful.h
-	@echo "compiling cc_useful.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/cc_useful.o $(S)/cc_useful.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<

--- a/sample_apps/simple_app_under_sev/sev_example_app.mak
+++ b/sample_apps/simple_app_under_sev/sev_example_app.mak
@@ -34,7 +34,6 @@ INCLUDE=-I $(I) -I/usr/local/opt/openssl@1.1/include/ -I $(S)/sev-snp
 # Inherit -D<flags> provided externally
 CFLAGS := $(CFLAGS)
 CFLAGS += $(INCLUDE) -O3 -g -Wall -std=c++11 -Wno-unused-variable -D X64 -D SEV_SNP -Wno-deprecated-declarations
-CFLAGS1 += $(INCLUDE) -O1 -g -Wall -std=c++11 -Wno-unused-variable -D X64 -D SEV_SNP -Wno-deprecated-declarations
 
 CC=g++
 LINK=g++
@@ -46,10 +45,10 @@ LDFLAGS= -L $(LOCAL_LIB) -lprotobuf -lgtest -lgflags -lpthread -L/usr/local/opt/
 
 # Note:  You can omit all the files below in d_obj except $(O)/example_app.o,
 #  if you link in the certifier library certifier.a.
-dobj=	$(O)/sev_example_app.o $(O)/certifier.pb.o $(O)/certifier.o $(O)/certifier_proofs.o $(O)/support.o \
-$(O)/application_enclave.o $(O)/simulated_enclave.o  $(O)/sev_support.o \
-$(O)/sev_report.o $(O)/cc_helpers.o $(O)/cc_useful.o
-
+dobj = $(O)/sev_example_app.o $(O)/certifier.pb.o $(O)/certifier.o \
+       $(O)/certifier_proofs.o $(O)/support.o $(O)/application_enclave.o \
+       $(O)/simulated_enclave.o  $(O)/sev_support.o $(O)/sev_report.o \
+       $(O)/cc_helpers.o $(O)/cc_useful.o
 
 all:	sev_example_app.exe
 clean:
@@ -60,62 +59,61 @@ clean:
 	@echo "removing executable file"
 	rm -rf $(EXE_DIR)/sev_example_app.exe
 
-sev_example_app.exe: $(dobj) 
-	@echo "linking executable files"
-	$(LINK) -o $(EXE_DIR)/sev_example_app.exe $(dobj) $(LDFLAGS)
+$(EXE_DIR)/sev_example_app.exe: $(dobj)
+	@echo "\nlinking executable $@"
+	$(LINK) $(dobj) $(LDFLAGS) -o $(@D)/$@
 
 $(I)/certifier.pb.h: $(US)/certifier.pb.cc
 $(US)/certifier.pb.cc: $(CP)/certifier.proto
-	$(PROTO) --proto_path=$(CP) --cpp_out=$(US) $<
-	mv certifier.pb.h $(I)
+	$(PROTO) --proto_path=$(<D) --cpp_out=$(@D) $<
+	mv $(@D)/certifier.pb.h $(I)
 
 $(O)/certifier.pb.o: $(US)/certifier.pb.cc $(I)/certifier.pb.h
-	@echo "compiling certifier.pb.cc"
-	$(CC) $(CFLAGS) -Wno-array-bounds -c -o $(O)/certifier.pb.o $(US)/certifier.pb.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -Wno-array-bounds -o $(@D)/$@ -c $<
 
 $(O)/sev_example_app.o: $(US)/sev_example_app.cc $(I)/certifier.h $(US)/certifier.pb.cc
-	@echo "compiling sev_example_app.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/sev_example_app.o $(US)/sev_example_app.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/certifier.o: $(S)/certifier.cc $(I)/certifier.pb.h $(I)/certifier.h
-	@echo "compiling certifier.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/certifier.o $(S)/certifier.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/certifier_proofs.o: $(S)/certifier_proofs.cc $(I)/certifier.pb.h $(I)/certifier.h
-	@echo "compiling certifier_proofs.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/certifier_proofs.o $(S)/certifier_proofs.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/support.o: $(S)/support.cc $(I)/support.h
-	@echo "compiling support.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/support.o $(S)/support.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/simulated_enclave.o: $(S)/simulated_enclave.cc $(I)/simulated_enclave.h
-	@echo "compiling simulated_enclave.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/simulated_enclave.o $(S)/simulated_enclave.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/application_enclave.o: $(S)/application_enclave.cc $(I)/application_enclave.h
-	@echo "compiling application_enclave.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/application_enclave.o $(S)/application_enclave.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/cc_helpers.o: $(S)/cc_helpers.cc $(I)/certifier.h $(US)/certifier.pb.cc
-	@echo "compiling cc_helpers.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/cc_helpers.o $(S)/cc_helpers.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/cc_useful.o: $(S)/cc_useful.cc $(I)/cc_useful.h
-	@echo "compiling cc_useful.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/cc_useful.o $(S)/cc_useful.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 SEV_S=$(S)/sev-snp
 
 $(O)/sev_support.o: $(SEV_S)/sev_support.cc \
-$(I)/certifier.h $(I)/support.h $(SEV_S)/attestation.h  $(SEV_S)/sev_guest.h  \
-$(SEV_S)/snp_derive_key.h
-	@echo "compiling sev_support.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/sev_support.o $(SEV_S)/sev_support.cc
+                    $(I)/certifier.h $(I)/support.h $(SEV_S)/attestation.h \
+                    $(SEV_S)/sev_guest.h $(SEV_S)/snp_derive_key.h
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/sev_report.o: $(SEV_S)/sev_report.cc \
-$(I)/certifier.h $(I)/support.h $(SEV_S)/attestation.h  $(SEV_S)/sev_guest.h  \
-$(SEV_S)/snp_derive_key.h
-	@echo "compiling sev_report.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/sev_report.o $(SEV_S)/sev_report.cc
-
+                   $(I)/certifier.h $(I)/support.h $(SEV_S)/attestation.h \
+                   $(SEV_S)/sev_guest.h $(SEV_S)/snp_derive_key.h
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<

--- a/src/certifier.mak
+++ b/src/certifier.mak
@@ -38,12 +38,12 @@ CL=..
 
 INCLUDE=-I $(I) -I/usr/local/opt/openssl@1.1/include/ -I $(S)/sev-snp
 
+CFLAGS_COMMON = $(INCLUDE) -g -Wall -std=c++11 -Wno-unused-variable -D X64 -Wno-deprecated-declarations
+
+CFLAGS  = $(CFLAGS_COMMON) -O3
+
 ifdef ENABLE_SEV
-CFLAGS=$(INCLUDE) -O3 -g -Wall -std=c++11 -Wno-unused-variable -D X64 -D SEV_SNP -Wno-deprecated-declarations
-CFLAGS1=$(INCLUDE) -O1 -g -Wall -std=c++11 -Wno-unused-variable -D X64 -D SEV_SNP -Wno-deprecated-declarations
-else
-CFLAGS=$(INCLUDE) -O3 -g -Wall -std=c++11 -Wno-unused-variable -D X64 -Wno-deprecated-declarations
-CFLAGS1=$(INCLUDE) -O1 -g -Wall -std=c++11 -Wno-unused-variable -D X64 -Wno-deprecated-declarations
+CFLAGS  += -D SEV_SNP
 endif
 
 CC=g++
@@ -68,7 +68,6 @@ ifdef ENABLE_SEV
 dobj += $(O)/sev_support.o $(O)/sev_report.o
 endif
 
-
 all:	$(CL)/certifier.a
 clean:
 	@echo "removing generated files"
@@ -84,61 +83,61 @@ $(CL)/certifier.a: $(dobj)
 
 $(I)/certifier.pb.h: $(S)/certifier.pb.cc
 $(S)/certifier.pb.cc: $(CP)/certifier.proto
-	$(PROTO) --cpp_out=$(S) --proto_path $(CP) $<
+	$(PROTO) --cpp_out=$(S) --proto_path $(<D) $<
 	mv $(S)/certifier.pb.h $(I)
 
 $(O)/certifier_tests.o: $(S)/certifier_tests.cc $(I)/certifier.pb.h $(I)/certifier.h $(S)/test_support.cc
-	@echo "compiling certifier_tests.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/certifier_tests.o $(S)/certifier_tests.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/certifier.pb.o: $(S)/certifier.pb.cc $(I)/certifier.pb.h
-	@echo "compiling certifier.pb.cc"
-	$(CC) $(CFLAGS) -Wno-array-bounds -c -o $(O)/certifier.pb.o $(S)/certifier.pb.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -Wno-array-bounds -o $(@D)/$@ -c $<
 
 $(O)/certifier.o: $(S)/certifier.cc $(I)/certifier.pb.h $(I)/certifier.h
-	@echo "compiling certifier.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/certifier.o $(S)/certifier.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/certifier_proofs.o: $(S)/certifier_proofs.cc $(I)/certifier.pb.h $(I)/certifier.h
-	@echo "compiling certifier_proofs.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/certifier_proofs.o $(S)/certifier_proofs.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/support.o: $(S)/support.cc $(I)/support.h
-	@echo "compiling support.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/support.o $(S)/support.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/simulated_enclave.o: $(S)/simulated_enclave.cc $(I)/simulated_enclave.h
-	@echo "compiling simulated_enclave.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/simulated_enclave.o $(S)/simulated_enclave.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/application_enclave.o: $(S)/application_enclave.cc $(I)/application_enclave.h
-	@echo "compiling application_enclave.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/application_enclave.o $(S)/application_enclave.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/cc_helpers.o: $(S)/cc_helpers.cc $(I)/cc_helpers.h
-	@echo "compiling cc_helpers.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/cc_helpers.o $(S)/cc_helpers.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/cc_useful.o: $(S)/cc_useful.cc $(I)/cc_useful.h
-	@echo "compiling cc_useful.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/cc_useful.o $(S)/cc_useful.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/keystone_shim.o: $(S)/keystone/keystone_shim.cc $(S)/keystone/keystone_api.h
-	@echo "compiling keystone_shim.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/keystone_shim.o $(S)/keystone/keystone_shim.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 ifdef ENABLE_SEV
 SEV_S=$(S)/sev-snp
 
 $(O)/sev_support.o: $(SEV_S)/sev_support.cc \
-$(I)/certifier.h $(I)/support.h $(SEV_S)/attestation.h  $(SEV_S)/sev_guest.h  \
-$(SEV_S)/snp_derive_key.h
-	@echo "compiling sev_support.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/sev_support.o $(SEV_S)/sev_support.cc
+                    $(I)/certifier.h $(I)/support.h $(SEV_S)/attestation.h  \
+                    $(SEV_S)/sev_guest.h  $(SEV_S)/snp_derive_key.h
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/sev_report.o: $(SEV_S)/sev_report.cc \
-$(I)/certifier.h $(I)/support.h $(SEV_S)/attestation.h  $(SEV_S)/sev_guest.h  \
-$(SEV_S)/snp_derive_key.h
-	@echo "compiling sev_report.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/sev_report.o $(SEV_S)/sev_report.cc
+                   $(I)/certifier.h $(I)/support.h $(SEV_S)/attestation.h  \
+                   $(SEV_S)/sev_guest.h  $(SEV_S)/snp_derive_key.h
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 endif

--- a/src/certifier_tests.mak
+++ b/src/certifier_tests.mak
@@ -36,25 +36,20 @@ S= $(SRC_DIR)
 O= $(OBJ_DIR)
 I= $(INC_DIR)
 
-ifdef ENABLE_SEV
-INCLUDE=-I $(I) -I/usr/local/opt/openssl@1.1/include/ -I $(S)/sev-snp -I $(S)/gramine
-else
-INCLUDE=-I $(I) -I/usr/local/opt/openssl@1.1/include/ -I $(S)/sev-snp -I $(S)/gramine
-endif
+INCLUDE = -I $(I) -I/usr/local/opt/openssl@1.1/include/ -I $(S)/sev-snp -I $(S)/gramine
+
+CFLAGS_COMMON = $(INCLUDE) -g -std=c++11 -D X64 -Wall -Wno-unused-variable -Wno-deprecated-declarations
+
+CFLAGS  = $(CFLAGS_COMMON) -O3
 
 ifdef ENABLE_SEV
+
+CFLAGS  += -D SEV_SNP -D SEV_DUMMY_GUEST
 
 ifdef RUN_SEV_TESTS
-CFLAGS=$(INCLUDE) -O3 -g -Wall -std=c++11  -Wno-deprecated-declarations -Wno-unused-variable -D X64 -D SEV_SNP -D SEV_DUMMY_GUEST -D RUN_SEV_TESTS
-CFLAGS1=$(INCLUDE) -O1 -g -Wall -std=c++11  -Wno-deprecated-declarations -Wno-unused-variable -D X64 -D SEV_SNP -D SEV_DUMMY_GUEST -D RUN_SEV_TESTS
-else
-CFLAGS=$(INCLUDE) -O3 -g -Wall -std=c++11  -Wno-deprecated-declarations -Wno-unused-variable -D X64 -D SEV_SNP -D SEV_DUMMY_GUEST
-CFLAGS1=$(INCLUDE) -O1 -g -Wall -std=c++11  -Wno-deprecated-declarations -Wno-unused-variable -D X64 -D SEV_SNP -D SEV_DUMMY_GUEST
+CFLAGS  += -D RUN_SEV_TESTS
 endif
 
-else
-CFLAGS=$(INCLUDE) -O3 -g -Wall -std=c++11  -Wno-deprecated-declarations -Wno-unused-variable -D X64
-CFLAGS1=$(INCLUDE) -O1 -g -Wall -std=c++11  -Wno-deprecated-declarations -Wno-unused-variable -D X64
 endif
 
 CC=g++
@@ -70,26 +65,28 @@ LDFLAGS= -L $(LOCAL_LIB) -lprotobuf -lgtest -lgflags -lpthread -L/usr/local/opt/
 # Define list of objects for common case which will be extended for
 # ENABLE_SEV build mode.
 # ----------------------------------------------------------------------
-dobj = $(O)/certifier_tests.o $(O)/certifier.pb.o $(O)/certifier.o               \
-       $(O)/certifier_proofs.o $(O)/support.o $(O)/simulated_enclave.o           \
-       $(O)/cc_helpers.o $(O)/cc_useful.o $(O)/application_enclave.o             \
+common_objs = $(O)/certifier.pb.o $(O)/certifier.o      \
+              $(O)/certifier_proofs.o  $(O)/support.o $(O)/simulated_enclave.o \
+              $(O)/application_enclave.o
+
+dobj = $(O)/certifier_tests.o $(common_objs) \
+       $(O)/cc_helpers.o $(O)/cc_useful.o \
        $(O)/claims_tests.o $(O)/primitive_tests.o $(O)/certificate_tests.o       \
        $(O)/store_tests.o $(O)/support_tests.o $(O)/x509_tests.o
 
-channel_dobj =	$(O)/test_channel.o $(O)/certifier.pb.o $(O)/certifier.o          \
-               $(O)/certifier_proofs.o $(O)/support.o $(O)/simulated_enclave.o   \
-               $(O)/application_enclave.o $(O)/cc_helpers.o $(O)/cc_useful.o
+channel_dobj = $(O)/test_channel.o $(common_objs) \
+               $(O)/cc_helpers.o $(O)/cc_useful.o
 
-pipe_read_dobj = $(O)/pipe_read_test.o $(O)/certifier.pb.o $(O)/certifier.o      \
-                 $(O)/certifier_proofs.o  $(O)/support.o $(O)/simulated_enclave.o \
-                 $(O)/application_enclave.o
+pipe_read_dobj = $(O)/pipe_read_test.o $(common_objs)
 
 ifdef ENABLE_SEV
-dobj +=	$(O)/sev_tests.o $(O)/sev_support.o $(O)/sev_report.o
+sev_common_objs = $(O)/sev_support.o $(O)/sev_report.o
 
-channel_dobj += $(O)/sev_support.o $(O)/sev_report.o
+dobj +=	$(O)/sev_tests.o $(sev_common_objs)
 
-pipe_read_dobj += $(O)/sev_support.o $(O)/sev_report.o
+channel_dobj += $(sev_common_objs)
+
+pipe_read_dobj += $(sev_common_objs)
 endif
 
 all:	certifier_tests.exe test_channel.exe pipe_read_test.exe
@@ -103,77 +100,77 @@ clean:
 	rm -rf $(EXE_DIR)/certifier_tests.exe $(EXE_DIR)/pipe_read_test.exe $(EXE_DIR)/test_channel.exe
 
 certifier_tests.exe: $(dobj) 
-	@echo "linking executable files"
+	@echo "\nlinking executable $@"
 	$(LINK) -o $(EXE_DIR)/certifier_tests.exe $(dobj) $(LDFLAGS)
 
 $(I)/certifier.pb.h: $(S)/certifier.pb.cc
 $(S)/certifier.pb.cc: $(CP)/certifier.proto
-	$(PROTO) --cpp_out=$(S) --proto_path $(CP) $<
+	$(PROTO) --cpp_out=$(S) --proto_path $(<D) $<
 	mv $(S)/certifier.pb.h $(I)
 
 $(O)/support_tests.o: $(S)/support_tests.cc $(I)/certifier.pb.h $(I)/certifier.h
-	@echo "compiling support_tests.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/support_tests.o $(S)/support_tests.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/store_tests.o: $(S)/store_tests.cc $(I)/certifier.pb.h $(I)/certifier.h
-	@echo "compiling store_tests.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/store_tests.o $(S)/store_tests.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/primitive_tests.o: $(S)/primitive_tests.cc $(I)/certifier.pb.h $(I)/certifier.h
-	@echo "compiling primitive_tests.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/primitive_tests.o $(S)/primitive_tests.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/x509_tests.o: $(S)/x509_tests.cc $(I)/certifier.pb.h $(I)/certifier.h
-	@echo "compiling x509_tests.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/x509_tests.o $(S)/x509_tests.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/certificate_tests.o: $(S)/certificate_tests.cc $(I)/certifier.pb.h $(I)/certifier.h
-	@echo "compiling certificate_tests.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/certificate_tests.o $(S)/certificate_tests.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/claims_tests.o: $(S)/claims_tests.cc $(I)/certifier.pb.h $(I)/certifier.h $(S)/test_support.cc
-	@echo "compiling claims_tests.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/claims_tests.o $(S)/claims_tests.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/sev_tests.o: $(S)/sev_tests.cc $(I)/certifier.pb.h $(I)/certifier.h
-	@echo "compiling sev_tests.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/sev_tests.o $(S)/sev_tests.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/certifier_tests.o: $(S)/certifier_tests.cc $(I)/certifier.pb.h $(I)/certifier.h $(S)/test_support.cc
-	@echo "compiling certifier_tests.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/certifier_tests.o $(S)/certifier_tests.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/certifier.pb.o: $(S)/certifier.pb.cc $(I)/certifier.pb.h
-	@echo "compiling certifier.pb.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/certifier.pb.o $(S)/certifier.pb.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/certifier.o: $(S)/certifier.cc $(I)/certifier.pb.h $(I)/certifier.h
-	@echo "compiling certifier.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/certifier.o $(S)/certifier.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/certifier_proofs.o: $(S)/certifier_proofs.cc $(I)/certifier.pb.h $(I)/certifier.h
-	@echo "compiling certifier_proofs.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/certifier_proofs.o $(S)/certifier_proofs.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/cc_helpers.o: $(S)/cc_helpers.cc $(I)/certifier.pb.h $(I)/cc_helpers.h
-	@echo "compiling cc_helpers.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/cc_helpers.o $(S)/cc_helpers.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/cc_useful.o: $(S)/cc_useful.cc $(I)/cc_useful.h
-	@echo "compiling cc_useful.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/cc_useful.o $(S)/cc_useful.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/support.o: $(S)/support.cc $(I)/support.h
-	@echo "compiling support.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/support.o $(S)/support.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/simulated_enclave.o: $(S)/simulated_enclave.cc $(I)/simulated_enclave.h
-	@echo "compiling simulated_enclave.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/simulated_enclave.o $(S)/simulated_enclave.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/application_enclave.o: $(S)/application_enclave.cc $(I)/application_enclave.h
-	@echo "compiling application_enclave.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/application_enclave.o $(S)/application_enclave.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 ifdef ENABLE_SEV
 SEV_S=$(S)/sev-snp
@@ -181,28 +178,28 @@ SEV_S=$(S)/sev-snp
 $(O)/sev_support.o: $(SEV_S)/sev_support.cc \
 $(I)/certifier.h $(I)/support.h $(SEV_S)/attestation.h  $(SEV_S)/sev_guest.h  \
 $(SEV_S)/snp_derive_key.h
-	@echo "compiling sev_support.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/sev_support.o $(SEV_S)/sev_support.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/sev_report.o: $(SEV_S)/sev_report.cc \
 $(I)/certifier.h $(I)/support.h $(SEV_S)/attestation.h  $(SEV_S)/sev_guest.h  \
 $(SEV_S)/snp_derive_key.h
-	@echo "compiling sev_report.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/sev_report.o $(SEV_S)/sev_report.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 endif
 
 pipe_read_test.exe: $(pipe_read_dobj) 
-	@echo "linking executable files"
+	@echo "\nlinking executable $@"
 	$(LINK) -o $(EXE_DIR)/pipe_read_test.exe $(pipe_read_dobj) $(LDFLAGS)
 
 $(O)/pipe_read_test.o: $(S)/pipe_read_test.cc
-	@echo "compiling pipe_read_test.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/pipe_read_test.o $(S)/pipe_read_test.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 test_channel.exe: $(channel_dobj) 
-	@echo "linking executable files"
+	@echo "\nlinking executable $@"
 	$(LINK) -o $(EXE_DIR)/test_channel.exe $(channel_dobj) $(LDFLAGS)
 
 $(O)/test_channel.o: $(S)/test_channel.cc
-	@echo "compiling test_channel.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/test_channel.o $(S)/test_channel.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<

--- a/src/gramine/gramine_tests/gramine_tests.mak
+++ b/src/gramine/gramine_tests/gramine_tests.mak
@@ -31,7 +31,7 @@ CERTIFIER_SRC_PATH = ../../
 
 .SECONDARY: certifier
 CERTIFIER_SRC = $(CERTIFIER_SRC_PATH)/gramine/gramine_api.cc        \
-		$(CERTIFIER_SRC_PATH)/gramine/gramine_api_impl.cc   \
+		        $(CERTIFIER_SRC_PATH)/gramine/gramine_api_impl.cc   \
 
 CERTIFIER_INCLUDE = -I. -I$(CERTIFIER_SRC_PATH)/../include -I$(CERTIFIER_SRC_PATH)/gramine $(SGX_INCLUDE) -I./mbedtls/include
 CERTIFIER_CFLAGS = $(CERTIFIER_INCLUDE) -DGRAMINE_CERTIFIER

--- a/src/keystone/keystone_tests/keystone_tests.mak
+++ b/src/keystone/keystone_tests/keystone_tests.mak
@@ -52,12 +52,12 @@ dobj = certifier.a $(internal-dobj) # TODO: maybe move certifier library mix-in 
 
 # TODO: maybe fix?
 tests: $(dobj) $(KEYSTONE_SDK_LIB)
-	@echo "linking executable file tests"
+	@echo "linking executable $@"
 	$(LINK) -o $(EXE_DIR)/tests $(dobj) $(LDFLAGS)
 
 # uses keystone_api and not certifier
 tests_bare: $(internal-dobj) $(KEYSTONE_SDK_LIB)
-	@echo "linking executable file tests_bare"
+	@echo "linking executable $@"
 	$(LINK) -o $(EXE_DIR)/tests_bare $(internal-dobj) $(LDFLAGS)
 
 # does not use keystone
@@ -69,7 +69,7 @@ $(O)/keystone_shim.o: ./keystone_shim.cc
 shim-dobj = $(O)/keystone_shim.o $(O)/keystone_test.o
 
 tests_bare_shim: $(shim-dobj)
-	@echo "linking executable file tests_bare_shim"
+	@echo "linking executable $@"
 	$(LINK) -o ./tests_bare_shim $(shim-dobj) $(LDFLAGS)
 
 clean:

--- a/src/keystone/shim_test.mak
+++ b/src/keystone/shim_test.mak
@@ -37,12 +37,10 @@ CL=..
 
 INCLUDE=-I $(I) -I/usr/local/opt/openssl@1.1/include/ -I .
 
+CFLAGS = $(INCLUDE) -O3 -g -D X64 -std=c++11 -Wall -Wno-unused-variable -Wno-deprecated-declarations
+
 ifdef ENABLE_SEV
-CFLAGS=$(INCLUDE) -O3 -g -Wall -std=c++11 -Wno-unused-variable -D X64 -D SEV_SNP -Wno-deprecated-declarations
-CFLAGS1=$(INCLUDE) -O1 -g -Wall -std=c++11 -Wno-unused-variable -D X64 -D SEV_SNP -Wno-deprecated-declarations
-else
-CFLAGS=$(INCLUDE) -O3 -g -Wall -std=c++11 -Wno-unused-variable -D X64 -Wno-deprecated-declarations
-CFLAGS1=$(INCLUDE) -O1 -g -Wall -std=c++11 -Wno-unused-variable -D X64 -Wno-deprecated-declarations
+CFLAGS += -D SEV_SNP
 endif
 
 CC=g++
@@ -59,7 +57,7 @@ dobj = $(O)/certifier.pb.o $(O)/certifier.o $(O)/certifier_proofs.o        \
        $(O)/support.o $(O)/application_enclave.o $(O)/simulated_enclave.o  \
        $(O)/cc_helpers.o $(O)/cc_useful.o $(O)/keystone_shim.o $(O)/keystone_test.o
 
-all:	$(CL)/keystone_test.exe
+all:	$(EXE_DIR)/keystone_test.exe
 clean:
 	@echo "removing generated files"
 	rm -rf $(S)/certifier.pb.cc $(S)/certifier.pb.h $(I)/certifier.pb.h
@@ -72,50 +70,50 @@ clean:
 
 $(I)/certifier.pb.h: $(S)/certifier.pb.cc
 $(S)/certifier.pb.cc: $(CP)/certifier.proto
-	$(PROTO) --proto_path=$(CP) --cpp_out=$(S) $<
-	mv $(S)/certifier.pb.h $(I)
+	$(PROTO) --proto_path=$(CP) --cpp_out=$(@D) $<
+	mv $(@D)/certifier.pb.h $(I)
 
-$(CL)/keystone_test.exe: $(dobj)
-	@echo "linking certifier library"
-	$(LINK) -o $(EXE_DIR)/keystone_test.exe $(dobj) $(LDFLAGS)
+$(EXE_DIR)/keystone_test.exe: $(dobj)
+	@echo "\nlinking $@"
+	$(LINK) $(dobj) $(LDFLAGS) -o $(@D)/$@
 
 $(O)/keystone_test.o: $(S)/keystone_test.cc $(I)/certifier.pb.h $(I)/certifier.h
-	@echo "compiling keystone_test.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/keystone_test.o $(S)/keystone_test.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -c -o $(@D)/$@ -c $<
 
 $(O)/keystone_shim.o: $(S)/keystone_shim.cc $(I)/certifier.pb.h $(I)/certifier.h
-	@echo "compiling keystone_shim.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/keystone_shim.o $(S)/keystone_shim.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -c -o $(@D)/$@ -c $<
 
 $(O)/certifier.pb.o: $(S)/certifier.pb.cc $(I)/certifier.pb.h
-	@echo "compiling certifier.pb.cc"
-	$(CC) $(CFLAGS) -Wno-array-bounds -c -o $(O)/certifier.pb.o $<
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -Wno-array-bounds -o $(@D)/$@ -c $<
 
 $(O)/certifier.o: $(SRC_DIR)/certifier.cc $(I)/certifier.pb.h $(I)/certifier.h
-	@echo "compiling certifier.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/certifier.o $(SRC_DIR)/certifier.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -c -o $(@D)/$@ -c $<
 
 $(O)/certifier_proofs.o: $(SRC_DIR)/certifier_proofs.cc $(I)/certifier.pb.h $(I)/certifier.h
-	@echo "compiling certifier_proofs.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/certifier_proofs.o $(SRC_DIR)/certifier_proofs.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -c -o $(@D)/$@ -c $<
 
 $(O)/support.o: $(SRC_DIR)/support.cc $(I)/support.h
-	@echo "compiling support.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/support.o $(SRC_DIR)/support.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -c -o $(@D)/$@ -c $<
 
 $(O)/simulated_enclave.o: $(SRC_DIR)/simulated_enclave.cc $(I)/simulated_enclave.h
-	@echo "compiling simulated_enclave.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/simulated_enclave.o $(SRC_DIR)/simulated_enclave.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -c -o $(@D)/$@ -c $<
 
 $(O)/application_enclave.o: $(SRC_DIR)/application_enclave.cc $(I)/application_enclave.h
-	@echo "compiling application_enclave.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/application_enclave.o $(SRC_DIR)/application_enclave.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -c -o $(@D)/$@ -c $<
 
 $(O)/cc_helpers.o: $(SRC_DIR)/cc_helpers.cc $(I)/cc_helpers.h
-	@echo "compiling cc_helpers.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/cc_helpers.o $(SRC_DIR)/cc_helpers.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -c -o $(@D)/$@ -c $<
 
 $(O)/cc_useful.o: $(SRC_DIR)/cc_useful.cc $(I)/cc_useful.h
-	@echo "compiling cc_useful.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/cc_useful.o $(SRC_DIR)/cc_useful.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -c -o $(@D)/$@ -c $<
 

--- a/utilities/cert_utility.mak
+++ b/utilities/cert_utility.mak
@@ -5,7 +5,7 @@
 CERTIFIER_ROOT = ..
 
 ifndef SRC_DIR
-SRC_DIR=..
+SRC_DIR=$(CERTIFIER_ROOT)/src
 endif
 ifndef OBJ_DIR
 OBJ_DIR=.
@@ -32,7 +32,7 @@ endif
 
 CP = $(CERTIFIER_ROOT)/certifier_service/certprotos
 
-S= $(SRC_DIR)/src
+S= $(SRC_DIR)
 O= $(OBJ_DIR)
 I= $(INC_DIR)
 US= .
@@ -54,15 +54,15 @@ AR=ar
 #export LD_LIBRARY_PATH=/usr/local/lib
 LDFLAGS= -L $(LOCAL_LIB) -lprotobuf -lgtest -lgflags -lpthread -L/usr/local/opt/openssl@1.1/lib/ -lcrypto -lssl
 
-dobj=	$(O)/cert_utility.o $(O)/certifier.pb.o $(O)/support.o $(O)/certifier.o \
-$(O)/certifier_proofs.o $(O)/simulated_enclave.o $(O)/application_enclave.o
+common_objs = $(O)/certifier.pb.o $(O)/support.o $(O)/certifier.o \
+              $(O)/certifier_proofs.o $(O)/simulated_enclave.o \
+              $(O)/application_enclave.o
 
-key_dobj=$(O)/key_utility.o $(O)/certifier.pb.o $(O)/support.o $(O)/certifier.o \
-$(O)/certifier_proofs.o $(O)/simulated_enclave.o $(O)/application_enclave.o
+dobj =	$(O)/cert_utility.o $(common_objs)
 
-mobj=	$(O)/measurement_init.o $(O)/certifier.pb.o $(O)/support.o $(O)/certifier.o \
-$(O)/certifier_proofs.o $(O)/simulated_enclave.o $(O)/application_enclave.o
+key_dobj = $(O)/key_utility.o $(common_objs)
 
+mobj = $(O)/measurement_init.o $(common_objs)
 
 all:	cert_utility.exe measurement_init.exe key_utility.exe
 clean:
@@ -72,54 +72,54 @@ clean:
 	rm -rf $(EXE_DIR)/cert_utility.exe
 
 cert_utility.exe: $(dobj) 
-	@echo "linking executable files"
-	$(LINK) -o $(EXE_DIR)/cert_utility.exe $(dobj) $(LDFLAGS)
+	@echo "\nlinking executable $@"
+	$(LINK) $(dobj) $(LDFLAGS) -o $(EXE_DIR)/$@
 
 key_utility.exe: $(key_dobj)
-	@echo "linking executable files"
-	$(LINK) -o $(EXE_DIR)/key_utility.exe $(key_dobj) $(LDFLAGS)
+	@echo "\nlinking executable $@"
+	$(LINK) $(key_dobj) $(LDFLAGS) -o $(EXE_DIR)/$@
 
 measurement_init.exe: $(mobj)
-	@echo "linking executable files"
-	$(LINK) -o $(EXE_DIR)/measurement_init.exe $(mobj) $(LDFLAGS)
+	@echo "\nlinking executable $@"
+	$(LINK) $(mobj) $(LDFLAGS) -o $(EXE_DIR)/$@
 
 $(O)/measurement_init.o: $(US)/measurement_init.cc
-	@echo "compiling measurement_init.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/measurement_init.o $(US)/measurement_init.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/cert_utility.o: $(US)/cert_utility.cc $(I)/support.h $(I)/certifier.pb.h
-	@echo "compiling cert_utility.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/cert_utility.o $(US)/cert_utility.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/key_utility.o: $(US)/key_utility.cc $(I)/support.h $(I)/certifier.pb.h
-	@echo "compiling key_utility.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/key_utility.o $(US)/key_utility.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(I)/certifier.pb.h: $(US)/certifier.pb.cc
 $(US)/certifier.pb.cc: $(CP)/certifier.proto
-	$(PROTO) --cpp_out=$(US) --proto_path $(CP) $<
-	mv certifier.pb.h $(I)
+	$(PROTO) --cpp_out=$(US) --proto_path $(<D) $<
+	mv $(@D)/certifier.pb.h $(I)
 
 $(O)/certifier.pb.o: $(US)/certifier.pb.cc $(I)/certifier.pb.h
-	@echo "compiling certifier.pb.cc"
-	$(CC) $(CFLAGS_NOERROR) -Wno-array-bounds -c  -o $(O)/certifier.pb.o $(US)/certifier.pb.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS_NOERROR) -Wno-array-bounds -o $(@D)/$@ -c $<
 
 $(O)/support.o: $(S)/support.cc $(I)/support.h $(I)/certifier.pb.h
-	@echo "compiling support.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/support.o $(S)/support.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/certifier.o: $(S)/certifier.cc $(I)/certifier.pb.h $(I)/certifier.h
-	@echo "compiling certifier.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/certifier.o $(S)/certifier.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/certifier_proofs.o: $(S)/certifier_proofs.cc $(I)/certifier.pb.h $(I)/certifier.h
-	@echo "compiling certifier_proofs.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/certifier_proofs.o $(S)/certifier_proofs.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/simulated_enclave.o: $(S)/simulated_enclave.cc $(I)/simulated_enclave.h
-	@echo "compiling simulated_enclave.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/simulated_enclave.o $(S)/simulated_enclave.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/application_enclave.o: $(S)/application_enclave.cc $(I)/application_enclave.h
-	@echo "compiling application_enclave.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/application_enclave.o $(S)/application_enclave.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<

--- a/utilities/policy_generator.mak
+++ b/utilities/policy_generator.mak
@@ -1,15 +1,15 @@
 #
 #    File: policy_generator.mak
 
-ifndef CERTIFIER_PROTOTYPE_DIR
-CERTIFIER_PROTOTYPE_DIR=..
+# CERTIFIER_ROOT will be certifier-framework-for-confidential-computing/ dir
+ifndef CERTIFIER_ROOT
+CERTIFIER_ROOT=..
 endif
+
 ifndef SRC_DIR
-SRC_DIR=$(CERTIFIER_PROTOTYPE_DIR)/utilities
+SRC_DIR=.
 endif
-ifndef INC_DIR
-INC_DIR=$(CERTIFIER_PROTOTYPE_DIR)/include
-endif
+
 ifndef OBJ_DIR
 OBJ_DIR=.
 endif
@@ -18,7 +18,7 @@ EXE_DIR=.
 endif
 
 S= $(SRC_DIR)
-CERT_SRC=$(CERTIFIER_PROTOTYPE_DIR)/src
+CERT_SRC=$(CERTIFIER_ROOT)/src
 O= $(OBJ_DIR)
 
 JSON_VALIDATOR=/usr/local
@@ -33,11 +33,11 @@ LDFLAGS= -L$(LOCAL_LIB) -lnlohmann_json_schema_validator -lgflags
 all:	$(EXE_DIR)/policy_generator.exe
 
 clean:
-	rm -rf $(O)/policy_generator.o
-	rm -rf $(EXE_DIR)/policy_generator.exe
+	rm -rf $(O)/policy_generator.o $(EXE_DIR)/policy_generator.exe
 
 $(EXE_DIR)/policy_generator.exe: $(EXE_DIR)/policy_generator.o
 	$(LD) -o $(EXE_DIR)/policy_generator.exe policy_generator.o $(LDFLAGS)
 
 $(O)/policy_generator.o: $(S)/policy_generator.cc
-	$(CC) $(CFLAGS) -c -o $(O)/policy_generator.o $(S)/policy_generator.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<

--- a/utilities/policy_utilities.mak
+++ b/utilities/policy_utilities.mak
@@ -5,7 +5,7 @@ ifndef CERTIFIER_ROOT
 CERTIFIER_ROOT=..
 endif
 ifndef SRC_DIR
-SRC_DIR=$(CERTIFIER_ROOT)/utilities
+SRC_DIR=.
 endif
 ifndef INC_DIR
 INC_DIR=$(CERTIFIER_ROOT)/include
@@ -36,13 +36,11 @@ CP = $(CERTIFIER_ROOT)/certifier_service/certprotos
 S= $(SRC_DIR)
 O= $(OBJ_DIR)
 I= $(INC_DIR)
-US= .
 
 INCLUDE= -I$(INC_DIR) -I/usr/local/opt/openssl@1.1/include/ -I$(CERT_SRC)/sev-snp/
 
 CFLAGS_NOERROR = $(INCLUDE) -O3 -g -Wall -std=c++11 -Wno-unused-variable -D X64 -Wno-deprecated -Wno-deprecated-declarations
 CFLAGS = $(CFLAGS_NOERROR) -Werror
-CFLAGS1= $(INCLUDE) -O1 -g -Wall -std=c++11 -Wno-unused-variable -D X64 -Wno-deprecated -Wno-deprecated-declarations
 # For Mac: -D MACOS should be defined
 
 CC=g++
@@ -55,76 +53,78 @@ AR=ar
 #export LD_LIBRARY_PATH=/usr/local/lib
 LDFLAGS= -L $(LOCAL_LIB) -lprotobuf -lgtest -lgflags -lpthread -L/usr/local/opt/openssl@1.1/lib/ -lcrypto -lssl
 
-measurement_utility_obj=$(O)/measurement_utility.o $(O)/support.o $(O)/certifier.o $(O)/certifier_proofs.o \
-$(O)/certifier.pb.o $(O)/simulated_enclave.o $(O)/application_enclave.o
-make_indirect_vse_clause_obj= $(O)/make_indirect_vse_clause.o $(O)/support.o $(O)/certifier.o \
-$(O)/certifier_proofs.o $(O)/certifier.pb.o $(O)/simulated_enclave.o $(O)/application_enclave.o
-make_simple_vse_clause_obj= $(O)/make_simple_vse_clause.o $(O)/support.o $(O)/certifier.o \
-$(O)/certifier_proofs.o $(O)/certifier.pb.o $(O)/simulated_enclave.o $(O)/application_enclave.o
-make_unary_vse_clause_obj= $(O)/make_unary_vse_clause.o $(O)/support.o $(O)/certifier.o \
-$(O)/certifier_proofs.o $(O)/certifier.pb.o $(O)/simulated_enclave.o $(O)/application_enclave.o
-make_signed_claim_from_vse_clause_obj= $(O)/make_signed_claim_from_vse_clause.o $(O)/support.o \
-$(O)/certifier.o $(O)/certifier_proofs.o $(O)/certifier.pb.o $(O)/simulated_enclave.o $(O)/application_enclave.o
-print_vse_clause_obj= $(O)/print_vse_clause.o $(O)/support.o $(O)/certifier.o $(O)/certifier_proofs.o \
-$(O)/certifier.pb.o $(O)/simulated_enclave.o $(O)/application_enclave.o
-print_signed_claim_obj= $(O)/print_signed_claim.o $(O)/support.o $(O)/certifier.o $(O)/certifier_proofs.o \
-$(O)/certifier.pb.o $(O)/simulated_enclave.o $(O)/application_enclave.o
-package_claims_obj= $(O)/package_claims.o $(O)/support.o $(O)/certifier.o $(O)/certifier_proofs.o \
-$(O)/certifier.pb.o $(O)/simulated_enclave.o $(O)/application_enclave.o
-print_packaged_claims_obj= $(O)/print_packaged_claims.o $(O)/support.o $(O)/certifier.o $(O)/certifier_proofs.o \
-$(O)/certifier.pb.o $(O)/simulated_enclave.o $(O)/application_enclave.o
+common_objs = $(O)/support.o $(O)/certifier.o $(O)/certifier_proofs.o \
+              $(O)/certifier.pb.o $(O)/simulated_enclave.o \
+              $(O)/application_enclave.o
+
+measurement_utility_obj = $(O)/measurement_utility.o $(common_objs)
+
+make_indirect_vse_clause_obj = $(O)/make_indirect_vse_clause.o $(common_objs)
+
+make_simple_vse_clause_obj = $(O)/make_simple_vse_clause.o $(common_objs)
+
+make_unary_vse_clause_obj = $(O)/make_unary_vse_clause.o $(common_objs)
+
+make_signed_claim_from_vse_clause_obj = $(O)/make_signed_claim_from_vse_clause.o \
+                                        $(common_objs)
+
+print_vse_clause_obj = $(O)/print_vse_clause.o $(common_objs)
+
+print_signed_claim_obj = $(O)/print_signed_claim.o $(common_objs)
+
+package_claims_obj = $(O)/package_claims.o $(common_objs)
+
+print_packaged_claims_obj = $(O)/print_packaged_claims.o $(common_objs)
+
 embed_policy_key_obj=$(O)/embed_policy_key.o
-make_platform_obj= $(O)/make_platform.o $(O)/support.o $(O)/certifier.o $(O)/certifier_proofs.o \
-$(O)/certifier.pb.o $(O)/simulated_enclave.o $(O)/application_enclave.o
-make_property_obj= $(O)/make_property.o $(O)/support.o $(O)/certifier.o $(O)/certifier_proofs.o \
-$(O)/certifier.pb.o $(O)/simulated_enclave.o $(O)/application_enclave.o
-combine_properties_obj= $(O)/combine_properties.o $(O)/support.o $(O)/certifier.o $(O)/certifier_proofs.o \
-$(O)/certifier.pb.o $(O)/simulated_enclave.o $(O)/application_enclave.o
-make_environment_obj= $(O)/make_environment.o $(O)/support.o $(O)/certifier.o $(O)/certifier_proofs.o \
-$(O)/certifier.pb.o $(O)/simulated_enclave.o $(O)/application_enclave.o
 
-simulated_sev.obj= $(O)/simulated_sev_attest.o $(O)/support.o $(O)/certifier.o $(O)/certifier_proofs.o \
-$(O)/certifier.pb.o $(O)/simulated_enclave.o $(O)/application_enclave.o
-sample_sev_key_generation.obj= $(O)/sample_sev_key_generation.o $(O)/support.o $(O)/certifier.o $(O)/certifier_proofs.o \
-$(O)/certifier.pb.o $(O)/simulated_enclave.o $(O)/application_enclave.o
-simulated_sev_key_generation.obj= $(O)/simulated_sev_key_generation.o $(O)/support.o $(O)/certifier.o $(O)/certifier_proofs.o \
-$(O)/certifier.pb.o $(O)/simulated_enclave.o $(O)/application_enclave.o
+make_platform_obj = $(O)/make_platform.o $(common_objs)
 
+make_property_obj = $(O)/make_property.o $(common_objs)
 
+combine_properties_obj = $(O)/combine_properties.o $(common_objs)
 
-all:	$(EXE_DIR)/measurement_utility.exe $(EXE_DIR)/make_indirect_vse_clause.exe \
-	$(EXE_DIR)/make_simple_vse_clause.exe $(EXE_DIR)/make_unary_vse_clause.exe \
-	$(EXE_DIR)/make_signed_claim_from_vse_clause.exe $(EXE_DIR)/print_vse_clause.exe \
-	$(EXE_DIR)/print_signed_claim.exe $(EXE_DIR)/package_claims.exe \
-	$(EXE_DIR)/print_packaged_claims.exe $(EXE_DIR)/embed_policy_key.exe \
-	$(EXE_DIR)/make_platform.exe $(EXE_DIR)/make_property.exe $(EXE_DIR)/combine_properties.exe \
-	$(EXE_DIR)/make_environment.exe $(EXE_DIR)/simulated_sev_attest.exe $(EXE_DIR)/sample_sev_key_generation.exe \
-	$(EXE_DIR)/simulated_sev_key_generation.exe
+make_environment_obj = $(O)/make_environment.o $(common_objs)
+
+simulated_sev.obj = $(O)/simulated_sev_attest.o $(common_objs)
+
+sample_sev_key_generation.obj = $(O)/sample_sev_key_generation.o $(common_objs)
+
+simulated_sev_key_generation.obj = $(O)/simulated_sev_key_generation.o $(common_objs)
+
+all:	$(EXE_DIR)/measurement_utility.exe \
+	    $(EXE_DIR)/make_indirect_vse_clause.exe \
+	    $(EXE_DIR)/make_simple_vse_clause.exe \
+	    $(EXE_DIR)/make_unary_vse_clause.exe \
+	    $(EXE_DIR)/make_signed_claim_from_vse_clause.exe \
+	    $(EXE_DIR)/make_platform.exe \
+	    $(EXE_DIR)/make_property.exe \
+	    $(EXE_DIR)/make_environment.exe \
+	    $(EXE_DIR)/package_claims.exe \
+	    $(EXE_DIR)/embed_policy_key.exe \
+	    $(EXE_DIR)/combine_properties.exe \
+	    $(EXE_DIR)/sample_sev_key_generation.exe \
+	    $(EXE_DIR)/simulated_sev_attest.exe \
+	    $(EXE_DIR)/simulated_sev_key_generation.exe \
+	    $(EXE_DIR)/print_vse_clause.exe \
+	    $(EXE_DIR)/print_signed_claim.exe \
+	    $(EXE_DIR)/print_packaged_claims.exe
 
 clean:
 	@echo "removing generated files"
 	rm -rf $(CERT_SRC)/certifier.pb.cc $(CERT_SRC)/certifier.pb.h $(I)/certifier.pb.h
 	@echo "removing object files"
 	rm -rf $(O)/*.o
-	@echo "removing executable file"
+	@echo "removing executables"
 	rm -rf $(EXE_DIR)/*.exe
 
 $(EXE_DIR)/measurement_utility.exe: $(measurement_utility_obj) 
-	@echo "linking executable files"
-	$(LINK) -o $(EXE_DIR)/measurement_utility.exe $(measurement_utility_obj) $(LDFLAGS)
-#-L $(CERTIFIER_ROOT)/certifier.a
+	@echo "\nlinking executable $@"
+	$(LINK) $(measurement_utility_obj) $(LDFLAGS) -o $(@D)/$@
 
 $(O)/measurement_utility.o: $(S)/measurement_utility.cc $(INC_DIR)/certifier.pb.h $(INC_DIR)/certifier.h
-	@echo "compiling measurement_utility.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/measurement_utility.o $(S)/measurement_utility.cc
-
-$(O)/cert_utility.o: $(US)/cert_utility.cc $(INC_DIR)/support.h $(INC_DIR)/certifier.pb.h
-	@echo "compiling cert_utility.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/cert_utility.o $(US)/cert_utility.cc
-
-$(O)/key_utility.o: $(US)/key_utility.cc $(INC_DIR)/support.h $(INC_DIR)/certifier.pb.h
-	@echo "compiling key_utility.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/key_utility.o $(US)/key_utility.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 # Generate certifier.pb.cc in src/ dir, using proto file from certprotos/
 $(I)/certifier.pb.h: $(CERT_SRC)/certifier.pb.cc
@@ -133,159 +133,157 @@ $(CERT_SRC)/certifier.pb.cc: $(CP)/certifier.proto
 	mv $(CERT_SRC)/certifier.pb.h $(I)
 
 $(O)/certifier.pb.o: $(CERT_SRC)/certifier.pb.cc $(INC_DIR)/certifier.pb.h
-	@echo "compiling certifier.pb.cc"
-	$(CC) $(CFLAGS_NOERROR) -Warray-bounds -c  -o $(O)/certifier.pb.o $(CERT_SRC)/certifier.pb.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS_NOERROR) -Warray-bounds -o $(@D)/$@ -c $<
 
 $(O)/support.o: $(CERT_SRC)/support.cc $(INC_DIR)/support.h $(INC_DIR)/certifier.pb.h
-	@echo "compiling support.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/support.o $(CERT_SRC)/support.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/certifier.o: $(CERT_SRC)/certifier.cc $(INC_DIR)/certifier.pb.h $(INC_DIR)/certifier.h
-	@echo "compiling certifier.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/certifier.o $(CERT_SRC)/certifier.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/certifier_proofs.o: $(CERT_SRC)/certifier_proofs.cc $(INC_DIR)/certifier.pb.h $(INC_DIR)/certifier.h
-	@echo "compiling certifier_proofs.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/certifier_proofs.o $(CERT_SRC)/certifier_proofs.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/simulated_enclave.o: $(CERT_SRC)/simulated_enclave.cc $(INC_DIR)/simulated_enclave.h
-	@echo "compiling simulated_enclave.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/simulated_enclave.o $(CERT_SRC)/simulated_enclave.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/application_enclave.o: $(CERT_SRC)/application_enclave.cc $(INC_DIR)/application_enclave.h
-	@echo "compiling application_enclave.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/application_enclave.o $(CERT_SRC)/application_enclave.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
-$(O)/measurement_init.o: $(US)/measurement_init.cc
-	@echo "compiling measurement_init.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/measurement_init.o $(US)/measurement_init.cc
+$(O)/measurement_init.o: $(S)/measurement_init.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/make_indirect_vse_clause.o: $(S)/make_indirect_vse_clause.cc $(INC_DIR)/certifier.pb.h $(INC_DIR)/certifier.h
-	@echo "compiling make_indirect_vse_clause.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/make_indirect_vse_clause.o $(S)/make_indirect_vse_clause.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(EXE_DIR)/make_indirect_vse_clause.exe: $(make_indirect_vse_clause_obj) 
-	@echo "linking executable files"
+	@echo "\nlinking executable $@"
 	$(LINK) -o $(EXE_DIR)/make_indirect_vse_clause.exe $(make_indirect_vse_clause_obj) $(LDFLAGS)
 
 $(O)/make_simple_vse_clause.o: $(S)/make_simple_vse_clause.cc $(INC_DIR)/certifier.pb.h $(INC_DIR)/certifier.h
-	@echo "compiling make_simple_vse_clause.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/make_simple_vse_clause.o $(S)/make_simple_vse_clause.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(EXE_DIR)/make_simple_vse_clause.exe: $(make_simple_vse_clause_obj) 
-	@echo "linking executable files"
+	@echo "\nlinking executable $@"
 	$(LINK) -o $(EXE_DIR)/make_simple_vse_clause.exe $(make_simple_vse_clause_obj) $(LDFLAGS)
 
 $(O)/make_unary_vse_clause.o: $(S)/make_unary_vse_clause.cc $(INC_DIR)/certifier.pb.h $(INC_DIR)/certifier.h
-	@echo "compiling make_unary_vse_clause.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/make_unary_vse_clause.o $(S)/make_unary_vse_clause.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(EXE_DIR)/make_unary_vse_clause.exe: $(make_unary_vse_clause_obj) 
-	@echo "linking executable files"
+	@echo "\nlinking executable $@"
 	$(LINK) -o $(EXE_DIR)/make_unary_vse_clause.exe $(make_unary_vse_clause_obj) $(LDFLAGS)
 
 $(O)/make_signed_claim_from_vse_clause.o: $(S)/make_signed_claim_from_vse_clause.cc $(INC_DIR)/certifier.pb.h $(INC_DIR)/certifier.h
-	@echo "compiling make_signed_claim_from_vse_clause.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/make_signed_claim_from_vse_clause.o $(S)/make_signed_claim_from_vse_clause.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(EXE_DIR)/make_signed_claim_from_vse_clause.exe: $(make_signed_claim_from_vse_clause_obj) 
-	@echo "linking executable files"
+	@echo "\nlinking executable $@"
 	$(LINK) -o $(EXE_DIR)/make_signed_claim_from_vse_clause.exe $(make_signed_claim_from_vse_clause_obj) $(LDFLAGS)
 
-# package_claims.exe print_packaged_claims.exe
-
 $(EXE_DIR)/print_vse_clause.exe: $(print_vse_clause_obj) 
-	@echo "linking executable files"
+	@echo "\nlinking executable $@"
 	$(LINK) -o $(EXE_DIR)/print_vse_clause.exe $(print_vse_clause_obj) $(LDFLAGS)
 
 $(O)/print_vse_clause.o: $(S)/print_vse_clause.cc $(INC_DIR)/certifier.pb.h $(INC_DIR)/certifier.h
-	@echo "compiling print_vse_clause.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/print_vse_clause.o $(S)/print_vse_clause.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(EXE_DIR)/print_signed_claim.exe: $(print_signed_claim_obj) 
-	@echo "linking executable files"
+	@echo "\nlinking executable $@"
 	$(LINK) -o $(EXE_DIR)/print_signed_claim.exe $(print_signed_claim_obj) $(LDFLAGS)
 
 $(O)/print_signed_claim.o: $(S)/print_signed_claim.cc $(INC_DIR)/certifier.pb.h $(INC_DIR)/certifier.h
-	@echo "compiling print_signed_claim.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/print_signed_claim.o $(S)/print_signed_claim.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(EXE_DIR)/package_claims.exe: $(package_claims_obj) 
-	@echo "linking executable files"
+	@echo "\nlinking executable $@"
 	$(LINK) -o $(EXE_DIR)/package_claims.exe $(package_claims_obj) $(LDFLAGS)
 
 $(O)/package_claims.o: $(S)/package_claims.cc $(INC_DIR)/certifier.pb.h $(INC_DIR)/certifier.h
-	@echo "compiling package_claims.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/package_claims.o $(S)/package_claims.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(EXE_DIR)/print_packaged_claims.exe: $(print_packaged_claims_obj) 
-	@echo "linking executable files"
+	@echo "\nlinking executable $@"
 	$(LINK) -o $(EXE_DIR)/print_packaged_claims.exe $(print_packaged_claims_obj) $(LDFLAGS)
 
 print_packaged_claims.o: $(S)/print_packaged_claims.cc $(INC_DIR)/certifier.pb.h $(INC_DIR)/certifier.h
-	@echo "compiling print_packaged_claims.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/print_packaged_claims.o $(S)/print_packaged_claims.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(EXE_DIR)/embed_policy_key.exe: $(embed_policy_key_obj)
-	@echo "linking executable files"
+	@echo "\nlinking executable $@"
 	$(LINK) -o $(EXE_DIR)/embed_policy_key.exe $(embed_policy_key_obj) $(LDFLAGS)
 
 $(O)/embed_policy_key.o: $(S)/embed_policy_key.cc $(INC_DIR)/certifier.pb.h $(INC_DIR)/certifier.h
-	@echo "compiling embed_policy_key.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/embed_policy_key.o $(S)/embed_policy_key.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(EXE_DIR)/make_platform.exe: $(make_platform_obj)
-	@echo "linking executable files"
+	@echo "\nlinking executable $@"
 	$(LINK) -o $(EXE_DIR)/make_platform.exe $(make_platform_obj) $(LDFLAGS)
 
 $(O)/make_platform.o: $(S)/make_platform.cc $(INC_DIR)/certifier.pb.h $(INC_DIR)/certifier.h
-	@echo "compiling make_platform.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/make_platform.o $(S)/make_platform.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(O)/make_property.o: $(S)/make_property.cc $(INC_DIR)/certifier.pb.h $(INC_DIR)/certifier.h
-	@echo "compiling make_property.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/make_property.o $(S)/make_property.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(EXE_DIR)/make_property.exe: $(make_property_obj)
-	@echo "linking executable files"
+	@echo "\nlinking executable $@"
 	$(LINK) -o $(EXE_DIR)/make_property.exe $(make_property_obj) $(LDFLAGS)
 
 $(O)/combine_properties.o: $(S)/combine_properties.cc $(INC_DIR)/certifier.pb.h $(INC_DIR)/certifier.h
-	@echo "compiling combine_properties.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/combine_properties.o $(S)/combine_properties.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(EXE_DIR)/combine_properties.exe: $(combine_properties_obj)
-	@echo "linking executable files"
+	@echo "\nlinking executable $@"
 	$(LINK) -o $(EXE_DIR)/combine_properties.exe $(combine_properties_obj) $(LDFLAGS)
 
 $(O)/make_environment.o: $(S)/make_environment.cc $(INC_DIR)/certifier.pb.h $(INC_DIR)/certifier.h
-	@echo "compiling make_environment.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/make_environment.o $(S)/make_environment.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(EXE_DIR)/make_environment.exe: $(make_environment_obj)
-	@echo "linking executable files"
+	@echo "\nlinking executable $@"
 	$(LINK) -o $(EXE_DIR)/make_environment.exe $(make_environment_obj) $(LDFLAGS)
 
 $(O)/simulated_sev_attest.o: $(S)/simulated_sev_attest.cc
-	@echo "compiling sev_simulated_attest.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/simulated_sev_attest.o $(S)/simulated_sev_attest.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(EXE_DIR)/simulated_sev_attest.exe: $(simulated_sev.obj)
-	@echo "linking executable files"
+	@echo "\nlinking executable $@"
 	$(LINK) -o $(EXE_DIR)/simulated_sev_attest.exe $(simulated_sev.obj) $(LDFLAGS)
 
 $(O)/sample_sev_key_generation.o: $(S)/sample_sev_key_generation.cc
-	@echo "compiling sample_sev_key_generation.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/sample_sev_key_generation.o $(S)/sample_sev_key_generation.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(EXE_DIR)/sample_sev_key_generation.exe: $(sample_sev_key_generation.obj)
-	@echo "linking executable files"
+	@echo "\nlinking executable $@"
 	$(LINK) -o $(EXE_DIR)/sample_sev_key_generation.exe $(sample_sev_key_generation.obj) $(LDFLAGS)
 
 $(O)/simulated_sev_key_generation.o: $(S)/simulated_sev_key_generation.cc
-	@echo "compiling simulated_sev_key_generation.cc"
-	$(CC) $(CFLAGS) -c -o $(O)/simulated_sev_key_generation.o $(S)/simulated_sev_key_generation.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 
 $(EXE_DIR)/simulated_sev_key_generation.exe: $(simulated_sev_key_generation.obj)
-	@echo "linking executable files"
+	@echo "\nlinking executable $@"
 	$(LINK) -o $(EXE_DIR)/simulated_sev_key_generation.exe $(simulated_sev_key_generation.obj) $(LDFLAGS)


### PR DESCRIPTION
This commit refactors existing Makefile-rules to replace hard-coded
file-names (e.g. "certifier_proofs.cc") to instead use Make-provided
automatic variables (such as `$@` and `$<`).

In a few places, use:
- `$(<D)` to name the directory of the 1st pre-requisite
- `$(@D)` to name the directory of the target.

With this change, much of the rules become more compact and follow
a pattern consistent with Make-suggested usage of variables.

Refactor few mak-files to define common_objs list; remove redundant definitions of CFLAGS and other unused symbols / make-rules.

-----

NOTE: To reviewer: This change-set is built on top of PR #148 so that I could use the `-j n` feature to speed up dev-cycles while editing and testing Makefile-diffs. Ignore the diffs from the 1st commit. I have marked-up imp diffs arising from this specific change that merit some review / attention.