### PR TITLE
Relocate Copyright notice to top-of-file in many .h/.cc files.

### DIFF
--- a/certifier_service/certprotos/certifier.proto
+++ b/certifier_service/certprotos/certifier.proto
@@ -1,5 +1,3 @@
-//  Certifier data structures
-
 //  Copyright (c) 2021-22, VMware Inc, and the Certifier Authors.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,6 +11,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+// -----------------------------------------------------------------------------
+//  Certifier Data Structures
+// -----------------------------------------------------------------------------
 
 syntax="proto2";
 option go_package = "github.com/jlmucb/crypto/v2/certifier_prototype/certifier_service/certprotos";

--- a/include/application_enclave.h
+++ b/include/application_enclave.h
@@ -1,3 +1,17 @@
+//  Copyright (c) 2021-22, VMware Inc, and the Certifier Authors.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <stdio.h>
 #include <stdint.h>
 #include <stdlib.h>
@@ -27,21 +41,6 @@ typedef unsigned char byte;
 #include "certifier.h" 
 
 using std::string;
-
-//  Copyright (c) 2021-22, VMware Inc, and the Certifier Authors.  All rights reserved.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 
 #ifndef _APPLICATION_ENCLAVE_H__
 #define _APPLICATION_ENCLAVE_H__

--- a/include/simulated_enclave.h
+++ b/include/simulated_enclave.h
@@ -1,3 +1,17 @@
+//  Copyright (c) 2021-22, VMware Inc, and the Certifier Authors.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <stdio.h>
 #include <stdint.h>
 #include <stdlib.h>
@@ -27,21 +41,6 @@ typedef unsigned char byte;
 #include "certifier.h" 
 
 using std::string;
-
-//  Copyright (c) 2021-22, VMware Inc, and the Certifier Authors.  All rights reserved.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 
 #ifndef _SIMULATED_ENCLAVE_H__
 #define _SIMULATED_ENCLAVE_H__

--- a/include/support.h
+++ b/include/support.h
@@ -1,3 +1,17 @@
+//  Copyright (c) 2021-22, VMware Inc, and the Certifier Authors.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <stdio.h>
 #include <stdint.h>
 #include <stdlib.h>
@@ -32,21 +46,6 @@ typedef unsigned char byte;
 #include "certifier_utilities.h"
 
 using std::string;
-
-//  Copyright (c) 2021-22, VMware Inc, and the Certifier Authors.  All rights reserved.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 
 #ifndef _SUPPORT_H__
 #define _SUPPORT_H__

--- a/src/application_enclave.cc
+++ b/src/application_enclave.cc
@@ -1,3 +1,17 @@
+//  Copyright (c) 2021-22, VMware Inc, and the Certifier Authors.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <openssl/ssl.h>
 #include <openssl/rsa.h>
 #include <openssl/x509.h>
@@ -13,20 +27,6 @@
 
 #include <string>
 using std::string;
-
-//  Copyright (c) 2021-22, VMware Inc, and the Certifier Authors.  All rights reserved.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 
 // #define DEBUG
 

