### PR TITLE
(#147) Fix various Makefiles to support parallel make using -j threads.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,7 @@ jobs:
 
     - name: test-core-certifier-programs
       run: |
+        echo " "
         echo "******************************************************************"
         echo "* Check that core certifier programs still compile and clear tests"
         echo "******************************************************************"
@@ -37,16 +38,17 @@ jobs:
         make -f certifier.mak clean
         make -f certifier_tests.mak clean
 
-        make -f certifier.mak
+        make -j2 -f certifier.mak
         make -f certifier.mak clean
 
-        make -f certifier_tests.mak
+        make -j2 -f certifier_tests.mak
         ./certifier_tests.exe
 
         popd
 
     - name: unit-test-certlib-utility-programs
       run: |
+        echo " "
         echo "******************************************************************"
         echo "* Check core Certlib interfaces for utility programs"
         echo "******************************************************************"
@@ -54,8 +56,8 @@ jobs:
         pushd utilities
 
         # Build utilities
-        make -f cert_utility.mak
-        make -f policy_utilities.mak
+        make -j2 -f cert_utility.mak
+        make -j2 -f policy_utilities.mak
 
         popd
 
@@ -317,7 +319,7 @@ jobs:
         pushd src
 
         make -f certifier_tests.mak clean
-        ENABLE_SEV=1 make -f certifier_tests.mak
+        ENABLE_SEV=1 make -j2 -f certifier_tests.mak
         sudo ./certifier_tests.exe --print_all=true
 
         echo " "
@@ -327,7 +329,7 @@ jobs:
         echo " "
         make -f certifier.mak clean
         make -f certifier_tests.mak clean
-        ENABLE_SEV=1 make -f certifier.mak
+        ENABLE_SEV=1 make -j2 -f certifier.mak
 
         popd
 

--- a/application_service/app_service.mak
+++ b/application_service/app_service.mak
@@ -83,6 +83,7 @@ test_user.exe: $(user_dobj)
 	@echo "linking executable files"
 	$(LINK) -o $(EXE_DIR)/test_user.exe $(user_dobj) $(LDFLAGS)
 
+$(I)/certifier.pb.h: $(US)/certifier.pb.cc
 $(US)/certifier.pb.cc: $(CP)/certifier.proto
 	$(PROTO) --proto_path=$(CP) --cpp_out=$(US) $<
 	mv certifier.pb.h $(I)

--- a/certifier_service/isletlib/Makefile
+++ b/certifier_service/isletlib/Makefile
@@ -46,14 +46,15 @@ build: $(ISLET_VERIFY_LIB)
 
 $(ISLET_VERIFY_LIB): $(dobj)
 
-$(O)/certifier.pb.o: $(S)/certifier.pb.cc $(I)/certifier.pb.h
-	@echo " \nCompiling $<"
-	$(CC) -fPIC $(CFLAGS) -Wno-array-bounds -c $< -o $@
-
-$(S)/certifier.pb.cc $(I)/certifier.pb.h: $(CP)/certifier.proto
+$(I)/certifier.pb.h: $(S)/certifier.pb.cc
+$(S)/certifier.pb.cc: $(CP)/certifier.proto
 	@echo "\nGenerate protobuf files"
 	$(PROTO) --proto_path=$(CP) --cpp_out=$(S) $<
 	mv $(S)/certifier.pb.h $(I)
+
+$(O)/certifier.pb.o: $(S)/certifier.pb.cc $(I)/certifier.pb.h
+	@echo " \nCompiling $<"
+	$(CC) -fPIC $(CFLAGS) -Wno-array-bounds -c $< -o $@
 
 $(O)/islet_verify.o: $(S)/islet_verify.cc
 	@ echo " \nCompiling $<"

--- a/sample_apps/analytics_example/enclave/oe_certifier.mak
+++ b/sample_apps/analytics_example/enclave/oe_certifier.mak
@@ -49,7 +49,8 @@ oe_certifier.exe: $(dobj)
 	@echo "linking executable files"
 	$(LINK) -o $(EXE_DIR)/oe_certifier.exe $(dobj) $(LDFLAGS)
 
-certifier.pb.cc certifier.pb.h: $(S)/certifier.proto
+certifier.pb.h: certifier.pb.cc
+certifier.pb.cc: $(S)/certifier.proto
 	$(PROTO) -I$(S) --cpp_out=. $(S)/certifier.proto
 
 $(O)/oe_certifier.o: oe_certifier.cc certifier.pb.h $(S)/certifier.h

--- a/sample_apps/simple_app/example_app.mak
+++ b/sample_apps/simple_app/example_app.mak
@@ -69,11 +69,10 @@ example_key_rotation.exe: $(robj)
 	@echo "linking executable files"
 	$(LINK) -o $(EXE_DIR)/example_key_rotation.exe $(robj) $(LDFLAGS)
 
+$(I)/certifier.pb.h: $(US)/certifier.pb.cc
 $(US)/certifier.pb.cc: $(CP)/certifier.proto
 	$(PROTO) --proto_path=$(CP) --cpp_out=$(US) $<
 	mv $(US)/certifier.pb.h $(I)
-
-$(I)/certifier.pb.h: $(US)/certifier.pb.cc
 
 $(O)/certifier.pb.o: $(US)/certifier.pb.cc $(I)/certifier.pb.h
 	@echo "compiling certifier.pb.cc"

--- a/sample_apps/simple_app_under_islet/islet_example_app.mak
+++ b/sample_apps/simple_app_under_islet/islet_example_app.mak
@@ -76,11 +76,10 @@ islet_example_app.exe: $(dobj)
 	@echo "linking executable files"
 	$(LINK) -o $(EXE_DIR)/islet_example_app.exe $(dobj) $(LDFLAGS)
 
+$(I)/certifier.pb.h: $(US)/certifier.pb.cc
 $(US)/certifier.pb.cc: $(CP)/certifier.proto
 	$(PROTO) --proto_path=$(CP) --cpp_out=$(US) $<
 	mv $(US)/certifier.pb.h $(I)
-
-$(I)/certifier.pb.h: $(US)/certifier.pb.cc
 
 $(O)/certifier.pb.o: $(US)/certifier.pb.cc $(I)/certifier.pb.h
 	@echo "compiling certifier.pb.cc"

--- a/sample_apps/simple_app_under_keystone/keystone_example_app.mak
+++ b/sample_apps/simple_app_under_keystone/keystone_example_app.mak
@@ -64,11 +64,10 @@ keystone_example_app.exe: $(dobj)
 	@echo "linking executable files"
 	$(LINK) -o $(EXE_DIR)/keystone_example_app.exe $(dobj) $(LDFLAGS)
 
+$(I)/certifier.pb.h: $(US)/certifier.pb.cc
 $(US)/certifier.pb.cc: $(CP)/certifier.proto
 	$(PROTO) --proto_path=$(CP) --cpp_out=$(US) $<
 	mv $(US)/certifier.pb.h $(I)
-
-$(I)/certifier.pb.h: $(US)/certifier.pb.cc
 
 $(O)/certifier.pb.o: $(US)/certifier.pb.cc $(I)/certifier.pb.h
 	@echo "compiling certifier.pb.cc"

--- a/sample_apps/simple_app_under_sev/sev_example_app.mak
+++ b/sample_apps/simple_app_under_sev/sev_example_app.mak
@@ -64,6 +64,7 @@ sev_example_app.exe: $(dobj)
 	@echo "linking executable files"
 	$(LINK) -o $(EXE_DIR)/sev_example_app.exe $(dobj) $(LDFLAGS)
 
+$(I)/certifier.pb.h: $(US)/certifier.pb.cc
 $(US)/certifier.pb.cc: $(CP)/certifier.proto
 	$(PROTO) --proto_path=$(CP) --cpp_out=$(US) $<
 	mv certifier.pb.h $(I)

--- a/src/certifier.mak
+++ b/src/certifier.mak
@@ -82,7 +82,8 @@ $(CL)/certifier.a: $(dobj)
 	@echo "linking certifier library"
 	$(AR) rcs $(CL)/certifier.a $(dobj)
 
-$(S)/certifier.pb.cc $(I)/certifier.pb.h: $(CP)/certifier.proto
+$(I)/certifier.pb.h: $(S)/certifier.pb.cc
+$(S)/certifier.pb.cc: $(CP)/certifier.proto
 	$(PROTO) --cpp_out=$(S) --proto_path $(CP) $<
 	mv $(S)/certifier.pb.h $(I)
 

--- a/src/certifier_tests.mak
+++ b/src/certifier_tests.mak
@@ -106,7 +106,8 @@ certifier_tests.exe: $(dobj)
 	@echo "linking executable files"
 	$(LINK) -o $(EXE_DIR)/certifier_tests.exe $(dobj) $(LDFLAGS)
 
-$(S)/certifier.pb.cc $(I)/certifier.pb.h: $(CP)/certifier.proto
+$(I)/certifier.pb.h: $(S)/certifier.pb.cc
+$(S)/certifier.pb.cc: $(CP)/certifier.proto
 	$(PROTO) --cpp_out=$(S) --proto_path $(CP) $<
 	mv $(S)/certifier.pb.h $(I)
 

--- a/src/keystone/shim_test.mak
+++ b/src/keystone/shim_test.mak
@@ -70,7 +70,8 @@ clean:
 	@echo "removing executable files"
 	rm -rf $(CL)/keystone_test.exe
 
-$(S)/certifier.pb.cc $(I)/certifier.pb.h: $(CP)/certifier.proto
+$(I)/certifier.pb.h: $(S)/certifier.pb.cc
+$(S)/certifier.pb.cc: $(CP)/certifier.proto
 	$(PROTO) --proto_path=$(CP) --cpp_out=$(S) $<
 	mv $(S)/certifier.pb.h $(I)
 

--- a/utilities/cert_utility.mak
+++ b/utilities/cert_utility.mak
@@ -95,7 +95,8 @@ $(O)/key_utility.o: $(US)/key_utility.cc $(I)/support.h $(I)/certifier.pb.h
 	@echo "compiling key_utility.cc"
 	$(CC) $(CFLAGS) -c -o $(O)/key_utility.o $(US)/key_utility.cc
 
-$(US)/certifier.pb.cc $(I)/certifier.pb.h: $(CP)/certifier.proto
+$(I)/certifier.pb.h: $(US)/certifier.pb.cc
+$(US)/certifier.pb.cc: $(CP)/certifier.proto
 	$(PROTO) --cpp_out=$(US) --proto_path $(CP) $<
 	mv certifier.pb.h $(I)
 

--- a/utilities/policy_utilities.mak
+++ b/utilities/policy_utilities.mak
@@ -127,7 +127,8 @@ $(O)/key_utility.o: $(US)/key_utility.cc $(INC_DIR)/support.h $(INC_DIR)/certifi
 	$(CC) $(CFLAGS) -c -o $(O)/key_utility.o $(US)/key_utility.cc
 
 # Generate certifier.pb.cc in src/ dir, using proto file from certprotos/
-$(CERT_SRC)/certifier.pb.cc $(I)/certifier.pb.h: $(CP)/certifier.proto
+$(I)/certifier.pb.h: $(CERT_SRC)/certifier.pb.cc
+$(CERT_SRC)/certifier.pb.cc: $(CP)/certifier.proto
 	$(PROTO) --proto_path=$(CP) --cpp_out=$(CERT_SRC) $<
 	mv $(CERT_SRC)/certifier.pb.h $(I)
 


### PR DESCRIPTION
This commit cleans-up several Makefiles to now support use of parallel make with -j <threads> . The main bug was in the definition of the dependency between:

```
certifier.pb.h: certifier.pb.cc
certifier.pb.cc: certifier.proto
```
The former was missing in some mak-files or was mis-defined along with the latter. Both caused parallel make to often fail.

This commit fixes this for all (commonly-used) *.mak files.

Additionally, run_example.sh is enhanced to supply -j flag, for # of CPUs on the machine.

On CI-Build machines with 2 CPUs, the e2e run-time of all tests drops from ~29+ mins to about ~20 mins with this parallel make support.

---
NOTE: To the reviewer: In multiple CI-build test runs I saw e2e run-times ranging from 16 mins to ~22 mins with this fix. Without parallel make, run-times were in the order of 29 mins. So, this is quite an improvement.