### PR TITLE
Add custom extensions to simulator VCEK certificate.

### DIFF
--- a/certifier_service/certlib/certlib_proofs.go
+++ b/certifier_service/certlib/certlib_proofs.go
@@ -1687,27 +1687,23 @@ func VerifySevAttestation(serialized []byte, k *certprotos.KeyMessage) []byte {
 	}
 
 	vcekTcbVer := k.GetSnpTcbVersion()
-	// TODO: Test whether the VCEK TCB Version is valid for now.
-	// This will be removed in the future after the simulator change.
-	if vcekTcbVer != ^uint64(0) {
-		tcbVer := GetTcbVersionFromSevAttest(ptr)
-		if vcekTcbVer != tcbVer {
-			fmt.Printf("VerifySevAttestation: Platform TCB Version check failed\n")
-			fmt.Printf("VCEK TCB Version: %08x\n", vcekTcbVer)
-			fmt.Printf("Platform TCB Version: %08x\n", tcbVer)
-			return nil
-		}
-		chipid := ptr[0x1A0:0x1E0]
-		if !bytes.Equal(chipid, k.GetSnpChipid()) {
-			fmt.Printf("VerifySevAttestation: Chipid check failed\n")
-			fmt.Printf("VCEK HwID: ")
-			PrintBytes(k.GetSnpChipid())
-			fmt.Printf("\n")
-			fmt.Printf("Platform Chip ID: ")
-			PrintBytes(chipid)
-			fmt.Printf("\n")
-			return nil
-		}
+	tcbVer := GetTcbVersionFromSevAttest(ptr)
+	if vcekTcbVer != tcbVer {
+		fmt.Printf("VerifySevAttestation: Platform TCB Version check failed\n")
+		fmt.Printf("VCEK TCB Version: %08x\n", vcekTcbVer)
+		fmt.Printf("Platform TCB Version: %08x\n", tcbVer)
+		return nil
+	}
+	chipid := ptr[0x1A0:0x1E0]
+	if !bytes.Equal(chipid, k.GetSnpChipid()) {
+		fmt.Printf("VerifySevAttestation: Chipid check failed\n")
+		fmt.Printf("VCEK HwID: ")
+		PrintBytes(k.GetSnpChipid())
+		fmt.Printf("\n")
+		fmt.Printf("Platform Chip ID: ")
+		PrintBytes(chipid)
+		fmt.Printf("\n")
+		return nil
 	}
 
 	// return measurement, if successful

--- a/include/certifier_utilities.h
+++ b/include/certifier_utilities.h
@@ -79,7 +79,7 @@ namespace certifier {
     bool produce_artifact(key_message& signing_key, string& issuer_name_str,
           string& issuer_description_str, key_message& subject_key,
           string& subject_name_str, string& subject_description_str,
-          uint64_t sn, double secs_duration, X509* x509, bool is_root);
+          uint64_t sn, double secs_duration, X509* x509, bool is_root, bool vcek = false);
     bool verify_artifact(X509& cert, key_message& verify_key,
         string* issuer_name_str, string* issuer_description_str,
         key_message* subject_key, string* subject_name_str, string* subject_description_str,

--- a/src/sev-snp/sev_vcek_ext.h
+++ b/src/sev-snp/sev_vcek_ext.h
@@ -1,0 +1,36 @@
+//  Copyright (c) 2023, VMware Inc, and the Certifier Authors.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef _SEV_VCEK_EXT_H_
+#define _SEV_VCEK_EXT_H_
+
+/*
+ * OIDs for the custom extensions AMD embedded into the VCEK certificate
+ * retrieved from the AMD KDS. Refer to Table 8, Versioned Chip Endorsement
+ * Key (VCEK) Certificate and KDS Interface Specification, revision 0.51,
+ * Jan 2023, for details.
+ */
+#define VCEK_EXT_STRUCT_VERSION  "1.3.6.1.4.1.3704.1.1"
+#define VCEK_EXT_PRODUCT_NAME    "1.3.6.1.4.1.3704.1.2"
+#define VCEK_EXT_BLSPL           "1.3.6.1.4.1.3704.1.3.1"
+#define VCEK_EXT_TEESPL          "1.3.6.1.4.1.3704.1.3.2"
+#define VCEK_EXT_SNPSPL          "1.3.6.1.4.1.3704.1.3.3"
+#define VCEK_EXT_SPL4            "1.3.6.1.4.1.3704.1.3.4"
+#define VCEK_EXT_SPL5            "1.3.6.1.4.1.3704.1.3.5"
+#define VCEK_EXT_SPL6            "1.3.6.1.4.1.3704.1.3.6"
+#define VCEK_EXT_SPL7            "1.3.6.1.4.1.3704.1.3.7"
+#define VCEK_EXT_UCODESPL        "1.3.6.1.4.1.3704.1.3.8"
+#define VCEK_EXT_HWID            "1.3.6.1.4.1.3704.1.4"
+
+#endif  /* _SEV_VCEK_EXT_H_ */

--- a/utilities/simulated_sev_key_generation.cc
+++ b/utilities/simulated_sev_key_generation.cc
@@ -179,7 +179,7 @@ int main(int an, char** av) {
 
   X509* vcek_509 = X509_new();
   if (!produce_artifact(ask_vse_key, ask_name, ask_desc_str, pub_vcek_vse_key,
-          vcek_name, vcek_desc_str, 1ULL, 86400 * 365.25, vcek_509, false)) {
+          vcek_name, vcek_desc_str, 1ULL, 86400 * 365.25, vcek_509, false, true)) {
     printf("Generate ark cert failed\n");
     return 1;
   }


### PR DESCRIPTION
Added custom extensions with fixed values to the simulator VCEK certificates we generate. The VCEK certificate extension verification check is also removed so we always check for the extensions during report verification.