--- a/src/certificate_tests.cc
+++ b/src/certificate_tests.cc
@@ -1,8 +1,3 @@
-#include "certifier.h"
-#include "support.h"
-
-using namespace certifier::utilities;
-
 //  Copyright (c) 2021-22, VMware Inc, and the Certifier Authors.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,6 +11,11 @@ using namespace certifier::utilities;
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+#include "certifier.h"
+#include "support.h"
+
+using namespace certifier::utilities;
 
 char hex_digit(byte v) {
   if (v >= 0 && v <= 9)

--- a/src/certifier_proofs.cc
+++ b/src/certifier_proofs.cc
@@ -1,17 +1,3 @@
-#include "support.h"
-#include "certifier.h"
-#include "simulated_enclave.h"
-#include "application_enclave.h"
-#include <sys/socket.h>
-#include <netdb.h>
-#ifdef SEV_SNP
-#include "attestation.h"
-#endif
-#ifdef GRAMINE_CERTIFIER
-#include "gramine_api.h"
-#endif
-
-
 //  Copyright (c) 2021-22, VMware Inc, and the Certifier Authors.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,6 +11,19 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+#include "support.h"
+#include "certifier.h"
+#include "simulated_enclave.h"
+#include "application_enclave.h"
+#include <sys/socket.h>
+#include <netdb.h>
+#ifdef SEV_SNP
+#include "attestation.h"
+#endif
+#ifdef GRAMINE_CERTIFIER
+#include "gramine_api.h"
+#endif
 
 using namespace certifier::framework;
 using namespace certifier::utilities;

--- a/src/certifier_tests.cc
+++ b/src/certifier_tests.cc
@@ -1,10 +1,3 @@
-#include <gtest/gtest.h>
-#include <gflags/gflags.h>
-
-#include "certifier.h"
-#include "support.h"
-#include "simulated_enclave.h"
-
 //  Copyright (c) 2021-22, VMware Inc, and the Certifier Authors.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,6 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <gtest/gtest.h>
+#include <gflags/gflags.h>
+
+#include "certifier.h"
+#include "support.h"
+#include "simulated_enclave.h"
 
 DEFINE_bool(print_all, false,  "verbose");
 DEFINE_string(trusted_measurements_file, "binary_trusted_measurements_file.bin",  "binary_trusted_measurements_file");

--- a/src/claims_tests.cc
+++ b/src/claims_tests.cc
@@ -1,9 +1,3 @@
-#include "certifier.h"
-#include "support.h"
-
-using namespace certifier::framework;
-using namespace certifier::utilities;
-
 //  Copyright (c) 2021-22, VMware Inc, and the Certifier Authors.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,6 +12,11 @@ using namespace certifier::utilities;
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "certifier.h"
+#include "support.h"
+
+using namespace certifier::framework;
+using namespace certifier::utilities;
 
 bool test_claims_1(bool print_all) {
   key_message k;

--- a/src/pipe_read_test.cc
+++ b/src/pipe_read_test.cc
@@ -1,12 +1,3 @@
-#include <gtest/gtest.h>
-#include <gflags/gflags.h>
-
-#include "certifier.h"
-#include "support.h"
-#include "simulated_enclave.h"
-
-using namespace certifier::utilities;
-
 //  Copyright (c) 2021-22, VMware Inc, and the Certifier Authors.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,6 +12,14 @@ using namespace certifier::utilities;
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <gtest/gtest.h>
+#include <gflags/gflags.h>
+
+#include "certifier.h"
+#include "support.h"
+#include "simulated_enclave.h"
+
+using namespace certifier::utilities;
 
 int main(int an, char** av) {
 

--- a/src/primitive_tests.cc
+++ b/src/primitive_tests.cc
@@ -1,11 +1,3 @@
-#include "certifier.h"
-#include "support.h"
-#include "simulated_enclave.h"
-#include "application_enclave.h"
-
-using namespace certifier::framework;
-using namespace certifier::utilities;
-
 //  Copyright (c) 2021-22, VMware Inc, and the Certifier Authors.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,6 +11,14 @@ using namespace certifier::utilities;
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+#include "certifier.h"
+#include "support.h"
+#include "simulated_enclave.h"
+#include "application_enclave.h"
+
+using namespace certifier::framework;
+using namespace certifier::utilities;
 
 
 bool test_seal(bool print_all) {

--- a/src/sev_tests.cc
+++ b/src/sev_tests.cc
@@ -1,6 +1,3 @@
-#include "certifier.h"
-#include "support.h"
-
 //  Copyright (c) 2021-22, VMware Inc, and the Certifier Authors.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +11,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+#include "certifier.h"
+#include "support.h"
 
 #ifdef SEV_SNP
 

--- a/src/simulated_enclave.cc
+++ b/src/simulated_enclave.cc
@@ -1,3 +1,17 @@
+//  Copyright (c) 2021-22, VMware Inc, and the Certifier Authors.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <openssl/ssl.h>
 #include <openssl/rsa.h>
 #include <openssl/x509.h>
@@ -15,21 +29,6 @@
 using std::string;
 using namespace certifier::framework;
 using namespace certifier::utilities;
-
-//  Copyright (c) 2021-22, VMware Inc, and the Certifier Authors.  All rights reserved.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 
 // simulated enclave data
 bool my_data_initialized = false;

--- a/src/store_tests.cc
+++ b/src/store_tests.cc
@@ -1,9 +1,3 @@
-#include "certifier.h"
-#include "support.h"
-
-using namespace certifier::framework;
-using namespace certifier::utilities;
-
 //  Copyright (c) 2021-22, VMware Inc, and the Certifier Authors.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,6 +11,12 @@ using namespace certifier::utilities;
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+#include "certifier.h"
+#include "support.h"
+
+using namespace certifier::framework;
+using namespace certifier::utilities;
 
 bool test_protect(bool print_all) {
 

--- a/src/support_tests.cc
+++ b/src/support_tests.cc
@@ -1,8 +1,3 @@
-#include "certifier.h"
-#include "support.h"
-
-using namespace certifier::utilities;
-
 //  Copyright (c) 2021-22, VMware Inc, and the Certifier Authors.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,6 +11,11 @@ using namespace certifier::utilities;
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+#include "certifier.h"
+#include "support.h"
+
+using namespace certifier::utilities;
 
 bool test_random(bool print_all) {
   int n = 128;

--- a/src/test_channel.cc
+++ b/src/test_channel.cc
@@ -1,3 +1,17 @@
+//  Copyright (c) 2021-22, VMware Inc, and the Certifier Authors.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <gtest/gtest.h>
 #include <gflags/gflags.h>
 
@@ -20,21 +34,6 @@
 
 using namespace certifier::framework;
 using namespace certifier::utilities;
-
-//  Copyright (c) 2021-22, VMware Inc, and the Certifier Authors.  All rights reserved.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 
 // operations are: client, server
 DEFINE_bool(print_all, false,  "verbose");

--- a/src/test_support.cc
+++ b/src/test_support.cc
@@ -1,12 +1,3 @@
-#include "certifier.h"
-#include "support.h"
-#ifdef SEV_SNP
-#include "sev-snp/attestation.h"
-#endif
-
-using namespace certifier::framework;
-using namespace certifier::utilities;
-
 //  Copyright (c) 2021-22, VMware Inc, and the Certifier Authors.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,6 +11,15 @@ using namespace certifier::utilities;
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+#include "certifier.h"
+#include "support.h"
+#ifdef SEV_SNP
+#include "sev-snp/attestation.h"
+#endif
+
+using namespace certifier::framework;
+using namespace certifier::utilities;
 
 bool debug_print = false;
 

--- a/src/x509_tests.cc
+++ b/src/x509_tests.cc
@@ -1,11 +1,3 @@
-#include "certifier.h"
-#include "support.h"
-#include "simulated_enclave.h"
-#include "application_enclave.h"
-
-using namespace certifier::framework;
-using namespace certifier::utilities;
-
 //  Copyright (c) 2021-22, VMware Inc, and the Certifier Authors.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,6 +12,13 @@ using namespace certifier::utilities;
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "certifier.h"
+#include "support.h"
+#include "simulated_enclave.h"
+#include "application_enclave.h"
+
+using namespace certifier::framework;
+using namespace certifier::utilities;
 
 bool test_x_509_chain(bool print_all) {
 


### PR DESCRIPTION
This commit fixes many `.h` and `.cc` files to relocate the Copyright notice to the top-of-the file. 
No further code / logic changes are included.