### PR TITLE
(#170) Refactor cc_trust_data() constructor to fix bug.

### DIFF
--- a/include/certifier_framework.h
+++ b/include/certifier_framework.h
@@ -125,6 +125,9 @@ public:
 
     class cc_trust_data {
 
+    private:
+      void cc_trust_data_default_init();
+
     public:
       // Python swig bindings need this to be public, to size other array decls
       static const int max_symmetric_key_size_ = 128;

--- a/src/cc_helpers.cc
+++ b/src/cc_helpers.cc
@@ -117,6 +117,15 @@ void certifier::framework::cc_trust_data::cc_trust_data_default_init() {
 }
 
 certifier::framework::cc_trust_data::~cc_trust_data() {
+  for (int i = 0; i < num_certified_domains_; i++) {
+      if (certified_domains_[i] != nullptr) {
+        delete certified_domains_[i];
+        certified_domains_[i] = nullptr;
+      }
+  }
+  delete certified_domains_;
+  certified_domains_ = nullptr;
+  num_certified_domains_ = 0;
 }
 
 bool certifier::framework::cc_trust_data::cc_all_initialized() {
@@ -1247,7 +1256,7 @@ bool certifier::framework::cc_trust_data::certify_secondary_domain(const string&
     }
   }
 
-  return found->certify_domain();
+  return (found ? found->certify_domain() : false);
 }
 
 bool certifier::framework::cc_trust_data::init_peer_certification_data(const string& public_key_alg) {

--- a/src/cc_helpers.cc
+++ b/src/cc_helpers.cc
@@ -82,16 +82,22 @@ extern string gramine_platform_cert;
 
 certifier::framework::cc_trust_data::cc_trust_data(const string& enclave_type, const string& purpose,
     const string& policy_store_name) {
-
+  cc_trust_data_default_init();
   if (purpose == "authentication" || purpose == "attestation") {
     purpose_= purpose;
     cc_basic_data_initialized_ = true;
-  } else {
-    cc_basic_data_initialized_ = false;
-    purpose_ = "unknown";
   }
   enclave_type_ = enclave_type;
   store_file_name_ = policy_store_name;
+}
+
+certifier::framework::cc_trust_data::cc_trust_data() {
+  cc_trust_data_default_init();
+}
+
+void certifier::framework::cc_trust_data::cc_trust_data_default_init() {
+  cc_basic_data_initialized_ = false;
+  purpose_ = "unknown";
   cc_policy_info_initialized_= false;
   cc_policy_store_initialized_ = false;
   cc_service_key_initialized_ = false;
@@ -108,29 +114,6 @@ certifier::framework::cc_trust_data::cc_trust_data(const string& enclave_type, c
   for (int i = 0; i < max_num_certified_domains_; i++) {
       certified_domains_[i] = nullptr;
   }
-}
-
-certifier::framework::cc_trust_data::cc_trust_data() {
-  cc_basic_data_initialized_ = false;
-  cc_policy_info_initialized_= false;
-  cc_policy_store_initialized_ = false;
-  cc_service_key_initialized_ = false;
-  cc_service_cert_initialized_ = false;
-  cc_service_platform_rule_initialized_ = false;
-  cc_sealing_key_initialized_ = false;
-  cc_provider_provisioned_ = false;
-  x509_policy_cert_ = nullptr;
-  cc_is_certified_ = false;
-
-  for (int i = 0; i < num_certified_domains_; i++) {
-      if (certified_domains_[i] != nullptr) {
-        delete certified_domains_[i];
-        certified_domains_[i] = nullptr;
-      }
-  }
-  delete certified_domains_;
-  certified_domains_ = nullptr;
-  num_certified_domains_ = 0;
 }
 
 certifier::framework::cc_trust_data::~cc_trust_data() {

--- a/tests/pytests/test_cert_framework_basic.py
+++ b/tests/pytests/test_cert_framework_basic.py
@@ -54,6 +54,29 @@ def test_getmembers_of_cc_framework():
         print(' -', item[0], item[1])
 
 # ##############################################################################
+def test_cf_cc_trust_data_default_ctor():
+    """
+    Basic exerciser for an empty cc_trust_data() object.
+    """
+    cctd = libcf.new_cc_trust_data()
+    result = libcf.cc_trust_data_cc_all_initialized(cctd)
+    assert result is False
+
+    libcf.delete_cc_trust_data(cctd)
+
+# ##############################################################################
+def test_cf_cc_trust_data():
+    """
+    Instantiate a cc_trust_data() object with some arguments.
+    """
+    cctd = libcf.new_cc_trust_data('simulated-enclave', 'authentication', 'policy_store')
+
+    result = libcf.cc_trust_data_cc_all_initialized(cctd)
+    assert result is False
+
+    libcf.delete_cc_trust_data(cctd)
+
+# ##############################################################################
 def test_cf_policy_store_basic():
     """
     This test case shows ways to exercise basic interfaces in Py-bindings.

--- a/tests/pytests/test_cert_framework_basic.py
+++ b/tests/pytests/test_cert_framework_basic.py
@@ -77,6 +77,45 @@ def test_cf_cc_trust_data():
     libcf.delete_cc_trust_data(cctd)
 
 # ##############################################################################
+def test_cf_cc_trust_data_add_or_update_new_domain():
+    """
+    Exercise add_or_update_new_domain(), which will create a new certified_domain()
+    object. Dismantiling this cc_trust_data() will test the destructor of that
+    object which should correctly release memory for new certified-domains.
+    """
+    cctd = libcf.new_cc_trust_data()
+
+    result = libcf.cc_trust_data_add_or_update_new_domain(cctd,
+                                                          'test-security-domain',
+                                                          'test-dummy-certificate',
+                                                          'localhost', 8121,
+                                                          'localhost', 8123)
+    assert result is True
+
+    libcf.delete_cc_trust_data(cctd)
+
+# ##############################################################################
+def test_cf_cc_trust_data_certify_secondary_domain_not_found():
+    """
+    Exercise certify_secondary_domain(). (Verifies fix to handle a secondary
+    domain that is not found; leading to null domain ptr.)
+    """
+    cctd = libcf.new_cc_trust_data()
+
+    result = libcf.cc_trust_data_add_or_update_new_domain(cctd,
+                                                          'test-security-domain',
+                                                          'test-dummy-certificate',
+                                                          'localhost', 8121,
+                                                          'localhost', 8123)
+    assert result is True
+
+    result = libcf.cc_trust_data_certify_secondary_domain(cctd,
+                                                          'non-existent-secondary-domain')
+    assert result is False
+
+    libcf.delete_cc_trust_data(cctd)
+
+# ##############################################################################
 def test_cf_policy_store_basic():
     """
     This test case shows ways to exercise basic interfaces in Py-bindings.


### PR DESCRIPTION
Default constructor for cc_trust_data() ran into seg-faults due to use of uninitialized variables. Refactor the constructor to add  a common private `cc_trust_data_default_init()` method, shared by both constructors. 

Add Python tests which trigger this bug and test the fix.

Good catch!

The only concern I have is that the destructor does not delete the certifiers structures that were newed when adding.

You are correct that the code that does that, below, should be in the destructor (Man, that was a wierd mistake).

  for (int i = 0; i < num_certified_domains_; i++) {
      if (certified_domains_[i] != nullptr) {
        delete certified_domains_[i];
        certified_domains_[i] = nullptr;
      }
  }
  delete certified_domains_;
  certified_domains_ = nullptr;
  num_certified_domains_ = 0;


