### PR TITLE
Add AMD SEV-SNP VCEK extensions parsing and checks.

### DIFF
--- a/certifier_service/certprotos/certifier.proto
+++ b/certifier_service/certprotos/certifier.proto
@@ -73,6 +73,9 @@ message key_message {
   optional bytes other_key_formats          = 8;
   optional string not_before                = 9;
   optional string not_after                 = 10;
+  // Optional SEV-SNP VCEK specific fields
+  optional uint64 snp_tcb_version           = 11;
+  optional bytes snp_chipid                 = 12;
 };
 
 message protected_blob_message {


### PR DESCRIPTION
This patch added AMD SEV-SNP VCEK certificate custom extension parsing support. The platform TCB version is now checked as part of the SEV-SNP attestation report verification in addition to signature verification.