### PR TITLE
(#166) Replace hard-coded strings with const strings, defined once and used everywhere.

### DIFF
--- a/CI/scripts/algorithm_names_map.dat
+++ b/CI/scripts/algorithm_names_map.dat
@@ -1,0 +1,52 @@
+# #############################################################################
+# Certifier Framework Encryption algorigthm names mapping
+# Specify the way hard-coded strings will be remapped based on some
+# organization.
+# #############################################################################
+#
+# Enc_method:Encryption algorithms supported.
+#
+Enc_method:"aes-128"
+Enc_method:"aes-128-cbc-hmac-sha256"
+Enc_method:"aes-256"
+Enc_method:"aes-256-cbc"
+Enc_method:"aes-256-cbc-hmac-sha256"
+Enc_method:"aes-256-cbc-hmac-sha384"
+Enc_method:"aes-256-gcm"
+Enc_method:"ecc-256-private"
+Enc_method:"ecc-256-public"
+Enc_method:"ecc-256-sha256-pkcs-sign"
+Enc_method:"ecc-384"
+Enc_method:"ecc-384-private"
+Enc_method:"ecc-384-public"
+Enc_method:"ecc-384-sha384-pkcs-sign"
+Enc_method:"rsa-1024"
+Enc_method:"rsa-1024-private"
+Enc_method:"rsa-1024-public"
+Enc_method:"rsa-1024-sha256-pkcs-sign"
+Enc_method:"rsa-2048"
+Enc_method:"rsa-2048-private"
+Enc_method:"rsa-2048-public"
+Enc_method:"rsa-2048-sha256-pkcs-sign"
+Enc_method:"rsa-3072"
+Enc_method:"rsa-3072-private"
+Enc_method:"rsa-3072-public"
+Enc_method:"rsa-3072-sha384-pkcs-sign"
+Enc_method:"rsa-4096"
+Enc_method:"rsa-4096-private"
+Enc_method:"rsa-4096-public"
+Enc_method:"rsa-4096-sha384-pkcs-sign"
+#
+# Digest_method:Cryptographic hash algorithms supported.
+#
+Digest_method:"sha256"
+Digest_method:"sha-256"
+Digest_method:"sha-384"
+Digest_method:"sha-512"
+#
+# Integrity_method:Integrity protection algorithms, used in conjunction with specific encryption algorithms.
+#
+Integrity_method:"aes-256-cbc-hmac-sha256"
+Integrity_method:"aes-256-cbc-hmac-sha384"
+Integrity_method:"aes-256-gcm"
+Integrity_method:"hmac-sha256"

--- a/CI/scripts/replace_algname.sh
+++ b/CI/scripts/replace_algname.sh
@@ -1,0 +1,190 @@
+#!/bin/bash
+# #############################################################################
+# Simple script to take a list of input tokens and replace the algorithm name
+# with a specified new-name. This script receives a mapping data-file which
+# specifies the prefix of the new name.
+#
+# Example:
+#   "aes-128"   -> Enc_method_aes_128
+#   "sha256"    -> Digest_method_sha256
+#
+# This replacement rule is specified by a line as follows in the map file:
+#
+# Enc_method:"aes-128"
+# Digest_method:"sha-256"
+#
+# This script will drive the text substitution.
+# #############################################################################
+set -Eeuo pipefail
+
+# Setup script globals, to establish curdir and root path to Certifier code base
+Me=$(basename "$0")
+
+# Expect to run this script from Certifier source root dir
+# shellcheck disable=SC2046
+CERT_SRC_ROOT="$(pwd)"; export CERT_SRC_ROOT
+
+# Base name of generated file(s)
+CERT_GEN_FILE_BASE="certifier_algorithms"
+CERT_HDR_GUARD="CERTIFIER_ALGORITHMS"
+
+# ##################################################################
+# Print help / usage
+# ##################################################################
+function usage_help() {
+    echo "Usage: $Me [-h | --help] <algorithm-map-file-name>"
+}
+
+# ##################################################################
+function gen_copyright() {
+echo "//  Copyright (c) 2021-22, VMware Inc, and the Certifier Authors.  All rights
+//  reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+"
+}
+
+# ##################################################################
+function gen_definitions() {
+    ftype="$1"  # 'dotc' or 'doth'
+    tag="$2"
+    map_file="$3"
+    namelen="$4"
+
+    # Grab title line for this category of algorithm names from map file
+    cat_title=$(grep -E "^# ${tag}" ${map_file} | cut -f2 -d':')
+
+    echo "/*"
+    echo " * ${cat_title}"
+    echo " */"
+
+    fmtext=""
+    if [ "${ftype}" = "doth" ]; then fmtext="extern "; fi
+
+    for map in $(cat ${map_file} | grep -E "^${tag}" | grep -v -E "#"); do
+
+        orig=$(echo "${map}" | cut -f2 -d':')
+        from=$(echo "${orig}" | cut -f2 -d':' | sed 's/-/_/g' | sed 's/"//g' )
+        category=$(echo ${map} | cut -f1 -d':')
+        to="${category}_${from}"
+
+        # Construct .h / .c file entries, as in:
+        # .h -> extern const char *Enc_method_aes_128;
+        # .c -> const char * Enc_method_aes_128                   = "aes-128";
+        fmtstr="${fmtext}const char *"
+        if [ "${ftype}" = "dotc" ]; then
+            fmtstr="${fmtstr} %-${namelen}s = ${orig}"
+        else
+            fmtstr="${fmtstr}%s"
+        fi
+        fmtstr="${fmtstr};\n"
+
+        # echo "$fmtstr"
+        echo "${to}" | awk -va_fmt="${fmtstr}" '{printf a_fmt, $1}'
+    done
+    echo " "
+}
+
+# ##################################################################
+# main() begins here
+# ##################################################################
+
+# Simple command-line arg processing. Expect mapping file-name
+if [ $# -eq 0 ] || [ "$1" == "--help" ] || [ "$1" == "-h" ]; then
+    usage_help
+    exit 1
+fi
+
+map_file="$1"
+
+# Can supply file(s) to process on command-line. Otherwise, script will
+# plough thru source dirs, looking for files where source string appears.
+shift
+
+# ###########################################################################
+# Iterate thru each "<prefix>:<string>" pairs, and apply to source files
+# ###########################################################################
+Max_enc_method_nlen=0
+Max_digest_nlen=0
+Max_mac_nlen=0
+
+if [ $# -gt 0 ]; then
+    # shellcheck disable=SC2086,SC2048
+    list_of_files=$*
+else
+    list_of_files=$(find "${CERT_SRC_ROOT}" -name "*.cc" -print)
+fi
+
+for map in $(cat ${map_file} | grep -v -E "#"); do
+
+    orig=$(echo "${map}" | cut -f2 -d':')
+    from=$(echo "${orig}" | cut -f2 -d':' | sed 's/-/_/g' | sed 's/"//g' )
+    category=$(echo ${map} | cut -f1 -d':')
+    to="${category}_${from}"
+    # echo "${map} : ${orig} -> ${to}"
+
+    # Establish max name-lengths of generated string
+    len_to=${#to}
+    if [ "${category}" = "Enc_method" ]; then
+        if [ ${len_to} -gt ${Max_enc_method_nlen} ]; then
+            Max_enc_method_nlen=${len_to}
+        fi
+    elif [ "${category}" = "Digest_method" ]; then
+        if [ ${len_to} -gt ${Max_digest_nlen} ]; then
+            Max_digest_nlen=${len_to}
+        fi
+    elif [ "${category}" = "Integrity_method" ]; then
+        if [ ${len_to} -gt ${Max_mac_nlen} ]; then
+            Max_mac_nlen=${len_to}
+        fi
+    fi
+
+    perl -i -p -e "s/${orig}/${to}/" ${list_of_files}
+done
+
+# echo "Enc_method=${Max_enc_method_nlen}, Digest_method=${Max_digest_nlen}, Integrity_method=${Max_mac_nlen}"
+
+
+# ###########################################################################
+# Generate the corresponding .h / .c-files listing the algorigthm names.
+# ###########################################################################
+dotc_file="${CERT_SRC_ROOT}/src/${CERT_GEN_FILE_BASE}.cc"
+
+gen_copyright > "${dotc_file}"
+
+echo "
+// clang-format off
+" >> "${dotc_file}"
+
+gen_definitions "dotc" "Enc_method" "${map_file}" ${Max_enc_method_nlen} >> "${dotc_file}"
+gen_definitions "dotc" "Digest_method" "${map_file}" ${Max_digest_nlen} >> "${dotc_file}"
+gen_definitions "dotc" "Integrity_method" "${map_file}" ${Max_mac_nlen} >> "${dotc_file}"
+
+echo "// clang-format on
+" >> "${dotc_file}"
+
+doth_file="${CERT_SRC_ROOT}/include/${CERT_GEN_FILE_BASE}.h"
+
+gen_copyright > "${doth_file}"
+
+echo "
+#ifndef __${CERT_HDR_GUARD}_H__
+#define __${CERT_HDR_GUARD}_H__
+" >> "${doth_file}"
+
+gen_definitions "doth" "Enc_method" "${map_file}" ${Max_enc_method_nlen} >> "${doth_file}"
+gen_definitions "doth" "Digest_method" "${map_file}" ${Max_digest_nlen} >> "${doth_file}"
+gen_definitions "doth" "Integrity_method" "${map_file}" ${Max_mac_nlen} >> "${doth_file}"
+
+echo "#endif // __${CERT_HDR_GUARD}_H__" >> "${doth_file}"
+

--- a/application_service/app_service.cc
+++ b/application_service/app_service.cc
@@ -181,7 +181,11 @@ bool measure_binary(const string &file, string *m) {
   }
   byte         digest[32];
   unsigned int len = 32;
-  if (!digest_message("sha256", file_contents, bytes_read, digest, len)) {
+  if (!digest_message(Digest_method_sha256,
+                      file_contents,
+                      bytes_read,
+                      digest,
+                      len)) {
     printf("%s() error, line %d, Digest failed\n", __func__, __LINE__);
     free(file_contents);
     return false;
@@ -194,7 +198,11 @@ bool measure_binary(const string &file, string *m) {
 bool measure_in_mem_binary(byte *file_contents, int size, string *m) {
   byte         digest[32];
   unsigned int len = 32;
-  if (!digest_message("sha256", file_contents, (unsigned)size, digest, len)) {
+  if (!digest_message(Digest_method_sha256,
+                      file_contents,
+                      (unsigned)size,
+                      digest,
+                      len)) {
     printf("%s() error, line %d, Digest failed\n", __func__, __LINE__);
     return false;
   }
@@ -333,14 +341,15 @@ bool soft_Attest(spawned_children *kid, string in, string *out) {
   const string type("vse-attestation-report");
   string       signing_alg;
 
-  if (app_trust_data->private_service_key_.key_type() == "rsa-2048-private") {
-    signing_alg.assign("rsa-2048-sha256-pkcs-sign");
+  if (app_trust_data->private_service_key_.key_type()
+      == Enc_method_rsa_2048_private) {
+    signing_alg.assign(Enc_method_rsa_2048_sha256_pkcs_sign);
   } else if (app_trust_data->private_service_key_.key_type()
-             == "rsa-4096-private") {
-    signing_alg.assign("rsa-4096-sha384-pkcs-sign");
+             == Enc_method_rsa_4096_private) {
+    signing_alg.assign(Enc_method_rsa_4096_sha384_pkcs_sign);
   } else if (app_trust_data->private_service_key_.key_type()
-             == "ecc-384-private") {
-    signing_alg.assign("ecc-384-sha384-pkcs-sign");
+             == Enc_method_ecc_384_private) {
+    signing_alg.assign(Enc_method_ecc_384_sha384_pkcs_sign);
   } else {
     return false;
   }
@@ -766,8 +775,8 @@ done:
 
 
 // Standard algorithms for the enclave
-string public_key_alg("rsa-2048");
-string symmetric_key_alg("aes-256-cbc-hmac-sha256");
+string public_key_alg(Enc_method_rsa_2048);
+string symmetric_key_alg(Enc_method_aes_256_cbc_hmac_sha256);
 
 int main(int an, char **av) {
   string usage("Application Service utility");

--- a/deprecated/simple_app_under_asylo_secure_grpc/asylo_trusted.cc
+++ b/deprecated/simple_app_under_asylo_secure_grpc/asylo_trusted.cc
@@ -253,10 +253,10 @@ bool certifier_init(char *usr_data_dir, size_t usr_data_dir_size) {
 
 bool cold_init() {
   // Standard algorithms for the enclave
-  string public_key_alg("rsa-2048");
-  string symmetric_key_alg("aes-256");
+  string public_key_alg(Enc_method_rsa_2048);
+  string symmetric_key_alg(Enc_method_aes_256);
   ;
-  string hash_alg("sha-256");
+  string hash_alg(Digest_method_sha_256);
   string hmac_alg("sha-256-hmac");
 
   if (!app_trust_data->cold_init(public_key_alg,

--- a/include/certifier_algorithms.h
+++ b/include/certifier_algorithms.h
@@ -1,0 +1,71 @@
+//  Copyright (c) 2021-22, VMware Inc, and the Certifier Authors.  All rights
+//  reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+#ifndef __CERTIFIER_ALGORITHMS_H__
+#define __CERTIFIER_ALGORITHMS_H__
+
+/*
+ * Encryption algorithms supported.
+ */
+extern const char *Enc_method_aes_128;
+extern const char *Enc_method_aes_128_cbc_hmac_sha256;
+extern const char *Enc_method_aes_256;
+extern const char *Enc_method_aes_256_cbc;
+extern const char *Enc_method_aes_256_cbc_hmac_sha256;
+extern const char *Enc_method_aes_256_cbc_hmac_sha384;
+extern const char *Enc_method_aes_256_gcm;
+extern const char *Enc_method_ecc_256_private;
+extern const char *Enc_method_ecc_256_public;
+extern const char *Enc_method_ecc_256_sha256_pkcs_sign;
+extern const char *Enc_method_ecc_384;
+extern const char *Enc_method_ecc_384_private;
+extern const char *Enc_method_ecc_384_public;
+extern const char *Enc_method_ecc_384_sha384_pkcs_sign;
+extern const char *Enc_method_rsa_1024;
+extern const char *Enc_method_rsa_1024_private;
+extern const char *Enc_method_rsa_1024_public;
+extern const char *Enc_method_rsa_1024_sha256_pkcs_sign;
+extern const char *Enc_method_rsa_2048;
+extern const char *Enc_method_rsa_2048_private;
+extern const char *Enc_method_rsa_2048_public;
+extern const char *Enc_method_rsa_2048_sha256_pkcs_sign;
+extern const char *Enc_method_rsa_3072;
+extern const char *Enc_method_rsa_3072_private;
+extern const char *Enc_method_rsa_3072_public;
+extern const char *Enc_method_rsa_3072_sha384_pkcs_sign;
+extern const char *Enc_method_rsa_4096;
+extern const char *Enc_method_rsa_4096_private;
+extern const char *Enc_method_rsa_4096_public;
+extern const char *Enc_method_rsa_4096_sha384_pkcs_sign;
+
+/*
+ * Cryptographic hash algorithms supported.
+ */
+extern const char *Digest_method_sha256;
+extern const char *Digest_method_sha_256;
+extern const char *Digest_method_sha_384;
+extern const char *Digest_method_sha_512;
+
+/*
+ * Integrity protection algorithms, used in conjunction with specific encryption
+ * algorithms.
+ */
+extern const char *Integrity_method_aes_256_cbc_hmac_sha256;
+extern const char *Integrity_method_aes_256_cbc_hmac_sha384;
+extern const char *Integrity_method_aes_256_gcm;
+extern const char *Integrity_method_hmac_sha256;
+
+#endif  // __CERTIFIER_ALGORITHMS_H__

--- a/include/certifier_framework.h
+++ b/include/certifier_framework.h
@@ -22,6 +22,7 @@
 #include <openssl/x509.h>
 #include <openssl/evp.h>
 
+#include "certifier_algorithms.h"
 #include "certifier.pb.h"
 
 #ifndef byte

--- a/include/support.h
+++ b/include/support.h
@@ -45,6 +45,7 @@ typedef unsigned char byte;
 #endif
 
 #include "certifier_utilities.h"
+#include "certifier_algorithms.h"
 
 using std::string;
 

--- a/sample_apps/analytics_example/enclave/ecalls.cc
+++ b/sample_apps/analytics_example/enclave/ecalls.cc
@@ -74,8 +74,8 @@ byte         app_symmetric_key[app_symmetric_key_size];
 key_message  symmertic_key_for_protect;
 
 // Standard algorithms for the enclave
-string public_key_alg("rsa-2048");
-string symmetric_key_alg("aes-256-cbc-hmac-sha256");
+string public_key_alg(Enc_method_rsa_2048);
+string symmetric_key_alg(Enc_method_aes_256_cbc_hmac_sha256);
 
 void print_trust_data() {
   if (!trust_data_initialized)

--- a/sample_apps/att_systemd_service/attsvc.cc
+++ b/sample_apps/att_systemd_service/attsvc.cc
@@ -264,8 +264,8 @@ int main(int argc, char *argv[]) {
 #endif
 
   // Standard algorithms for the enclave
-  string public_key_alg("rsa-2048");
-  string symmetric_key_alg("aes-256-cbc-hmac-sha256");
+  string public_key_alg(Enc_method_rsa_2048);
+  string symmetric_key_alg(Enc_method_aes_256_cbc_hmac_sha256);
 
   if (!file_exists(store_file)) {
     ATT_LOG(LOG_INFO, "Performing cold initialization...");

--- a/sample_apps/multidomain_simple_app/multidomain_client_app.cc
+++ b/sample_apps/multidomain_simple_app/multidomain_client_app.cc
@@ -157,8 +157,8 @@ int main(int an, char **av) {
   }
 
   // Standard algorithms for the enclave
-  string public_key_alg("rsa-2048");
-  string symmetric_key_alg("aes-256-cbc-hmac-sha256");
+  string public_key_alg(Enc_method_rsa_2048);
+  string symmetric_key_alg(Enc_method_aes_256_cbc_hmac_sha256);
 
   // Carry out operation
   int ret = 0;

--- a/sample_apps/multidomain_simple_app/multidomain_server_app.cc
+++ b/sample_apps/multidomain_simple_app/multidomain_server_app.cc
@@ -146,8 +146,8 @@ int main(int an, char **av) {
   }
 
   // Standard algorithms for the enclave
-  string public_key_alg("rsa-2048");
-  string symmetric_key_alg("aes-256-cbc-hmac-sha256");
+  string public_key_alg(Enc_method_rsa_2048);
+  string symmetric_key_alg(Enc_method_aes_256_cbc_hmac_sha256);
 
   // Carry out operation
   int ret = 0;

--- a/sample_apps/simple_app/example_app.cc
+++ b/sample_apps/simple_app/example_app.cc
@@ -167,8 +167,8 @@ int main(int an, char **av) {
   }
 
   // Standard algorithms for the enclave
-  string public_key_alg("rsa-2048");
-  string symmetric_key_alg("aes-256-cbc-hmac-sha256");
+  string public_key_alg(Enc_method_rsa_2048);
+  string symmetric_key_alg(Enc_method_aes_256_cbc_hmac_sha256);
 
   // Carry out operation
   int ret = 0;

--- a/sample_apps/simple_app_under_app_service/service_example_app.cc
+++ b/sample_apps/simple_app_under_app_service/service_example_app.cc
@@ -117,8 +117,8 @@ bool run_me_as_server(const string &host_name,
 }
 
 // Standard algorithms for the enclave
-string public_key_alg("rsa-2048");
-string symmetric_key_alg("aes-256-cbc-hmac-sha256");
+string public_key_alg(Enc_method_rsa_2048);
+string symmetric_key_alg(Enc_method_aes_256_cbc_hmac_sha256);
 
 int main(int an, char **av) {
 

--- a/sample_apps/simple_app_under_gramine/gramine_example_app.cc
+++ b/sample_apps/simple_app_under_gramine/gramine_example_app.cc
@@ -178,8 +178,8 @@ int main(int an, char **av) {
   }
 
   // Standard algorithms for the enclave
-  string public_key_alg("rsa-2048");
-  string symmetric_key_alg("aes-256-cbc-hmac-sha256");
+  string public_key_alg(Enc_method_rsa_2048);
+  string symmetric_key_alg(Enc_method_aes_256_cbc_hmac_sha256);
 
   // Carry out operation
   if (FLAGS_operation == "cold-init") {

--- a/sample_apps/simple_app_under_islet/islet_example_app.cc
+++ b/sample_apps/simple_app_under_islet/islet_example_app.cc
@@ -170,8 +170,8 @@ int main(int an, char **av) {
   }
 
   // Standard algorithms for the enclave
-  string public_key_alg("rsa-2048");
-  string symmetric_key_alg("aes-256-cbc-hmac-sha256");
+  string public_key_alg(Enc_method_rsa_2048);
+  string symmetric_key_alg(Enc_method_aes_256_cbc_hmac_sha256);
 
   // Carry out operation
   int ret = 0;

--- a/sample_apps/simple_app_under_keystone/keystone_example_app.cc
+++ b/sample_apps/simple_app_under_keystone/keystone_example_app.cc
@@ -167,8 +167,8 @@ int main(int an, char **av) {
   }
 
   // Standard algorithms for the enclave
-  string public_key_alg("rsa-2048");
-  string symmetric_key_alg("aes-256-cbc-hmac-sha256");
+  string public_key_alg(Enc_method_rsa_2048);
+  string symmetric_key_alg(Enc_method_aes_256_cbc_hmac_sha256);
 
   // Carry out operation
   int ret = 0;

--- a/sample_apps/simple_app_under_oe/enclave/ecalls.cc
+++ b/sample_apps/simple_app_under_oe/enclave/ecalls.cc
@@ -63,8 +63,8 @@ byte         app_symmetric_key[app_symmetric_key_size];
 key_message  symmertic_key_for_protect;
 
 // Standard algorithms for the enclave
-string public_key_alg("rsa-2048");
-string symmetric_key_alg("aes-256-cbc-hmac-sha256");
+string public_key_alg(Enc_method_rsa_2048);
+string symmetric_key_alg(Enc_method_aes_256_cbc_hmac_sha256);
 
 void print_trust_data() {
   if (!trust_data_initialized)

--- a/sample_apps/simple_app_under_sev/sev_example_app.cc
+++ b/sample_apps/simple_app_under_sev/sev_example_app.cc
@@ -159,8 +159,8 @@ int main(int an, char **av) {
   }
 
   // Standard algorithms for the enclave
-  string public_key_alg("rsa-2048");
-  string symmetric_key_alg("aes-256-cbc-hmac-sha256");
+  string public_key_alg(Enc_method_rsa_2048);
+  string symmetric_key_alg(Enc_method_aes_256_cbc_hmac_sha256);
 
   // Carry out operation
   int ret = 0;

--- a/src/cc_helpers.cc
+++ b/src/cc_helpers.cc
@@ -548,7 +548,7 @@ bool certifier::framework::cc_trust_data::fetch_store() {
 
   key_message pk;
   pk.set_key_name("protect-key");
-  pk.set_key_type("aes-256-cbc-hmac-sha256");
+  pk.set_key_type(Enc_method_aes_256_cbc_hmac_sha256);
   pk.set_key_format("vse-key");
 
   if (!unprotect_blob(enclave_type_,
@@ -950,9 +950,9 @@ bool certifier::framework::cc_trust_data::generate_symmetric_key(bool regen) {
 
   // Make up symmetric keys (e.g.-for sealing)for app
   int num_key_bytes;
-  if (symmetric_key_algorithm_ == "aes-256-cbc-hmac-sha256"
-      || symmetric_key_algorithm_ == "aes-256-cbc-hmac-sha384"
-      || symmetric_key_algorithm_ == "aes-256-gcm") {
+  if (symmetric_key_algorithm_ == Enc_method_aes_256_cbc_hmac_sha256
+      || symmetric_key_algorithm_ == Enc_method_aes_256_cbc_hmac_sha384
+      || symmetric_key_algorithm_ == Enc_method_aes_256_gcm) {
     num_key_bytes = cipher_key_byte_size(symmetric_key_algorithm_.c_str());
     if (num_key_bytes <= 0) {
       printf("%s() error, line %d, Can't recover symmetric alg key size\n",
@@ -989,9 +989,9 @@ bool certifier::framework::cc_trust_data::generate_sealing_key(bool regen) {
 
   // Make up symmetric keys (e.g.-for sealing)for app
   int num_key_bytes;
-  if (symmetric_key_algorithm_ == "aes-256-cbc-hmac-sha256"
-      || symmetric_key_algorithm_ == "aes-256-cbc-hmac-sha384"
-      || symmetric_key_algorithm_ == "aes-256-gcm") {
+  if (symmetric_key_algorithm_ == Enc_method_aes_256_cbc_hmac_sha256
+      || symmetric_key_algorithm_ == Enc_method_aes_256_cbc_hmac_sha384
+      || symmetric_key_algorithm_ == Enc_method_aes_256_gcm) {
     num_key_bytes = cipher_key_byte_size(symmetric_key_algorithm_.c_str());
     if (num_key_bytes <= 0) {
       printf("%s() error, line %d, Can't get symmetric alg key size\n",
@@ -1028,28 +1028,28 @@ bool certifier::framework::cc_trust_data::generate_auth_key(bool regen) {
     return true;
 
   // make app auth private and public key
-  if (public_key_algorithm_ == "rsa-2048") {
+  if (public_key_algorithm_ == Enc_method_rsa_2048) {
     if (!make_certifier_rsa_key(2048, &private_auth_key_)) {
       printf("%s() error, line %d, Can't generate App private key\n",
              __func__,
              __LINE__);
       return false;
     }
-  } else if (public_key_algorithm_ == "rsa-3072") {
+  } else if (public_key_algorithm_ == Enc_method_rsa_3072) {
     if (!make_certifier_rsa_key(3072, &private_auth_key_)) {
       printf("%s() error, line %d, Can't generate App private key\n",
              __func__,
              __LINE__);
       return false;
     }
-  } else if (public_key_algorithm_ == "rsa-4096") {
+  } else if (public_key_algorithm_ == Enc_method_rsa_4096) {
     if (!make_certifier_rsa_key(4096, &private_auth_key_)) {
       printf("%s() error, line %d, Can't generate App private key\n",
              __func__,
              __LINE__);
       return false;
     }
-  } else if (public_key_algorithm_ == "ecc-384") {
+  } else if (public_key_algorithm_ == Enc_method_ecc_384) {
     if (!make_certifier_ecc_key(384, &private_auth_key_)) {
       printf("%s() error, line %d, Can't generate App private key\n",
              __func__,
@@ -1080,28 +1080,28 @@ bool certifier::framework::cc_trust_data::generate_service_key(bool regen) {
     return true;
 
   // make app service private and public key
-  if (public_key_algorithm_ == "rsa-2048") {
+  if (public_key_algorithm_ == Enc_method_rsa_2048) {
     if (!make_certifier_rsa_key(2048, &private_service_key_)) {
       printf("%s() error, line %d, Can't generate App private key\n",
              __func__,
              __LINE__);
       return false;
     }
-  } else if (public_key_algorithm_ == "rsa-3072") {
+  } else if (public_key_algorithm_ == Enc_method_rsa_3072) {
     if (!make_certifier_rsa_key(3072, &private_service_key_)) {
       printf("%s() error, line %d, Can't generate App private key\n",
              __func__,
              __LINE__);
       return false;
     }
-  } else if (public_key_algorithm_ == "rsa-4096") {
+  } else if (public_key_algorithm_ == Enc_method_rsa_4096) {
     if (!make_certifier_rsa_key(4096, &private_service_key_)) {
       printf("%s() error, line %d, Can't generate App private key\n",
              __func__,
              __LINE__);
       return false;
     }
-  } else if (public_key_algorithm_ == "ecc-384") {
+  } else if (public_key_algorithm_ == Enc_method_ecc_384) {
     if (!make_certifier_ecc_key(384, &private_service_key_)) {
       printf("%s() error, line %d, Can't generate App private key\n",
              __func__,

--- a/src/certifier.cc
+++ b/src/certifier.cc
@@ -957,7 +957,7 @@ bool certifier::framework::unprotect_blob(const string &enclave_type,
     return false;
   }
 
-  if (key->key_type() != "aes-256-cbc-hmac-sha256") {
+  if (key->key_type() != Enc_method_aes_256_cbc_hmac_sha256) {
     printf(
         "%s() error, line %d, unprotect_blob, unsupported encryption scheme\n",
         __func__,

--- a/src/certifier_algorithms.cc
+++ b/src/certifier_algorithms.cc
@@ -1,0 +1,69 @@
+//  Copyright (c) 2021-22, VMware Inc, and the Certifier Authors.  All rights
+//  reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+// clang-format off
+
+/*
+ * Encryption algorithms supported.
+ */
+const char * Enc_method_aes_128                   = "aes-128";
+const char * Enc_method_aes_128_cbc_hmac_sha256   = "aes-128-cbc-hmac-sha256";
+const char * Enc_method_aes_256                   = "aes-256";
+const char * Enc_method_aes_256_cbc               = "aes-256-cbc";
+const char * Enc_method_aes_256_cbc_hmac_sha256   = "aes-256-cbc-hmac-sha256";
+const char * Enc_method_aes_256_cbc_hmac_sha384   = "aes-256-cbc-hmac-sha384";
+const char * Enc_method_aes_256_gcm               = "aes-256-gcm";
+const char * Enc_method_ecc_256_private           = "ecc-256-private";
+const char * Enc_method_ecc_256_public            = "ecc-256-public";
+const char * Enc_method_ecc_256_sha256_pkcs_sign  = "ecc-256-sha256-pkcs-sign";
+const char * Enc_method_ecc_384                   = "ecc-384";
+const char * Enc_method_ecc_384_private           = "ecc-384-private";
+const char * Enc_method_ecc_384_public            = "ecc-384-public";
+const char * Enc_method_ecc_384_sha384_pkcs_sign  = "ecc-384-sha384-pkcs-sign";
+const char * Enc_method_rsa_1024                  = "rsa-1024";
+const char * Enc_method_rsa_1024_private          = "rsa-1024-private";
+const char * Enc_method_rsa_1024_public           = "rsa-1024-public";
+const char * Enc_method_rsa_1024_sha256_pkcs_sign = "rsa-1024-sha256-pkcs-sign";
+const char * Enc_method_rsa_2048                  = "rsa-2048";
+const char * Enc_method_rsa_2048_private          = "rsa-2048-private";
+const char * Enc_method_rsa_2048_public           = "rsa-2048-public";
+const char * Enc_method_rsa_2048_sha256_pkcs_sign = "rsa-2048-sha256-pkcs-sign";
+const char * Enc_method_rsa_3072                  = "rsa-3072";
+const char * Enc_method_rsa_3072_private          = "rsa-3072-private";
+const char * Enc_method_rsa_3072_public           = "rsa-3072-public";
+const char * Enc_method_rsa_3072_sha384_pkcs_sign = "rsa-3072-sha384-pkcs-sign";
+const char * Enc_method_rsa_4096                  = "rsa-4096";
+const char * Enc_method_rsa_4096_private          = "rsa-4096-private";
+const char * Enc_method_rsa_4096_public           = "rsa-4096-public";
+const char * Enc_method_rsa_4096_sha384_pkcs_sign = "rsa-4096-sha384-pkcs-sign";
+ 
+/*
+ * Cryptographic hash algorithms supported.
+ */
+const char * Digest_method_sha256  = "sha256";
+const char * Digest_method_sha_256 = "sha-256";
+const char * Digest_method_sha_384 = "sha-384";
+const char * Digest_method_sha_512 = "sha-512";
+ 
+/*
+ * Integrity protection algorithms, used in conjunction with specific encryption algorithms.
+ */
+const char * Integrity_method_aes_256_cbc_hmac_sha256 = "aes-256-cbc-hmac-sha256";
+const char * Integrity_method_aes_256_cbc_hmac_sha384 = "aes-256-cbc-hmac-sha384";
+const char * Integrity_method_aes_256_gcm             = "aes-256-gcm";
+const char * Integrity_method_hmac_sha256             = "hmac-sha256";
+
+// clang-format on

--- a/src/certifier_proofs.cc
+++ b/src/certifier_proofs.cc
@@ -494,8 +494,8 @@ bool sign_report(const string &     type,
   }
 
   byte signature[size];
-  if (signing_alg == "rsa-2048-sha256-pkcs-sign") {
-    if (signing_key.key_type() != "rsa-2048-private") {
+  if (signing_alg == Enc_method_rsa_2048_sha256_pkcs_sign) {
+    if (signing_key.key_type() != Enc_method_rsa_2048_private) {
       printf("%s() error, line %d, sign_report: Wrong key\n",
              __func__,
              __LINE__);
@@ -508,7 +508,7 @@ bool sign_report(const string &     type,
              __LINE__);
       return false;
     }
-    if (!rsa_sign("sha-256",
+    if (!rsa_sign(Digest_method_sha_256,
                   rsa_key,
                   to_be_signed.size(),
                   (byte *)to_be_signed.data(),
@@ -521,8 +521,8 @@ bool sign_report(const string &     type,
       return false;
     }
     RSA_free(rsa_key);
-  } else if (signing_alg == "rsa-4096-sha384-pkcs-sign") {
-    if (signing_key.key_type() != "rsa-4096-private") {
+  } else if (signing_alg == Enc_method_rsa_4096_sha384_pkcs_sign) {
+    if (signing_key.key_type() != Enc_method_rsa_4096_private) {
       printf("%s() error, line %d, sign_report: Wrong key\n",
              __func__,
              __LINE__);
@@ -535,7 +535,7 @@ bool sign_report(const string &     type,
              __LINE__);
       return false;
     }
-    if (!rsa_sign("sha-384",
+    if (!rsa_sign(Digest_method_sha_384,
                   rsa_key,
                   to_be_signed.size(),
                   (byte *)to_be_signed.data(),
@@ -548,8 +548,8 @@ bool sign_report(const string &     type,
       return false;
     }
     RSA_free(rsa_key);
-  } else if (signing_alg == "rsa-3072-sha384-pkcs-sign") {
-    if (signing_key.key_type() != "rsa-3072-private") {
+  } else if (signing_alg == Enc_method_rsa_3072_sha384_pkcs_sign) {
+    if (signing_key.key_type() != Enc_method_rsa_3072_private) {
       printf("%s() error, line %d, sign_report: Wrong key\n",
              __func__,
              __LINE__);
@@ -562,7 +562,7 @@ bool sign_report(const string &     type,
              __LINE__);
       return false;
     }
-    if (!rsa_sign("sha-384",
+    if (!rsa_sign(Digest_method_sha_384,
                   rsa_key,
                   to_be_signed.size(),
                   (byte *)to_be_signed.data(),
@@ -575,8 +575,8 @@ bool sign_report(const string &     type,
       return false;
     }
     RSA_free(rsa_key);
-  } else if (signing_alg == "ecc-384-sha384-pkcs-sign") {
-    if (signing_key.key_type() != "ecc-384-private") {
+  } else if (signing_alg == Enc_method_ecc_384_sha384_pkcs_sign) {
+    if (signing_key.key_type() != Enc_method_ecc_384_private) {
       printf("%s() error, line %d, sign_report: Wrong key\n",
              __func__,
              __LINE__);
@@ -589,7 +589,7 @@ bool sign_report(const string &     type,
              __LINE__);
       return false;
     }
-    if (!ecc_sign("sha-384",
+    if (!ecc_sign(Digest_method_sha_384,
                   ecc_key,
                   to_be_signed.size(),
                   (byte *)to_be_signed.data(),
@@ -642,7 +642,7 @@ bool verify_report(string &           type,
   }
 
   bool success = false;
-  if (sr.signing_algorithm() == "rsa-2048-sha256-pkcs-sign") {
+  if (sr.signing_algorithm() == Enc_method_rsa_2048_sha256_pkcs_sign) {
     RSA *rsa_key = RSA_new();
     if (!key_to_RSA(signer_key, rsa_key)) {
       printf("%s() error, line %d, verify_report: key_to_RSA failed\n",
@@ -651,14 +651,14 @@ bool verify_report(string &           type,
       return false;
     }
     int size = sr.signature().size();
-    success = rsa_verify("sha-256",
+    success = rsa_verify(Digest_method_sha_256,
                          rsa_key,
                          sr.report().size(),
                          (byte *)sr.report().data(),
                          size,
                          (byte *)sr.signature().data());
     RSA_free(rsa_key);
-  } else if (sr.signing_algorithm() == "rsa-4096-sha384-pkcs-sign") {
+  } else if (sr.signing_algorithm() == Enc_method_rsa_4096_sha384_pkcs_sign) {
     RSA *rsa_key = RSA_new();
     if (!key_to_RSA(signer_key, rsa_key)) {
       printf("%s() error, line %d, verify_report: key_to_RSA failed\n",
@@ -667,14 +667,14 @@ bool verify_report(string &           type,
       return false;
     }
     int size = sr.signature().size();
-    success = rsa_verify("sha-384",
+    success = rsa_verify(Digest_method_sha_384,
                          rsa_key,
                          sr.report().size(),
                          (byte *)sr.report().data(),
                          size,
                          (byte *)sr.signature().data());
     RSA_free(rsa_key);
-  } else if (sr.signing_algorithm() == "rsa-3072-sha384-pkcs-sign") {
+  } else if (sr.signing_algorithm() == Enc_method_rsa_3072_sha384_pkcs_sign) {
     RSA *rsa_key = RSA_new();
     if (!key_to_RSA(signer_key, rsa_key)) {
       printf("%s() error, line %d, verify_report: key_to_RSA failed\n",
@@ -683,14 +683,14 @@ bool verify_report(string &           type,
       return false;
     }
     int size = sr.signature().size();
-    success = rsa_verify("sha-384",
+    success = rsa_verify(Digest_method_sha_384,
                          rsa_key,
                          sr.report().size(),
                          (byte *)sr.report().data(),
                          size,
                          (byte *)sr.signature().data());
     RSA_free(rsa_key);
-  } else if (sr.signing_algorithm() == "ecc-384-sha384-pkcs-sign") {
+  } else if (sr.signing_algorithm() == Enc_method_ecc_384_sha384_pkcs_sign) {
     EC_KEY *ecc_key = key_to_ECC(signer_key);
     if (ecc_key == nullptr) {
       printf("%s() error, line %d, verify_report: key_to_RSA failed\n",
@@ -699,7 +699,7 @@ bool verify_report(string &           type,
       return false;
     }
     int size = sr.signature().size();
-    success = ecc_verify("sha-384",
+    success = ecc_verify(Digest_method_sha_384,
                          ecc_key,
                          sr.report().size(),
                          (byte *)sr.report().data(),

--- a/src/claims_tests.cc
+++ b/src/claims_tests.cc
@@ -111,7 +111,7 @@ bool test_signed_claims(bool print_all) {
     return false;
   }
   my_rsa_key.set_key_name("my-rsa-key");
-  my_rsa_key.set_key_type("rsa-2048-private");
+  my_rsa_key.set_key_type(Enc_method_rsa_2048_private);
   my_rsa_key.set_key_format("vse-key");
 
   key_message my_public_rsa_key;
@@ -169,7 +169,7 @@ bool test_signed_claims(bool print_all) {
     printf("\n");
   }
   signed_claim_message signed_claim1;
-  if (!make_signed_claim("rsa-2048-sha256-pkcs-sign",
+  if (!make_signed_claim(Enc_method_rsa_2048_sha256_pkcs_sign,
                          claim1,
                          my_rsa_key,
                          &signed_claim1))
@@ -186,7 +186,7 @@ bool test_signed_claims(bool print_all) {
     return false;
   }
   my_medium_rsa_key.set_key_name("my-medium-rsa-key");
-  my_medium_rsa_key.set_key_type("rsa-3072-private");
+  my_medium_rsa_key.set_key_type(Enc_method_rsa_3072_private);
   my_medium_rsa_key.set_key_format("vse-key");
 
   if (print_all) {
@@ -241,7 +241,7 @@ bool test_signed_claims(bool print_all) {
     print_claim(claim12);
     printf("\n");
   }
-  if (!make_signed_claim("rsa-3072-sha384-pkcs-sign",
+  if (!make_signed_claim(Enc_method_rsa_3072_sha384_pkcs_sign,
                          claim12,
                          my_medium_rsa_key,
                          &signed_claim12)) {
@@ -260,7 +260,7 @@ bool test_signed_claims(bool print_all) {
     return false;
   }
   my_big_rsa_key.set_key_name("my-big-rsa-key");
-  my_big_rsa_key.set_key_type("rsa-4096-private");
+  my_big_rsa_key.set_key_type(Enc_method_rsa_4096_private);
   my_big_rsa_key.set_key_format("vse-key");
 
   if (print_all) {
@@ -307,7 +307,7 @@ bool test_signed_claims(bool print_all) {
     print_claim(claim2);
     printf("\n");
   }
-  if (!make_signed_claim("rsa-4096-sha384-pkcs-sign",
+  if (!make_signed_claim(Enc_method_rsa_4096_sha384_pkcs_sign,
                          claim2,
                          my_big_rsa_key,
                          &signed_claim2)) {
@@ -327,7 +327,7 @@ bool test_signed_claims(bool print_all) {
     return false;
   }
   my_ecc_key.set_key_name("my-ecc-key");
-  my_ecc_key.set_key_type("ecc-384-private");
+  my_ecc_key.set_key_type(Enc_method_ecc_384_private);
   my_ecc_key.set_key_format("vse-key");
 
   if (print_all) {
@@ -373,7 +373,7 @@ bool test_signed_claims(bool print_all) {
   }
 
   signed_claim_message signed_claim3;
-  if (!make_signed_claim("ecc-384-sha384-pkcs-sign",
+  if (!make_signed_claim(Enc_method_ecc_384_sha384_pkcs_sign,
                          claim3,
                          my_ecc_key,
                          &signed_claim3)) {

--- a/src/islet/islet_shim.cc
+++ b/src/islet/islet_shim.cc
@@ -36,9 +36,9 @@ bool islet_Attest(const int what_to_say_size,
                   int *     attestation_size_out,
                   byte *    attestation_out) {
 
-  int  len = digest_output_byte_size("sha-256");
+  int  len = digest_output_byte_size(Digest_method_sha_256);
   byte islet_what_to_say[len];
-  if (!digest_message("sha-256",
+  if (!digest_message(Digest_method_sha_256,
                       what_to_say,
                       what_to_say_size,
                       islet_what_to_say,
@@ -80,9 +80,9 @@ bool islet_Verify(const int what_to_say_size,
   if (rv != ISLET_SUCCESS)
     return false;
 
-  int  len = digest_output_byte_size("sha-256");
+  int  len = digest_output_byte_size(Digest_method_sha_256);
   byte islet_what_to_say_expected[len];
-  if (!digest_message("sha-256",
+  if (!digest_message(Digest_method_sha_256,
                       what_to_say,
                       what_to_say_size,
                       islet_what_to_say_expected,

--- a/src/keystone/keystone_shim.cc
+++ b/src/keystone/keystone_shim.cc
@@ -248,9 +248,9 @@ bool keystone_Verify(const int what_to_say_size,
 #endif
 
   // report.enclave.data should be hash of what_to_say
-  int  len = digest_output_byte_size("sha-256");
+  int  len = digest_output_byte_size(Digest_method_sha_256);
   byte expected_data[len];
-  if (!digest_message("sha-256",
+  if (!digest_message(Digest_method_sha_256,
                       what_to_say,
                       what_to_say_size,
                       expected_data,
@@ -264,7 +264,7 @@ bool keystone_Verify(const int what_to_say_size,
     return false;
   }
 
-  if (!keystone_ecc_verify("sha-256",
+  if (!keystone_ecc_verify(Digest_method_sha_256,
                            fake_attest_public_key,
                            MDSIZE + sizeof(uint64_t) + report.enclave.data_len,
                            (byte *)report.enclave.hash,
@@ -294,8 +294,8 @@ bool keystone_Attest(const int what_to_say_size,
       *reinterpret_cast<struct report_t *>(attestation_out);
 
   // report.enclave.data gets the hash of what_to_say
-  int len = digest_output_byte_size("sha-256");
-  if (!digest_message("sha-256",
+  int len = digest_output_byte_size(Digest_method_sha_256);
+  if (!digest_message(Digest_method_sha_256,
                       what_to_say,
                       what_to_say_size,
                       report.enclave.data,
@@ -321,7 +321,7 @@ bool keystone_Attest(const int what_to_say_size,
   //
 
   int size_out = SIGNATURE_SIZE;
-  if (!keystone_ecc_sign("sha-256",
+  if (!keystone_ecc_sign(Digest_method_sha_256,
                          fake_attest_private_key,
                          MDSIZE + sizeof(uint64_t) + report.enclave.data_len,
                          (byte *)report.enclave.hash,
@@ -369,7 +369,7 @@ bool keystone_Seal(int in_size, byte *in, int *size_out, byte *out) {
     return false;
   }
 
-  if (!authenticated_encrypt("aes-256-cbc-hmac-sha256",
+  if (!authenticated_encrypt(Enc_method_aes_256_cbc_hmac_sha256,
                              in,
                              in_size,
                              key,
@@ -389,7 +389,7 @@ bool keystone_Unseal(int in_size, byte *in, int *size_out, byte *out) {
     return false;
   }
 
-  if (!authenticated_decrypt("aes-256-cbc-hmac-sha256",
+  if (!authenticated_decrypt(Enc_method_aes_256_cbc_hmac_sha256,
                              in,
                              in_size,
                              key,

--- a/src/sev-snp/sev_support.cc
+++ b/src/sev-snp/sev_support.cc
@@ -449,7 +449,7 @@ bool sev_verify_report(EVP_PKEY *key, struct attestation_report *report) {
   byte         digest[size_digest];
 
   if (!digest_message(
-          "sha-384",
+          Digest_method_sha_384,
           (const byte *)report,
           sizeof(struct attestation_report) - sizeof(struct signature),
           digest,
@@ -658,7 +658,7 @@ bool sev_Seal(int in_size, byte *in, int *size_out, byte *out) {
     return false;
 
   // Encrypt and integrity protect
-  if (!authenticated_encrypt("aes-256-cbc-hmac-sha256",
+  if (!authenticated_encrypt(Enc_method_aes_256_cbc_hmac_sha256,
                              in,
                              in_size,
                              final_key,
@@ -680,7 +680,7 @@ bool sev_Unseal(int in_size, byte *in, int *size_out, byte *out) {
 #endif
 
   // decrypt and integity check
-  if (!authenticated_decrypt("aes-256-cbc-hmac-sha256",
+  if (!authenticated_decrypt(Enc_method_aes_256_cbc_hmac_sha256,
                              in,
                              in_size,
                              final_key,
@@ -703,7 +703,7 @@ bool sev_Attest(int   what_to_say_size,
   sev_attestation_message the_attestation;
   the_attestation.set_what_was_said(what_to_say, what_to_say_size);
 
-  if (!digest_message("sha-384",
+  if (!digest_message(Digest_method_sha_384,
                       what_to_say,
                       what_to_say_size,
                       hash,
@@ -754,7 +754,7 @@ bool verify_sev_Attest(EVP_PKEY *key,
   unsigned int digest_size = 64;
   byte         digest[digest_size];
   memset(digest, 0, digest_size);
-  if (!digest_message("sha-384",
+  if (!digest_message(Digest_method_sha_384,
                       (byte *)sev_att.what_was_said().data(),
                       sev_att.what_was_said().size(),
                       digest,
@@ -896,7 +896,7 @@ int verify_report(struct attestation_report *report) {
 #endif
 
   if (!digest_message(
-          "sha-384",
+          Digest_method_sha_384,
           (byte *)report,
           sizeof(struct attestation_report) - sizeof(struct signature),
           sha_digest_384,

--- a/src/sev_tests.cc
+++ b/src/sev_tests.cc
@@ -205,7 +205,7 @@ bool simulated_sev_Attest(const key_message& vcek, const string& enclave_type,
   attestation_report ar;
   memset(&ar, 0, sizeof(ar));
 
-  if (!digest_message("sha-384", ud_data, ud_size, ar.report_data, 48)) {
+  if (!digest_message(Digest_method_sha_384, ud_data, ud_size, ar.report_data, 48)) {
     printf("simulated_sev_Attest: can't digest ud\n");
     return false;
   }
@@ -237,7 +237,7 @@ bool simulated_sev_Attest(const key_message& vcek, const string& enclave_type,
   int blk_len = ECDSA_size(eck);
   int sig_size_out = 2 * blk_len;
   byte sig_out[sig_size_out];
-  if (!ecc_sign("sha-384", eck, sizeof(ar) - sizeof(ar.signature), (byte*)&ar,
+  if (!ecc_sign(Digest_method_sha_384, eck, sizeof(ar) - sizeof(ar.signature), (byte*)&ar,
           &sig_size_out, sig_out)) {
     printf("simulated_sev_Attest: can't ec_sign\n");
     return false;
@@ -435,7 +435,7 @@ bool test_sev_platform_certify(const bool    debug_print,
     return false;
   }
   ark_key.set_key_name("ARKKey");
-  ark_key.set_key_type("rsa-2048-private");
+  ark_key.set_key_type(Enc_method_rsa_2048_private);
   ark_key.set_key_format("vse-key");
   if (!private_key_to_public_key(ark_key, &ark_pk)) {
     printf("test_sev_platform_certify: Can't convert ark key\n");
@@ -454,7 +454,7 @@ bool test_sev_platform_certify(const bool    debug_print,
     return false;
   }
   ask_key.set_key_name("ASKKey");
-  ask_key.set_key_type("rsa-2048-private");
+  ask_key.set_key_type(Enc_method_rsa_2048_private);
   ask_key.set_key_format("vse-key");
   if (!private_key_to_public_key(ask_key, &ask_pk)) {
     printf("test_sev_platform_certify: Can't convert ask key\n");
@@ -473,7 +473,7 @@ bool test_sev_platform_certify(const bool    debug_print,
     return false;
   }
   vcek_key.set_key_name("VCEKKey");
-  vcek_key.set_key_type("ecc-384-private");
+  vcek_key.set_key_type(Enc_method_ecc_384_private);
   vcek_key.set_key_format("vse-key");
   if (!private_key_to_public_key(vcek_key, &vcek_pk)) {
     printf("test_sev_platform_certify: Can't convert vcek key\n");

--- a/src/simulated_enclave.cc
+++ b/src/simulated_enclave.cc
@@ -178,7 +178,7 @@ bool simulated_Seal(const string &enclave_type,
 
   // output is iv, encrypted bytes
   int real_output_size = output_size;
-  if (!authenticated_encrypt("aes-256-cbc-hmac-sha256",
+  if (!authenticated_encrypt(Enc_method_aes_256_cbc_hmac_sha256,
                              input,
                              input_size,
                              sealing_key,
@@ -214,7 +214,7 @@ bool simulated_Unseal(const string &enclave_type,
   memcpy(iv, in, iv_size);
 
   int real_output_size = output_size;
-  if (!authenticated_decrypt("aes-256-cbc-hmac-sha256",
+  if (!authenticated_decrypt(Enc_method_aes_256_cbc_hmac_sha256,
                              in,
                              in_size,
                              (byte *)sealing_key,
@@ -272,7 +272,7 @@ bool simulated_Attest(const string &enclave_type,
   }
 
   const string type("vse-attestation-report");
-  string       signing_alg("rsa-2048-sha256-pkcs-sign");
+  string       signing_alg(Enc_method_rsa_2048_sha256_pkcs_sign);
   string       serialized_signed_report;
 
   if (!sign_report(type,
@@ -358,7 +358,7 @@ bool simulator_init() {
     printf("simulator_init: Can't convert RSA key to internal\n");
     return false;
   }
-  my_attestation_key.set_key_type("rsa-2048-private");
+  my_attestation_key.set_key_type(Enc_method_rsa_2048_private);
   my_attestation_key.set_key_name("attestKey");
 
   return true;

--- a/src/store_tests.cc
+++ b/src/store_tests.cc
@@ -51,7 +51,7 @@ bool test_protect(bool print_all) {
   const char *secret_data = "I am a secret data.  Protect me.";
 
   key_start.set_key_name("Test key");
-  key_start.set_key_type("aes-256-cbc-hmac-sha256");
+  key_start.set_key_type(Enc_method_aes_256_cbc_hmac_sha256);
   key_start.set_key_format("vse-key");
   key_start.set_not_before(s_nb);
   key_start.set_not_after(s_na);
@@ -195,7 +195,7 @@ bool test_init_and_recover_containers(bool print_all) {
   if (!time_to_string(t_na, &s_na))
     return false;
   storage_key.set_key_name("storage-key");
-  storage_key.set_key_type("aes-256-cbc-hmac-sha256");
+  storage_key.set_key_type(Enc_method_aes_256_cbc_hmac_sha256);
   storage_key.set_key_format("vse-key");
   storage_key.set_not_before(s_nb);
   storage_key.set_not_after(s_na);
@@ -341,7 +341,7 @@ bool test_policy_store(bool print_all) {
     return false;
   }
 
-  string alg("aes-256");
+  string alg(Enc_method_aes_256);
   tag1 = "test-entry-4";
   type1 = "string";
   if (!ps.update_or_insert(tag1, type1, alg)) {

--- a/src/support.cc
+++ b/src/support.cc
@@ -34,6 +34,8 @@
 #include <sys/socket.h>
 #include <string>
 
+#include "certifier_algorithms.cc"
+
 using std::string;
 using namespace certifier::framework;
 using namespace certifier::utilities;
@@ -46,64 +48,68 @@ class name_size {
   int         size_;
 };
 
+// clang-format off
+
 name_size cipher_block_byte_name_size[] = {
-    {"aes-256", 16},
-    {"aes-256-cbc-hmac-sha256", 16},
-    {"aes-256-cbc-hmac-sha384", 16},
-    {"aes-256-gcm", 16},
-    {"aes-128", 16},
-    {"aes-128-cbc-hmac-sha256", 16},
-    {"rsa-2048-sha256-pkcs-sign", 256},
-    {"rsa-2048", 256},
-    {"rsa-1024-sha256-pkcs-sign", 128},
-    {"rsa-1024", 128},
-    {"rsa-1024-private", 128},
-    {"rsa-1024-public", 128},
-    {"rsa-2048-private", 256},
-    {"rsa-2048-public", 256},
-    {"rsa-4096-sha384-pkcs-sign", 512},
-    {"rsa-4096-private", 512},
-    {"rsa-4096-public", 512},
-    {"ecc-384-public", 48},
-    {"ecc-384-private", 48},
-    {"ecc-256-public", 32},
-    {"ecc-256-private", 32},
+    { Enc_method_aes_256                    , 16 },
+    { Enc_method_aes_256_cbc_hmac_sha256    , 16 },
+    { Enc_method_aes_256_cbc_hmac_sha384    , 16 },
+    { Enc_method_aes_256_gcm                , 16 },
+    { Enc_method_aes_128                    , 16 },
+    { Enc_method_aes_128_cbc_hmac_sha256    , 16 },
+    { Enc_method_rsa_2048_sha256_pkcs_sign  , 256 },
+    { Enc_method_rsa_2048                   , 256 },
+    { Enc_method_rsa_1024_sha256_pkcs_sign  , 128 },
+    { Enc_method_rsa_1024                   , 128 },
+    { Enc_method_rsa_1024_private           , 128 },
+    { Enc_method_rsa_1024_public            , 128 },
+    { Enc_method_rsa_2048_private           , 256 },
+    { Enc_method_rsa_2048_public            , 256 },
+    { Enc_method_rsa_4096_sha384_pkcs_sign  , 512 },
+    { Enc_method_rsa_4096_private           , 512 },
+    { Enc_method_rsa_4096_public            , 512 },
+    { Enc_method_ecc_384_public             , 48 },
+    { Enc_method_ecc_384_private            , 48 },
+    { Enc_method_ecc_256_public             , 32 },
+    { Enc_method_ecc_256_private            , 32 },
 };
 
 name_size cipher_key_byte_name_size[] = {
-    {"aes-256", 32},
-    {"aes-256-cbc-hmac-sha256", 64},
-    {"aes-256-cbc-hmac-sha384", 96},
-    {"aes-256-gcm", 32},
-    {"rsa-2048-sha256-pkcs-sign", 256},
-    {"rsa-2048", 256},
-    {"rsa-1024-sha256-pkcs-sign", 128},
-    {"rsa-1024", 128},
-    {"rsa-2048-private", 256},
-    {"rsa-2048-public", 256},
-    {"rsa-1024-private", 128},
-    {"rsa-1024-public", 128},
-    {"rsa-3072-sha384-pkcs-sign", 384},
-    {"rsa-3072-private", 384},
-    {"rsa-3072-public", 384},
-    {"rsa-4096-sha384-pkcs-sign", 512},
-    {"rsa-4096-private", 512},
-    {"rsa-4096-public", 512},
+    { Enc_method_aes_256                    , 32 },
+    { Enc_method_aes_256_cbc_hmac_sha256    , 64 },
+    { Enc_method_aes_256_cbc_hmac_sha384    , 96 },
+    { Enc_method_aes_256_gcm                , 32 },
+    { Enc_method_rsa_2048_sha256_pkcs_sign  , 256 },
+    { Enc_method_rsa_2048                   , 256 },
+    { Enc_method_rsa_1024_sha256_pkcs_sign  , 128 },
+    { Enc_method_rsa_1024                   , 128 },
+    { Enc_method_rsa_2048_private           , 256 },
+    { Enc_method_rsa_2048_public            , 256 },
+    { Enc_method_rsa_1024_private           , 128 },
+    { Enc_method_rsa_1024_public            , 128 },
+    { Enc_method_rsa_3072_sha384_pkcs_sign  , 384 },
+    { Enc_method_rsa_3072_private           , 384 },
+    { Enc_method_rsa_3072_public            , 384 },
+    { Enc_method_rsa_4096_sha384_pkcs_sign  , 512 },
+    { Enc_method_rsa_4096_private           , 512 },
+    { Enc_method_rsa_4096_public            , 512 },
 };
 
 name_size digest_byte_name_size[] = {
-    {"sha256", 32},
-    {"sha-256", 32},
-    {"sha-384", 48},
-    {"sha-512", 64},
+    { Digest_method_sha256   , 32 },
+    { Digest_method_sha_256  , 32 },
+    { Digest_method_sha_384  , 48 },
+    { Digest_method_sha_512  , 64 },
 };
 
 name_size mac_byte_name_size[] = {
-    {"hmac-sha256", 32},
-    {"aes-256-cbc-hmac-sha256", 32},
-    {"aes-256-cbc-hmac-sha384", 48},
-    {"aes-256-gcm", 16},
+    { Integrity_method_hmac_sha256       , 32 },
+    { Enc_method_aes_256_cbc_hmac_sha256 , 32 },
+    { Enc_method_aes_256_cbc_hmac_sha384 , 48 },
+    { Enc_method_aes_256_gcm             , 16 },
 };
+
+// clang-format on
 
 int certifier::utilities::cipher_block_byte_size(const char *alg_name) {
   int size = sizeof(cipher_block_byte_name_size)
@@ -668,7 +674,8 @@ bool certifier::utilities::digest_message(const char * alg,
 
   EVP_MD_CTX *mdctx;
 
-  if (strcmp(alg, "sha-256") == 0 || strcmp(alg, "sha256") == 0) {
+  if (strcmp(alg, Digest_method_sha_256) == 0
+      || strcmp(alg, Digest_method_sha256) == 0) {
     if ((mdctx = EVP_MD_CTX_new()) == NULL) {
       printf("%s() error, line: %d, EVP_MD_CTX_new failed\n",
              __func__,
@@ -681,7 +688,7 @@ bool certifier::utilities::digest_message(const char * alg,
              __LINE__);
       return false;
     }
-  } else if (strcmp(alg, "sha-384") == 0) {
+  } else if (strcmp(alg, Digest_method_sha_384) == 0) {
     if ((mdctx = EVP_MD_CTX_new()) == NULL) {
       printf("%s() error, line: %d, EVP_MD_CTX_new failed\n",
              __func__,
@@ -694,7 +701,7 @@ bool certifier::utilities::digest_message(const char * alg,
              __LINE__);
       return false;
     }
-  } else if (strcmp(alg, "sha-512") == 0) {
+  } else if (strcmp(alg, Digest_method_sha_512) == 0) {
     if ((mdctx = EVP_MD_CTX_new()) == NULL) {
       printf("%s() error, line: %d, EVP_MD_CTX_new failed\n",
              __func__,
@@ -735,9 +742,9 @@ bool aes_256_cbc_sha256_encrypt(byte *in,
                                 byte *iv,
                                 byte *out,
                                 int * out_size) {
-  int blk_size = cipher_block_byte_size("aes-256-cbc-hmac-sha256");
-  int key_size = cipher_key_byte_size("aes-256-cbc-hmac-sha256");
-  int mac_size = mac_output_byte_size("aes-256-cbc-hmac-sha256");
+  int blk_size = cipher_block_byte_size(Enc_method_aes_256_cbc_hmac_sha256);
+  int key_size = cipher_key_byte_size(Enc_method_aes_256_cbc_hmac_sha256);
+  int mac_size = mac_output_byte_size(Enc_method_aes_256_cbc_hmac_sha256);
   int cipher_size = *out_size - blk_size;
 
   memset(out, 0, *out_size);
@@ -768,9 +775,9 @@ bool aes_256_cbc_sha256_decrypt(byte *in,
                                 byte *key,
                                 byte *out,
                                 int * out_size) {
-  int blk_size = cipher_block_byte_size("aes-256-cbc-hmac-sha256");
-  int key_size = cipher_key_byte_size("aes-256-cbc-hmac-sha256");
-  int mac_size = mac_output_byte_size("aes-256-cbc-hmac-sha256");
+  int blk_size = cipher_block_byte_size(Enc_method_aes_256_cbc_hmac_sha256);
+  int key_size = cipher_key_byte_size(Enc_method_aes_256_cbc_hmac_sha256);
+  int mac_size = mac_output_byte_size(Enc_method_aes_256_cbc_hmac_sha256);
   int cipher_size = *out_size - blk_size;
 
   int          plain_size = *out_size - blk_size - mac_size;
@@ -813,9 +820,9 @@ bool aes_256_cbc_sha384_encrypt(byte *in,
                                 byte *iv,
                                 byte *out,
                                 int * out_size) {
-  int blk_size = cipher_block_byte_size("aes-256-cbc-hmac-sha384");
-  int key_size = cipher_key_byte_size("aes-256-cbc-hmac-sha384");
-  int mac_size = mac_output_byte_size("aes-256-cbc-hmac-sha384");
+  int blk_size = cipher_block_byte_size(Enc_method_aes_256_cbc_hmac_sha384);
+  int key_size = cipher_key_byte_size(Enc_method_aes_256_cbc_hmac_sha384);
+  int mac_size = mac_output_byte_size(Enc_method_aes_256_cbc_hmac_sha384);
   int cipher_size = *out_size - blk_size;
 
   memset(out, 0, *out_size);
@@ -846,9 +853,9 @@ bool aes_256_cbc_sha384_decrypt(byte *in,
                                 byte *key,
                                 byte *out,
                                 int * out_size) {
-  int blk_size = cipher_block_byte_size("aes-256-cbc-hmac-sha384");
-  int key_size = cipher_key_byte_size("aes-256-cbc-hmac-sha384");
-  int mac_size = mac_output_byte_size("aes-256-cbc-hmac-sha384");
+  int blk_size = cipher_block_byte_size(Enc_method_aes_256_cbc_hmac_sha384);
+  int key_size = cipher_key_byte_size(Enc_method_aes_256_cbc_hmac_sha384);
+  int mac_size = mac_output_byte_size(Enc_method_aes_256_cbc_hmac_sha384);
   int cipher_size = *out_size - blk_size;
 
   int          plain_size = *out_size - blk_size - mac_size;
@@ -895,8 +902,8 @@ bool aes_256_gcm_encrypt(byte *in,
   EVP_CIPHER_CTX *ctx = nullptr;
   int             len;
   int             ciphertext_len;
-  int             blk_size = cipher_block_byte_size("aes-256");
-  int             key_size = cipher_key_byte_size("aes-256");
+  int             blk_size = cipher_block_byte_size(Enc_method_aes_256);
+  int             key_size = cipher_key_byte_size(Enc_method_aes_256);
   int             tag_len = 0;
   byte            tag[16];
   int             aad_len = 0;
@@ -996,8 +1003,8 @@ bool aes_256_gcm_decrypt(byte *in,
                          byte *out,
                          int * out_size) {
   EVP_CIPHER_CTX *ctx = nullptr;
-  int             blk_size = cipher_block_byte_size("aes-256");
-  int             key_size = cipher_key_byte_size("aes-256");
+  int             blk_size = cipher_block_byte_size(Enc_method_aes_256);
+  int             key_size = cipher_key_byte_size(Enc_method_aes_256);
   byte *          iv = in;
   bool            ret = true;
   byte *          tag = in + in_len - blk_size;
@@ -1086,11 +1093,11 @@ bool certifier::utilities::authenticated_encrypt(const char *alg_name,
                                                  byte *      out,
                                                  int *       out_size) {
 
-  if (strcmp(alg_name, "aes-256-cbc-hmac-sha256") == 0) {
+  if (strcmp(alg_name, Enc_method_aes_256_cbc_hmac_sha256) == 0) {
     return aes_256_cbc_sha256_encrypt(in, in_len, key, iv, out, out_size);
-  } else if (strcmp(alg_name, "aes-256-cbc-hmac-sha384") == 0) {
+  } else if (strcmp(alg_name, Enc_method_aes_256_cbc_hmac_sha384) == 0) {
     return aes_256_cbc_sha384_encrypt(in, in_len, key, iv, out, out_size);
-  } else if (strcmp(alg_name, "aes-256-gcm") == 0) {
+  } else if (strcmp(alg_name, Enc_method_aes_256_gcm) == 0) {
     return aes_256_gcm_encrypt(in, in_len, key, iv, out, out_size);
   } else {
     printf("%s() error, line: %d, authenticated_decrypt: unsupported algorithm "
@@ -1109,11 +1116,11 @@ bool certifier::utilities::authenticated_decrypt(const char *alg_name,
                                                  byte *      out,
                                                  int *       out_size) {
 
-  if (strcmp(alg_name, "aes-256-cbc-hmac-sha256") == 0) {
+  if (strcmp(alg_name, Enc_method_aes_256_cbc_hmac_sha256) == 0) {
     return aes_256_cbc_sha256_decrypt(in, in_len, key, out, out_size);
-  } else if (strcmp(alg_name, "aes-256-cbc-hmac-sha384") == 0) {
+  } else if (strcmp(alg_name, Enc_method_aes_256_cbc_hmac_sha384) == 0) {
     return aes_256_cbc_sha384_decrypt(in, in_len, key, out, out_size);
-  } else if (strcmp(alg_name, "aes-256-gcm") == 0) {
+  } else if (strcmp(alg_name, Enc_method_aes_256_gcm) == 0) {
     return aes_256_gcm_decrypt(in, in_len, key, out, out_size);
   } else {
     printf("%s() error, line: %d, authenticated_decrypt: unsupported algorithm "
@@ -1132,30 +1139,30 @@ bool      certifier::utilities::private_key_to_public_key(const key_message &in,
 
   int n_bytes = 0;
   int alg_type = 0;
-  if (in.key_type() == "rsa-2048-private") {
+  if (in.key_type() == Enc_method_rsa_2048_private) {
     alg_type = rsa_alg_type;
-    out->set_key_type("rsa-2048-public");
-    n_bytes = cipher_block_byte_size("rsa-2048-public");
-  } else if (in.key_type() == "rsa-1024-private") {
+    out->set_key_type(Enc_method_rsa_2048_public);
+    n_bytes = cipher_block_byte_size(Enc_method_rsa_2048_public);
+  } else if (in.key_type() == Enc_method_rsa_1024_private) {
     alg_type = rsa_alg_type;
-    out->set_key_type("rsa-1024-public");
-    n_bytes = cipher_block_byte_size("rsa-1024-public");
-  } else if (in.key_type() == "rsa-3072-private") {
+    out->set_key_type(Enc_method_rsa_1024_public);
+    n_bytes = cipher_block_byte_size(Enc_method_rsa_1024_public);
+  } else if (in.key_type() == Enc_method_rsa_3072_private) {
     alg_type = rsa_alg_type;
-    out->set_key_type("rsa-3072-public");
-    n_bytes = cipher_block_byte_size("rsa-3072-public");
-  } else if (in.key_type() == "rsa-4096-private") {
+    out->set_key_type(Enc_method_rsa_3072_public);
+    n_bytes = cipher_block_byte_size(Enc_method_rsa_3072_public);
+  } else if (in.key_type() == Enc_method_rsa_4096_private) {
     alg_type = rsa_alg_type;
-    out->set_key_type("rsa-4096-public");
-    n_bytes = cipher_block_byte_size("rsa-4096-public");
-  } else if (in.key_type() == "ecc-384-private") {
+    out->set_key_type(Enc_method_rsa_4096_public);
+    n_bytes = cipher_block_byte_size(Enc_method_rsa_4096_public);
+  } else if (in.key_type() == Enc_method_ecc_384_private) {
     alg_type = ecc_alg_type;
-    out->set_key_type("ecc-384-public");
-    n_bytes = cipher_block_byte_size("ecc-384-public");
-  } else if (in.key_type() == "ecc-256-private") {
+    out->set_key_type(Enc_method_ecc_384_public);
+    n_bytes = cipher_block_byte_size(Enc_method_ecc_384_public);
+  } else if (in.key_type() == Enc_method_ecc_256_private) {
     alg_type = ecc_alg_type;
-    out->set_key_type("ecc-256-public");
-    n_bytes = cipher_block_byte_size("ecc-256-public");
+    out->set_key_type(Enc_method_ecc_256_public);
+    n_bytes = cipher_block_byte_size(Enc_method_ecc_256_public);
   } else {
     printf("%s() error, line %d, private_key_to_public_key: bad key type "
            "(n_bytes=%d)\n",
@@ -1209,13 +1216,13 @@ bool make_certifier_rsa_key(int n, key_message *k) {
   }
 
   if (n == 2048) {
-    k->set_key_type("rsa-2048-private");
+    k->set_key_type(Enc_method_rsa_2048_private);
   } else if (n == 1024) {
-    k->set_key_type("rsa-1024-private");
+    k->set_key_type(Enc_method_rsa_1024_private);
   } else if (n == 4096) {
-    k->set_key_type("rsa-4096-private");
+    k->set_key_type(Enc_method_rsa_4096_private);
   } else if (n == 3072) {
-    k->set_key_type("rsa-3072-private");
+    k->set_key_type(Enc_method_rsa_3072_private);
   } else {
     printf("%s() error, line: %d, bad modulus size failed\n",
            __func__,
@@ -1281,11 +1288,16 @@ bool rsa_sha256_sign(RSA * key,
                      byte *to_sign,
                      int * sig_size,
                      byte *sig) {
-  return rsa_sign("sha-256", key, to_sign_size, to_sign, sig_size, sig);
+  return rsa_sign(Digest_method_sha_256,
+                  key,
+                  to_sign_size,
+                  to_sign,
+                  sig_size,
+                  sig);
 }
 
 bool rsa_sha256_verify(RSA *key, int size, byte *msg, int sig_size, byte *sig) {
-  return rsa_verify("sha-256", key, size, msg, sig_size, sig);
+  return rsa_verify(Digest_method_sha_256, key, size, msg, sig_size, sig);
 }
 
 bool rsa_sign(const char *alg,
@@ -1313,7 +1325,7 @@ bool rsa_sign(const char *alg,
   }
 
   unsigned int size_digest = 0;
-  if (strcmp("sha-256", alg) == 0) {
+  if (strcmp(Digest_method_sha_256, alg) == 0) {
     if (EVP_DigestSignInit(sign_ctx,
                            nullptr,
                            EVP_sha256(),
@@ -1339,7 +1351,7 @@ bool rsa_sign(const char *alg,
       return false;
     }
     *sig_size = t;
-  } else if (strcmp("sha-384", alg) == 0) {
+  } else if (strcmp(Digest_method_sha_384, alg) == 0) {
     if (EVP_DigestSignInit(sign_ctx,
                            nullptr,
                            EVP_sha384(),
@@ -1383,12 +1395,12 @@ bool rsa_verify(const char *alg,
                 int         sig_size,
                 byte *      sig) {
 
-  if (strcmp("sha-256", alg) == 0) {
-    unsigned int size_digest = digest_output_byte_size("sha-256");
+  if (strcmp(Digest_method_sha_256, alg) == 0) {
+    unsigned int size_digest = digest_output_byte_size(Digest_method_sha_256);
     byte         digest[size_digest];
     memset(digest, 0, size_digest);
 
-    if (!digest_message("sha-256",
+    if (!digest_message(Digest_method_sha_256,
                         (const byte *)msg,
                         size,
                         digest,
@@ -1441,11 +1453,11 @@ bool rsa_verify(const char *alg,
       return false;
     }
     return memcmp(digest, &decrypted[n - size_digest], size_digest) == 0;
-  } else if (strcmp("sha-384", alg) == 0) {
-    unsigned int size_digest = digest_output_byte_size("sha-384");
+  } else if (strcmp(Digest_method_sha_384, alg) == 0) {
+    unsigned int size_digest = digest_output_byte_size(Digest_method_sha_384);
     byte         digest[size_digest];
     memset(digest, 0, size_digest);
-    if (!digest_message("sha-384",
+    if (!digest_message(Digest_method_sha_384,
                         (const byte *)msg,
                         size,
                         digest,
@@ -1535,28 +1547,28 @@ bool key_to_RSA(const key_message &k, RSA *r) {
 
   bool private_key = true;
   int  key_size_bits = 0;
-  if (k.key_type() == "rsa-1024-public") {
+  if (k.key_type() == Enc_method_rsa_1024_public) {
     key_size_bits = 1024;
     private_key = false;
-  } else if (k.key_type() == "rsa-1024-private") {
+  } else if (k.key_type() == Enc_method_rsa_1024_private) {
     key_size_bits = 1024;
     private_key = true;
-  } else if (k.key_type() == "rsa-2048-public") {
+  } else if (k.key_type() == Enc_method_rsa_2048_public) {
     key_size_bits = 2048;
     private_key = false;
-  } else if (k.key_type() == "rsa-2048-private") {
+  } else if (k.key_type() == Enc_method_rsa_2048_private) {
     key_size_bits = 2048;
     private_key = true;
-  } else if (k.key_type() == "rsa-4096-private") {
+  } else if (k.key_type() == Enc_method_rsa_4096_private) {
     key_size_bits = 4096;
     private_key = true;
-  } else if (k.key_type() == "rsa-4096-public") {
+  } else if (k.key_type() == Enc_method_rsa_4096_public) {
     key_size_bits = 4096;
     private_key = false;
-  } else if (k.key_type() == "rsa-3072-private") {
+  } else if (k.key_type() == Enc_method_rsa_3072_private) {
     key_size_bits = 3072;
     private_key = true;
-  } else if (k.key_type() == "rsa-3072-public") {
+  } else if (k.key_type() == Enc_method_rsa_3072_public) {
     key_size_bits = 3072;
     private_key = false;
   } else {
@@ -1690,24 +1702,24 @@ bool RSA_to_key(const RSA *r, key_message *k) {
   int rsa_size = RSA_bits(r);
   if (rsa_size == 1024) {
     if (d == nullptr)
-      k->set_key_type("rsa-1024-public");
+      k->set_key_type(Enc_method_rsa_1024_public);
     else
-      k->set_key_type("rsa-1024-private");
+      k->set_key_type(Enc_method_rsa_1024_private);
   } else if (rsa_size == 2048) {
     if (d == nullptr)
-      k->set_key_type("rsa-2048-public");
+      k->set_key_type(Enc_method_rsa_2048_public);
     else
-      k->set_key_type("rsa-2048-private");
+      k->set_key_type(Enc_method_rsa_2048_private);
   } else if (rsa_size == 4096) {
     if (d == nullptr)
-      k->set_key_type("rsa-4096-public");
+      k->set_key_type(Enc_method_rsa_4096_public);
     else
-      k->set_key_type("rsa-4096-private");
+      k->set_key_type(Enc_method_rsa_4096_private);
   } else if (rsa_size == 3072) {
     if (d == nullptr)
-      k->set_key_type("rsa-3072-public");
+      k->set_key_type(Enc_method_rsa_3072_public);
     else
-      k->set_key_type("rsa-3072-private");
+      k->set_key_type(Enc_method_rsa_3072_private);
   } else {
     return false;
   }
@@ -1986,10 +1998,11 @@ EC_KEY *certifier::utilities::generate_new_ecc_key(int num_bits) {
 EC_KEY *certifier::utilities::key_to_ECC(const key_message &k) {
 
   EC_KEY *ecc_key = nullptr;
-  if (k.key_type() == "ecc-384-private" || k.key_type() == "ecc-384-public") {
+  if (k.key_type() == Enc_method_ecc_384_private
+      || k.key_type() == Enc_method_ecc_384_public) {
     ecc_key = EC_KEY_new_by_curve_name(NID_secp384r1);
-  } else if (k.key_type() == "ecc-256-private"
-             || k.key_type() == "ecc-256-public") {
+  } else if (k.key_type() == Enc_method_ecc_256_private
+             || k.key_type() == Enc_method_ecc_256_public) {
     ecc_key = EC_KEY_new_by_curve_name(NID_X9_62_prime256v1);
   } else {
     printf("%s() error, line: %d, key_to_ECC: wrong type %s\n",
@@ -2120,10 +2133,10 @@ bool certifier::utilities::ECC_to_key(const EC_KEY *ecc_key, key_message *k) {
   int modulus_size = BN_num_bytes(p);
 
   if (modulus_size == 48) {
-    k->set_key_type("ecc-384-public");
+    k->set_key_type(Enc_method_ecc_384_public);
     ek->set_curve_name("P-384");
   } else if (modulus_size == 32) {
-    k->set_key_type("ecc-256-public");
+    k->set_key_type(Enc_method_ecc_256_public);
     ek->set_curve_name("P-256");
   } else {
     printf("%s() error, line: %d, ECC_to_key: Modulus size not supported: %d\n",
@@ -2238,9 +2251,9 @@ bool certifier::utilities::ECC_to_key(const EC_KEY *ecc_key, key_message *k) {
   const BIGNUM *pk = EC_KEY_get0_private_key(ecc_key);
   if (pk != nullptr) {
     if (modulus_size == 48) {
-      k->set_key_type("ecc-384-private");
+      k->set_key_type(Enc_method_ecc_384_private);
     } else if (modulus_size == 32) {
-      k->set_key_type("ecc-256-private");
+      k->set_key_type(Enc_method_ecc_256_private);
     } else {
       printf("%s() error, line: %d, EC_KEY_get0_private_key failed\n",
              __func__,
@@ -2263,9 +2276,9 @@ bool make_certifier_ecc_key(int n, key_message *k) {
   if (k == nullptr)
     return false;
   if (n == 384) {
-    k->set_key_type("ecc-384-private");
+    k->set_key_type(Enc_method_ecc_384_private);
   } else if (n == 256) {
-    k->set_key_type("ecc-256-private");
+    k->set_key_type(Enc_method_ecc_256_private);
   } else {
     printf(
         "%s() error, line: %d, make_certifier_ecc_key: unsupported key size\n",
@@ -2334,13 +2347,14 @@ bool same_key(const key_message &k1, const key_message &k2) {
     return false;
   }
 
-  if (k1.key_type() == "rsa-2048-private" || k1.key_type() == "rsa-2048-public"
-      || k1.key_type() == "rsa-1024-private"
-      || k1.key_type() == "rsa-1024-public"
-      || k1.key_type() == "rsa-3072-private"
-      || k1.key_type() == "rsa-3072-public"
-      || k1.key_type() == "rsa-4096-private"
-      || k1.key_type() == "rsa-4096-public") {
+  if (k1.key_type() == Enc_method_rsa_2048_private
+      || k1.key_type() == Enc_method_rsa_2048_public
+      || k1.key_type() == Enc_method_rsa_1024_private
+      || k1.key_type() == Enc_method_rsa_1024_public
+      || k1.key_type() == Enc_method_rsa_3072_private
+      || k1.key_type() == Enc_method_rsa_3072_public
+      || k1.key_type() == Enc_method_rsa_4096_private
+      || k1.key_type() == Enc_method_rsa_4096_public) {
     string b1, b2;
     if (!k1.has_rsa_key() || !k2.has_rsa_key()) {
       return false;
@@ -2352,8 +2366,9 @@ bool same_key(const key_message &k1, const key_message &k2) {
       return false;
     }
     return true;
-  } else if (k1.key_type() == "aes-256-cbc-hmac-sha256"
-             || k1.key_type() == "aes-256-cbc" || k1.key_type() == "aes-256") {
+  } else if (k1.key_type() == Enc_method_aes_256_cbc_hmac_sha256
+             || k1.key_type() == Enc_method_aes_256_cbc
+             || k1.key_type() == Enc_method_aes_256) {
     if (!k1.has_secret_key_bits()) {
       printf("%s() error, line: %d, no secret key bits\n", __func__, __LINE__);
       return false;
@@ -2368,8 +2383,8 @@ bool same_key(const key_message &k1, const key_message &k2) {
                    k2.secret_key_bits().data(),
                    k1.secret_key_bits().size())
             == 0);
-  } else if (k1.key_type() == "ecc-384-public"
-             || k1.key_type() == "ecc-384-private") {
+  } else if (k1.key_type() == Enc_method_ecc_384_public
+             || k1.key_type() == Enc_method_ecc_384_private) {
     const ecc_message &em1 = k1.ecc_key();
     const ecc_message &em2 = k2.ecc_key();
     if (em1.curve_p().size() != em2.curve_p().size()
@@ -2400,8 +2415,8 @@ bool same_key(const key_message &k1, const key_message &k2) {
       return false;
     }
     return true;
-  } else if (k1.key_type() == "ecc-256-public"
-             || k1.key_type() == "ecc-256-private") {
+  } else if (k1.key_type() == Enc_method_ecc_256_public
+             || k1.key_type() == Enc_method_ecc_256_private) {
     const ecc_message &em1 = k1.ecc_key();
     const ecc_message &em2 = k2.ecc_key();
     if (em1.curve_p().size() != em2.curve_p().size()
@@ -2815,11 +2830,14 @@ void print_key_descriptor(const key_message &k) {
   if (!k.has_key_type())
     return;
 
-  if (k.key_type() == "rsa-2048-private" || k.key_type() == "rsa-2048-public"
-      || k.key_type() == "rsa-3072-private" || k.key_type() == "rsa-3072-public"
-      || k.key_type() == "rsa-1024-private" || k.key_type() == "rsa-1024-public"
-      || k.key_type() == "rsa-4096-private"
-      || k.key_type() == "rsa-4096-public") {
+  if (k.key_type() == Enc_method_rsa_2048_private
+      || k.key_type() == Enc_method_rsa_2048_public
+      || k.key_type() == Enc_method_rsa_3072_private
+      || k.key_type() == Enc_method_rsa_3072_public
+      || k.key_type() == Enc_method_rsa_1024_private
+      || k.key_type() == Enc_method_rsa_1024_public
+      || k.key_type() == Enc_method_rsa_4096_private
+      || k.key_type() == Enc_method_rsa_4096_public) {
     printf("Key[rsa, ");
     if (k.has_key_name()) {
       printf("%s, ", k.key_name().c_str());
@@ -2833,10 +2851,10 @@ void print_key_descriptor(const key_message &k) {
       }
       printf("]");
     }
-  } else if (k.key_type() == "ecc-384-private"
-             || k.key_type() == "ecc-384-public"
-             || k.key_type() == "ecc-256-private"
-             || k.key_type() == "ecc-256-public") {
+  } else if (k.key_type() == Enc_method_ecc_384_private
+             || k.key_type() == Enc_method_ecc_384_public
+             || k.key_type() == Enc_method_ecc_256_private
+             || k.key_type() == Enc_method_ecc_256_public) {
     printf("Key[ecc, ");
     if (k.has_key_name()) {
       printf("%s, ", k.key_name().c_str());
@@ -3025,7 +3043,7 @@ bool make_signed_claim(const char *          alg,
 
   int  sig_size = 0;
   bool success = false;
-  if (strcmp(alg, "rsa-2048-sha256-pkcs-sign") == 0) {
+  if (strcmp(alg, Enc_method_rsa_2048_sha256_pkcs_sign) == 0) {
     RSA *r = RSA_new();
     if (!key_to_RSA(key, r)) {
       printf("%s() error, line: %d, make_signed_claim: key_to_RSA failed\n",
@@ -3055,7 +3073,7 @@ bool make_signed_claim(const char *          alg,
     out->set_allocated_signing_key(psk);
     out->set_signing_algorithm(alg);
     out->set_signature((void *)sig, sig_size);
-  } else if (strcmp(alg, "rsa-3072-sha384-pkcs-sign") == 0) {
+  } else if (strcmp(alg, Enc_method_rsa_3072_sha384_pkcs_sign) == 0) {
     RSA *r = RSA_new();
     if (!key_to_RSA(key, r)) {
       printf("%s() error, line: %d, make_signed_claim: key_to_RSA failed\n",
@@ -3066,7 +3084,7 @@ bool make_signed_claim(const char *          alg,
 
     sig_size = RSA_size(r);
     byte sig[sig_size];
-    success = rsa_sign("sha-384",
+    success = rsa_sign(Digest_method_sha_384,
                        r,
                        serialized_claim.size(),
                        (byte *)serialized_claim.data(),
@@ -3089,7 +3107,7 @@ bool make_signed_claim(const char *          alg,
     out->set_allocated_signing_key(psk);
     out->set_signing_algorithm(alg);
     out->set_signature((void *)sig, sig_size);
-  } else if (strcmp(alg, "rsa-4096-sha384-pkcs-sign") == 0) {
+  } else if (strcmp(alg, Enc_method_rsa_4096_sha384_pkcs_sign) == 0) {
     RSA *r = RSA_new();
     if (!key_to_RSA(key, r)) {
       printf("%s() error, line: %d, make_signed_claim: key_to_RSA failed\n",
@@ -3100,7 +3118,7 @@ bool make_signed_claim(const char *          alg,
 
     sig_size = RSA_size(r);
     byte sig[sig_size];
-    success = rsa_sign("sha-384",
+    success = rsa_sign(Digest_method_sha_384,
                        r,
                        serialized_claim.size(),
                        (byte *)serialized_claim.data(),
@@ -3125,7 +3143,7 @@ bool make_signed_claim(const char *          alg,
     out->set_allocated_signing_key(psk);
     out->set_signing_algorithm(alg);
     out->set_signature((void *)sig, sig_size);
-  } else if (strcmp(alg, "ecc-384-sha384-pkcs-sign") == 0) {
+  } else if (strcmp(alg, Enc_method_ecc_384_sha384_pkcs_sign) == 0) {
     EC_KEY *k = key_to_ECC(key);
     if (k == nullptr) {
       printf("%s() error, line: %d, make_signed_claim: to_ECC failed\n",
@@ -3136,7 +3154,7 @@ bool make_signed_claim(const char *          alg,
     sig_size = 2 * ECDSA_size(k);
     byte sig[sig_size];
 
-    success = ecc_sign("sha-384",
+    success = ecc_sign(Digest_method_sha_384,
                        k,
                        serialized_claim.size(),
                        (byte *)serialized_claim.data(),
@@ -3155,7 +3173,7 @@ bool make_signed_claim(const char *          alg,
     }
     out->set_allocated_signing_key(psk);
     out->set_signature((void *)sig, sig_size);
-  } else if (strcmp(alg, "ecc-256-sha256-pkcs-sign") == 0) {
+  } else if (strcmp(alg, Enc_method_ecc_256_sha256_pkcs_sign) == 0) {
     EC_KEY *k = key_to_ECC(key);
     if (k == nullptr) {
       printf("%s() error, line: %d, make_signed_claim: to_ECC failed\n",
@@ -3166,7 +3184,7 @@ bool make_signed_claim(const char *          alg,
     sig_size = 2 * ECDSA_size(k);
     byte sig[sig_size];
 
-    success = ecc_sign("sha-256",
+    success = ecc_sign(Digest_method_sha_256,
                        k,
                        serialized_claim.size(),
                        (byte *)serialized_claim.data(),
@@ -3280,7 +3298,8 @@ bool verify_signed_claim(const signed_claim_message &signed_claim,
   }
 
   bool success = false;
-  if (signed_claim.signing_algorithm() == "rsa-2048-sha256-pkcs-sign") {
+  if (signed_claim.signing_algorithm()
+      == Enc_method_rsa_2048_sha256_pkcs_sign) {
     RSA *r = RSA_new();
     if (!key_to_RSA(key, r)) {
       printf("%s() error, line: %d, verify_signed_claim: key_to_RSA failed\n",
@@ -3295,7 +3314,8 @@ bool verify_signed_claim(const signed_claim_message &signed_claim,
         (int)signed_claim.signature().size(),
         (byte *)signed_claim.signature().data());
     RSA_free(r);
-  } else if (signed_claim.signing_algorithm() == "rsa-3072-sha384-pkcs-sign") {
+  } else if (signed_claim.signing_algorithm()
+             == Enc_method_rsa_3072_sha384_pkcs_sign) {
     RSA *r = RSA_new();
     if (!key_to_RSA(key, r)) {
       printf("%s() error, line: %d, verify_signed_claim: key_to_RSA failed\n",
@@ -3303,14 +3323,15 @@ bool verify_signed_claim(const signed_claim_message &signed_claim,
              __LINE__);
       return false;
     }
-    success = rsa_verify("sha-384",
+    success = rsa_verify(Digest_method_sha_384,
                          r,
                          (int)signed_claim.serialized_claim_message().size(),
                          (byte *)signed_claim.serialized_claim_message().data(),
                          (int)signed_claim.signature().size(),
                          (byte *)signed_claim.signature().data());
     RSA_free(r);
-  } else if (signed_claim.signing_algorithm() == "rsa-4096-sha384-pkcs-sign") {
+  } else if (signed_claim.signing_algorithm()
+             == Enc_method_rsa_4096_sha384_pkcs_sign) {
     RSA *r = RSA_new();
     if (!key_to_RSA(key, r)) {
       printf("%s() error, line: %d, verify_signed_claim: key_to_RSA failed\n",
@@ -3318,14 +3339,15 @@ bool verify_signed_claim(const signed_claim_message &signed_claim,
              __LINE__);
       return false;
     }
-    success = rsa_verify("sha-384",
+    success = rsa_verify(Digest_method_sha_384,
                          r,
                          (int)signed_claim.serialized_claim_message().size(),
                          (byte *)signed_claim.serialized_claim_message().data(),
                          (int)signed_claim.signature().size(),
                          (byte *)signed_claim.signature().data());
     RSA_free(r);
-  } else if (signed_claim.signing_algorithm() == "ecc-384-sha384-pkcs-sign") {
+  } else if (signed_claim.signing_algorithm()
+             == Enc_method_ecc_384_sha384_pkcs_sign) {
     EC_KEY *k = key_to_ECC(key);
     if (k == nullptr) {
       printf("%s() error, line: %d, verify_signed_claim: key_to_ECC failed\n",
@@ -3333,19 +3355,20 @@ bool verify_signed_claim(const signed_claim_message &signed_claim,
              __LINE__);
       return false;
     }
-    success = ecc_verify("sha-384",
+    success = ecc_verify(Digest_method_sha_384,
                          k,
                          (int)signed_claim.serialized_claim_message().size(),
                          (byte *)signed_claim.serialized_claim_message().data(),
                          (int)signed_claim.signature().size(),
                          (byte *)signed_claim.signature().data());
     EC_KEY_free(k);
-  } else if (signed_claim.signing_algorithm() == "ecc-256-sha256-pkcs-sign") {
+  } else if (signed_claim.signing_algorithm()
+             == Enc_method_ecc_256_sha256_pkcs_sign) {
     EC_KEY *k = key_to_ECC(key);
     if (k == nullptr) {
       return false;
     }
-    success = ecc_verify("sha-256",
+    success = ecc_verify(Digest_method_sha_256,
                          k,
                          (int)signed_claim.serialized_claim_message().size(),
                          (byte *)signed_claim.serialized_claim_message().data(),
@@ -3539,10 +3562,10 @@ bool certifier::utilities::produce_artifact(key_message &signing_key,
   }
 
   EVP_PKEY *signing_pkey = EVP_PKEY_new();
-  if (signing_key.key_type() == "rsa-1024-private"
-      || signing_key.key_type() == "rsa-2048-private"
-      || signing_key.key_type() == "rsa-3072-private"
-      || signing_key.key_type() == "rsa-4096-private") {
+  if (signing_key.key_type() == Enc_method_rsa_1024_private
+      || signing_key.key_type() == Enc_method_rsa_2048_private
+      || signing_key.key_type() == Enc_method_rsa_3072_private
+      || signing_key.key_type() == Enc_method_rsa_4096_private) {
     RSA *signing_rsa_key = RSA_new();
     if (!key_to_RSA(signing_key, signing_rsa_key)) {
       printf("produce_artifact: can't get rsa signing key\n");
@@ -3552,14 +3575,14 @@ bool certifier::utilities::produce_artifact(key_message &signing_key,
     X509_set_pubkey(x509, signing_pkey);
 
     EVP_PKEY *subject_pkey = EVP_PKEY_new();
-    if (subject_key.key_type() == "rsa-1024-public"
-        || subject_key.key_type() == "rsa-2048-public"
-        || subject_key.key_type() == "rsa-4096-public"
-        || subject_key.key_type() == "rsa-3072-public"
-        || subject_key.key_type() == "rsa-1024-private"
-        || subject_key.key_type() == "rsa-2048-private"
-        || subject_key.key_type() == "rsa-3072-private"
-        || subject_key.key_type() == "rsa-4096-private") {
+    if (subject_key.key_type() == Enc_method_rsa_1024_public
+        || subject_key.key_type() == Enc_method_rsa_2048_public
+        || subject_key.key_type() == Enc_method_rsa_4096_public
+        || subject_key.key_type() == Enc_method_rsa_3072_public
+        || subject_key.key_type() == Enc_method_rsa_1024_private
+        || subject_key.key_type() == Enc_method_rsa_2048_private
+        || subject_key.key_type() == Enc_method_rsa_3072_private
+        || subject_key.key_type() == Enc_method_rsa_4096_private) {
       RSA *subject_rsa_key = RSA_new();
       if (!key_to_RSA(subject_key, subject_rsa_key)) {
         printf("%s() error, line: %d, produce_artifact: can't get rsa subject "
@@ -3571,10 +3594,10 @@ bool certifier::utilities::produce_artifact(key_message &signing_key,
       EVP_PKEY_set1_RSA(subject_pkey, subject_rsa_key);
       X509_set_pubkey(x509, subject_pkey);
       RSA_free(subject_rsa_key);
-    } else if (subject_key.key_type() == "ecc-384-public"
-               || subject_key.key_type() == "ecc-384-private"
-               || subject_key.key_type() == "ecc-256-public"
-               || subject_key.key_type() == "ecc-256-private") {
+    } else if (subject_key.key_type() == Enc_method_ecc_384_public
+               || subject_key.key_type() == Enc_method_ecc_384_private
+               || subject_key.key_type() == Enc_method_ecc_256_public
+               || subject_key.key_type() == Enc_method_ecc_256_private) {
       EC_KEY *subject_ecc_key = key_to_ECC(subject_key);
       if (subject_ecc_key == nullptr) {
         printf(
@@ -3594,8 +3617,8 @@ bool certifier::utilities::produce_artifact(key_message &signing_key,
              subject_key.key_type().c_str());
       return false;
     }
-    if (signing_key.key_type() == "rsa-4096-private"
-        || signing_key.key_type() == "ecc-384-private") {
+    if (signing_key.key_type() == Enc_method_rsa_4096_private
+        || signing_key.key_type() == Enc_method_ecc_384_private) {
       X509_sign(x509, signing_pkey, EVP_sha384());
     } else {
       X509_sign(x509, signing_pkey, EVP_sha256());
@@ -3603,8 +3626,8 @@ bool certifier::utilities::produce_artifact(key_message &signing_key,
     EVP_PKEY_free(signing_pkey);
     EVP_PKEY_free(subject_pkey);
     RSA_free(signing_rsa_key);
-  } else if (signing_key.key_type() == "ecc-384-private"
-             || signing_key.key_type() == "ecc-256-private") {
+  } else if (signing_key.key_type() == Enc_method_ecc_384_private
+             || signing_key.key_type() == Enc_method_ecc_256_private) {
     EC_KEY *signing_ecc_key = key_to_ECC(signing_key);
     if (signing_ecc_key == nullptr) {
       printf("%s() error, line: %d, produce_artifact: can't get signing key\n",
@@ -3617,14 +3640,14 @@ bool certifier::utilities::produce_artifact(key_message &signing_key,
     X509_set_pubkey(x509, signing_pkey);
 
     EVP_PKEY *subject_pkey = EVP_PKEY_new();
-    if (subject_key.key_type() == "rsa-1024-public"
-        || subject_key.key_type() == "rsa-2048-public"
-        || subject_key.key_type() == "rsa-3072-public"
-        || subject_key.key_type() == "rsa-4096-public"
-        || subject_key.key_type() == "rsa-1024-private"
-        || subject_key.key_type() == "rsa-2048-private"
-        || subject_key.key_type() == "rsa-3072-private"
-        || subject_key.key_type() == "rsa-4096-private") {
+    if (subject_key.key_type() == Enc_method_rsa_1024_public
+        || subject_key.key_type() == Enc_method_rsa_2048_public
+        || subject_key.key_type() == Enc_method_rsa_3072_public
+        || subject_key.key_type() == Enc_method_rsa_4096_public
+        || subject_key.key_type() == Enc_method_rsa_1024_private
+        || subject_key.key_type() == Enc_method_rsa_2048_private
+        || subject_key.key_type() == Enc_method_rsa_3072_private
+        || subject_key.key_type() == Enc_method_rsa_4096_private) {
       RSA *subject_rsa_key = RSA_new();
       if (!key_to_RSA(subject_key, subject_rsa_key)) {
         printf("%s() error, line: %d, produce_artifact: can't get rsa subject "
@@ -3636,10 +3659,10 @@ bool certifier::utilities::produce_artifact(key_message &signing_key,
       EVP_PKEY_set1_RSA(subject_pkey, subject_rsa_key);
       X509_set_pubkey(x509, subject_pkey);
       RSA_free(subject_rsa_key);
-    } else if (subject_key.key_type() == "ecc-384-public"
-               || subject_key.key_type() == "ecc-384-private"
-               || subject_key.key_type() == "ecc-256-public"
-               || subject_key.key_type() == "ecc-256-private") {
+    } else if (subject_key.key_type() == Enc_method_ecc_384_public
+               || subject_key.key_type() == Enc_method_ecc_384_private
+               || subject_key.key_type() == Enc_method_ecc_256_public
+               || subject_key.key_type() == Enc_method_ecc_256_private) {
       EC_KEY *subject_ecc_key = key_to_ECC(subject_key);
       if (subject_ecc_key == nullptr) {
         printf(
@@ -3687,14 +3710,14 @@ bool certifier::utilities::verify_artifact(X509 &       cert,
                                            uint64_t *sn) {
 
   bool success = false;
-  if (verify_key.key_type() == "rsa-1024-public"
-      || verify_key.key_type() == "rsa-1024-private"
-      || verify_key.key_type() == "rsa-2048-public"
-      || verify_key.key_type() == "rsa-2048-private"
-      || verify_key.key_type() == "rsa-3072-public"
-      || verify_key.key_type() == "rsa-3072-private"
-      || verify_key.key_type() == "rsa-4096-public"
-      || verify_key.key_type() == "rsa-4096-private") {
+  if (verify_key.key_type() == Enc_method_rsa_1024_public
+      || verify_key.key_type() == Enc_method_rsa_1024_private
+      || verify_key.key_type() == Enc_method_rsa_2048_public
+      || verify_key.key_type() == Enc_method_rsa_2048_private
+      || verify_key.key_type() == Enc_method_rsa_3072_public
+      || verify_key.key_type() == Enc_method_rsa_3072_private
+      || verify_key.key_type() == Enc_method_rsa_4096_public
+      || verify_key.key_type() == Enc_method_rsa_4096_private) {
     EVP_PKEY *verify_pkey = EVP_PKEY_new();
     RSA *     verify_rsa_key = RSA_new();
     if (!key_to_RSA(verify_key, verify_rsa_key))
@@ -3712,10 +3735,10 @@ bool certifier::utilities::verify_artifact(X509 &       cert,
     EVP_PKEY_free(verify_pkey);
     EVP_PKEY_free(subject_pkey);
     // Todo: Make this work
-  } else if (verify_key.key_type() == "ecc-384-public"
-             || verify_key.key_type() == "ecc-384-private"
-             || verify_key.key_type() == "ecc-256-public"
-             || verify_key.key_type() == "ecc-256-private") {
+  } else if (verify_key.key_type() == Enc_method_ecc_384_public
+             || verify_key.key_type() == Enc_method_ecc_384_private
+             || verify_key.key_type() == Enc_method_ecc_256_public
+             || verify_key.key_type() == Enc_method_ecc_256_private) {
     EVP_PKEY *verify_pkey = EVP_PKEY_new();
     EC_KEY *  verify_ecc_key = key_to_ECC(verify_key);
     if (verify_ecc_key == nullptr) {
@@ -3916,16 +3939,16 @@ bool key_from_pkey(EVP_PKEY *pkey, const string &name, key_message *k) {
     }
     switch (size) {
       case 1024:
-        k->set_key_type("rsa-1024-public");
+        k->set_key_type(Enc_method_rsa_1024_public);
         break;
       case 2048:
-        k->set_key_type("rsa-2048-public");
+        k->set_key_type(Enc_method_rsa_2048_public);
         break;
       case 3072:
-        k->set_key_type("rsa-3072-public");
+        k->set_key_type(Enc_method_rsa_3072_public);
         break;
       case 4096:
-        k->set_key_type("rsa-4096-public");
+        k->set_key_type(Enc_method_rsa_4096_public);
         break;
       default:
         return false;
@@ -3941,9 +3964,9 @@ bool key_from_pkey(EVP_PKEY *pkey, const string &name, key_message *k) {
       return false;
     }
     if (size == 384) {
-      k->set_key_type("ecc-384-public");
+      k->set_key_type(Enc_method_ecc_384_public);
     } else if (size == 256) {
-      k->set_key_type("ecc-256-public");
+      k->set_key_type(Enc_method_ecc_256_public);
     } else {
       return false;
     }
@@ -4012,11 +4035,14 @@ key_message *get_issuer_key(X509 *x, cert_keys_seen_list &list) {
 EVP_PKEY *pkey_from_key(const key_message &k) {
   EVP_PKEY *pkey = EVP_PKEY_new();
 
-  if (k.key_type() == "rsa-1024-public" || k.key_type() == "rsa-1024-private"
-      || k.key_type() == "rsa-3072-public" || k.key_type() == "rsa-3072-private"
-      || k.key_type() == "rsa-2048-public" || k.key_type() == "rsa-2048-private"
-      || k.key_type() == "rsa-4096-public"
-      || k.key_type() == "rsa-4096-private") {
+  if (k.key_type() == Enc_method_rsa_1024_public
+      || k.key_type() == Enc_method_rsa_1024_private
+      || k.key_type() == Enc_method_rsa_3072_public
+      || k.key_type() == Enc_method_rsa_3072_private
+      || k.key_type() == Enc_method_rsa_2048_public
+      || k.key_type() == Enc_method_rsa_2048_private
+      || k.key_type() == Enc_method_rsa_4096_public
+      || k.key_type() == Enc_method_rsa_4096_private) {
     RSA *rsa_key = RSA_new();
     if (!key_to_RSA(k, rsa_key)) {
       printf("%s() error, line: %d, pkey_from_key: Can't translate key to RSA "
@@ -4034,10 +4060,10 @@ EVP_PKEY *pkey_from_key(const key_message &k) {
       return nullptr;
     }
     return pkey;
-  } else if (k.key_type() == "ecc-384-public"
-             || k.key_type() == "ecc-384-private"
-             || k.key_type() == "ecc-256-public"
-             || k.key_type() == "ecc-256-private") {
+  } else if (k.key_type() == Enc_method_ecc_384_public
+             || k.key_type() == Enc_method_ecc_384_private
+             || k.key_type() == Enc_method_ecc_256_public
+             || k.key_type() == Enc_method_ecc_256_private) {
     EC_KEY *ecc_key = key_to_ECC(k);
     if (ecc_key == nullptr) {
       EVP_PKEY_free(pkey);
@@ -4073,16 +4099,16 @@ bool x509_to_public_key(X509 *x, key_message *k) {
     }
     switch (size) {
       case 1024:
-        k->set_key_type("rsa-1024-public");
+        k->set_key_type(Enc_method_rsa_1024_public);
         break;
       case 2048:
-        k->set_key_type("rsa-2048-public");
+        k->set_key_type(Enc_method_rsa_2048_public);
         break;
       case 3072:
-        k->set_key_type("rsa-3072-public");
+        k->set_key_type(Enc_method_rsa_3072_public);
         break;
       case 4096:
-        k->set_key_type("rsa-4096-public");
+        k->set_key_type(Enc_method_rsa_4096_public);
         break;
       default:
         printf("%s() error, line: %d, x509_to_public_key: bad key type\n",
@@ -4098,9 +4124,9 @@ bool x509_to_public_key(X509 *x, key_message *k) {
       return false;
     }
     if (size == 384) {
-      k->set_key_type("ecc-384-public");
+      k->set_key_type(Enc_method_ecc_384_public);
     } else if (size == 256) {
-      k->set_key_type("ecc-256-public");
+      k->set_key_type(Enc_method_ecc_256_public);
     } else {
       return false;
     }
@@ -4135,16 +4161,17 @@ bool certifier::utilities::make_root_key_with_cert(string &     type,
                                                    key_message *k) {
   string root_name("root");
 
-  if (type == "rsa-4096-private" || type == "rsa-2048-private"
-      || type == "rsa-3072-private" || type == "rsa-1024-private") {
+  if (type == Enc_method_rsa_4096_private || type == Enc_method_rsa_2048_private
+      || type == Enc_method_rsa_3072_private
+      || type == Enc_method_rsa_1024_private) {
     int n = 2048;
-    if (type == "rsa-2048-private")
+    if (type == Enc_method_rsa_2048_private)
       n = 2048;
-    else if (type == "rsa-1024-private")
+    else if (type == Enc_method_rsa_1024_private)
       n = 1024;
-    else if (type == "rsa-3072-private")
+    else if (type == Enc_method_rsa_3072_private)
       n = 3072;
-    else if (type == "rsa-4096-private")
+    else if (type == Enc_method_rsa_4096_private)
       n = 4096;
 
     if (!make_certifier_rsa_key(n, k))
@@ -4173,7 +4200,7 @@ bool certifier::utilities::make_root_key_with_cert(string &     type,
       return false;
     k->set_certificate((byte *)cert_asn.data(), cert_asn.size());
     X509_free(cert);
-  } else if (type == "ecc-384-private") {
+  } else if (type == Enc_method_ecc_384_private) {
     if (!make_certifier_ecc_key(384, k))
       return false;
     k->set_key_format("vse-key");
@@ -4200,7 +4227,7 @@ bool certifier::utilities::make_root_key_with_cert(string &     type,
       return false;
     k->set_certificate((byte *)cert_asn.data(), cert_asn.size());
     X509_free(cert);
-  } else if (type == "ecc-256-private") {
+  } else if (type == Enc_method_ecc_256_private) {
     if (!make_certifier_ecc_key(256, k))
       return false;
     k->set_key_format("vse-key");

--- a/src/support_tests.cc
+++ b/src/support_tests.cc
@@ -39,7 +39,7 @@ bool test_random(bool print_all) {
 bool test_encrypt(bool print_all) {
   const int   in_size = 2 * block_size;
   const int   out_size = in_size + 128;
-  const char *alg_name = "aes-256-cbc-hmac-sha256";
+  const char *alg_name = Enc_method_aes_256_cbc_hmac_sha256;
   const int   key_size = cipher_key_byte_size(alg_name);
   int         blk_size = cipher_block_byte_size(alg_name);
 
@@ -138,7 +138,7 @@ bool test_authenticated_encrypt(bool print_all) {
     printf("\n");
   }
 
-  if (!authenticated_encrypt("aes-256-cbc-hmac-sha256",
+  if (!authenticated_encrypt(Enc_method_aes_256_cbc_hmac_sha256,
                              plain,
                              in_size,
                              key,
@@ -162,7 +162,7 @@ bool test_authenticated_encrypt(bool print_all) {
     print_bytes(size_encrypt_out, cipher);
     printf("\n");
   }
-  if (!authenticated_decrypt("aes-256-cbc-hmac-sha256",
+  if (!authenticated_decrypt(Enc_method_aes_256_cbc_hmac_sha256,
                              cipher,
                              size_encrypt_out,
                              key,
@@ -198,7 +198,7 @@ bool test_authenticated_encrypt(bool print_all) {
     printf("\n");
   }
 
-  if (!authenticated_encrypt("aes-256-cbc-hmac-sha384",
+  if (!authenticated_encrypt(Enc_method_aes_256_cbc_hmac_sha384,
                              plain,
                              in_size,
                              key,
@@ -222,7 +222,7 @@ bool test_authenticated_encrypt(bool print_all) {
     print_bytes(size_encrypt_out, cipher);
     printf("\n");
   }
-  if (!authenticated_decrypt("aes-256-cbc-hmac-sha384",
+  if (!authenticated_decrypt(Enc_method_aes_256_cbc_hmac_sha384,
                              cipher,
                              size_encrypt_out,
                              key,
@@ -253,7 +253,7 @@ bool test_authenticated_encrypt(bool print_all) {
   size_encrypt_out = out_size;
   size_decrypt_out = out_size;
 
-  if (!authenticated_encrypt("aes-256-gcm",
+  if (!authenticated_encrypt(Enc_method_aes_256_gcm,
                              plain,
                              in_size,
                              key,
@@ -278,7 +278,7 @@ bool test_authenticated_encrypt(bool print_all) {
     print_bytes(size_encrypt_out, cipher);
     printf("\n");
   }
-  if (!authenticated_decrypt("aes-256-gcm",
+  if (!authenticated_decrypt(Enc_method_aes_256_gcm,
                              cipher,
                              size_encrypt_out,
                              key,
@@ -455,7 +455,12 @@ bool test_public_keys(bool print_all) {
     print_bytes(size_data, data);
     printf("\n");
   }
-  if (!ecc_sign("sha-384", ecc_key, size_data, data, &size_out, out)) {
+  if (!ecc_sign(Digest_method_sha_384,
+                ecc_key,
+                size_data,
+                data,
+                &size_out,
+                out)) {
     printf("ecc_sign failed\n");
     printf("Sig size: %d\n", size_out);
     return false;
@@ -465,7 +470,12 @@ bool test_public_keys(bool print_all) {
     print_bytes(size_out, out);
     printf("\n");
   }
-  if (!ecc_verify("sha-384", ecc_key, size_data, data, size_out, out)) {
+  if (!ecc_verify(Digest_method_sha_384,
+                  ecc_key,
+                  size_data,
+                  data,
+                  size_out,
+                  out)) {
     printf("%s() error, line: %d, ecc verify failed\n", __func__, __LINE__);
     return false;
   }
@@ -478,7 +488,7 @@ bool test_public_keys(bool print_all) {
   }
 
   priv_km.set_key_name("test-key");
-  priv_km.set_key_type("ecc-384-private");
+  priv_km.set_key_type(Enc_method_ecc_384_private);
   if (print_all) {
     printf("Key:\n");
     print_key(priv_km);
@@ -533,7 +543,12 @@ bool test_public_keys(bool print_all) {
     print_bytes(size_data, data);
     printf("\n");
   }
-  if (!ecc_sign("sha-256", ecc_key2, size_data, data, &size_out, out)) {
+  if (!ecc_sign(Digest_method_sha_256,
+                ecc_key2,
+                size_data,
+                data,
+                &size_out,
+                out)) {
     printf("%s() error, line: %d, ecc_sign failed, size: %d\n",
            __func__,
            __LINE__,
@@ -547,7 +562,12 @@ bool test_public_keys(bool print_all) {
   }
 #if 1
   // TODO: sometimes this faults
-  if (!ecc_verify("sha-256", ecc_key, size_data, data, size_out, out)) {
+  if (!ecc_verify(Digest_method_sha_256,
+                  ecc_key,
+                  size_data,
+                  data,
+                  size_out,
+                  out)) {
     printf("%s() error, line: %d, ecc_verify failed\n", __func__, __LINE__);
     return false;
   }
@@ -561,7 +581,7 @@ bool test_public_keys(bool print_all) {
   }
 
   priv_km2.set_key_name("test-key");
-  priv_km2.set_key_type("ecc-256-private");
+  priv_km2.set_key_type(Enc_method_ecc_256_private);
   if (print_all) {
     printf("Key:\n");
     print_key(priv_km2);
@@ -623,7 +643,7 @@ bool test_digest(bool print_all) {
   byte         digest[size_digest];
 
   memset(digest, 0, size_digest);
-  if (!digest_message("sha-256",
+  if (!digest_message(Digest_method_sha_256,
                       (const byte *)message,
                       msg_len,
                       digest,
@@ -647,7 +667,7 @@ bool test_digest(bool print_all) {
   const char *message2 = "abc";
   msg_len = 3;
 
-  size_digest = (unsigned int)digest_output_byte_size("sha256");
+  size_digest = (unsigned int)digest_output_byte_size(Digest_method_sha256);
   if (size_digest < 0) {
     printf("%s() error, line: %d, digest size failed, %d\n",
            __func__,
@@ -656,7 +676,7 @@ bool test_digest(bool print_all) {
     return false;
   }
   memset(digest, 0, size_digest);
-  if (!digest_message("sha-256",
+  if (!digest_message(Digest_method_sha_256,
                       (const byte *)message2,
                       msg_len,
                       digest,
@@ -681,13 +701,13 @@ bool test_digest(bool print_all) {
     return false;
   }
 
-  size_digest = (unsigned int)digest_output_byte_size("sha-384");
+  size_digest = (unsigned int)digest_output_byte_size(Digest_method_sha_384);
   if (size_digest < 0) {
     printf("%s() error, line: %d, digest_message failed\n", __func__, __LINE__);
     return false;
   }
   memset(digest, 0, size_digest);
-  if (!digest_message("sha-384",
+  if (!digest_message(Digest_method_sha_384,
                       (const byte *)message2,
                       msg_len,
                       digest,
@@ -708,13 +728,13 @@ bool test_digest(bool print_all) {
     return false;
   }
 
-  size_digest = (unsigned int)digest_output_byte_size("sha-512");
+  size_digest = (unsigned int)digest_output_byte_size(Digest_method_sha_512);
   if (size_digest < 0) {
     printf("%s() error, line: %d, digest_message failed\n", __func__, __LINE__);
     return false;
   }
   memset(digest, 0, size_digest);
-  if (!digest_message("sha-512",
+  if (!digest_message(Digest_method_sha_512,
                       (const byte *)message2,
                       msg_len,
                       digest,

--- a/src/test_support.cc
+++ b/src/test_support.cc
@@ -96,7 +96,10 @@ bool read_trusted_binary_measurements_and_sign(string &     file_name,
                     &claim))
       return false;
     signed_claim_message sc;
-    if (!make_signed_claim("rsa-2048-sha256-pkcs-sign", claim, policy_key, &sc))
+    if (!make_signed_claim(Enc_method_rsa_2048_sha256_pkcs_sign,
+                           claim,
+                           policy_key,
+                           &sc))
       return false;
 
     signed_claim_message *scm = list->add_claims();
@@ -337,7 +340,10 @@ bool construct_standard_evidence_package(
     return false;
 
   signed_claim_message sc1;
-  if (!make_signed_claim("rsa-2048-sha256-pkcs-sign", cl1, *policy_key, &sc1))
+  if (!make_signed_claim(Enc_method_rsa_2048_sha256_pkcs_sign,
+                         cl1,
+                         *policy_key,
+                         &sc1))
     return false;
 
   claim_message cl2;
@@ -351,7 +357,10 @@ bool construct_standard_evidence_package(
     return false;
 
   signed_claim_message sc2;
-  if (!make_signed_claim("rsa-2048-sha256-pkcs-sign", cl2, *policy_key, &sc2))
+  if (!make_signed_claim(Enc_method_rsa_2048_sha256_pkcs_sign,
+                         cl2,
+                         *policy_key,
+                         &sc2))
     return false;
 
   claim_message cl3;
@@ -365,7 +374,10 @@ bool construct_standard_evidence_package(
     return false;
 
   signed_claim_message sc3;
-  if (!make_signed_claim("rsa-2048-sha256-pkcs-sign", cl3, intel_key, &sc3))
+  if (!make_signed_claim(Enc_method_rsa_2048_sha256_pkcs_sign,
+                         cl3,
+                         intel_key,
+                         &sc3))
     return false;
 
   string serialized_what_to_say;
@@ -861,7 +873,10 @@ bool construct_standard_constrained_evidence_package(
     return false;
 
   signed_claim_message sc1;
-  if (!make_signed_claim("rsa-2048-sha256-pkcs-sign", cl1, *policy_key, &sc1))
+  if (!make_signed_claim(Enc_method_rsa_2048_sha256_pkcs_sign,
+                         cl1,
+                         *policy_key,
+                         &sc1))
     return false;
 
   claim_message cl2;
@@ -875,7 +890,10 @@ bool construct_standard_constrained_evidence_package(
     return false;
 
   signed_claim_message sc2;
-  if (!make_signed_claim("rsa-2048-sha256-pkcs-sign", cl2, *policy_key, &sc2))
+  if (!make_signed_claim(Enc_method_rsa_2048_sha256_pkcs_sign,
+                         cl2,
+                         *policy_key,
+                         &sc2))
     return false;
 
   claim_message cl3;
@@ -889,7 +907,10 @@ bool construct_standard_constrained_evidence_package(
     return false;
 
   signed_claim_message sc3;
-  if (!make_signed_claim("rsa-2048-sha256-pkcs-sign", cl3, intel_key, &sc3))
+  if (!make_signed_claim(Enc_method_rsa_2048_sha256_pkcs_sign,
+                         cl3,
+                         intel_key,
+                         &sc3))
     return false;
 
   string serialized_what_to_say;

--- a/src/x509_tests.cc
+++ b/src/x509_tests.cc
@@ -793,7 +793,7 @@ bool test_sev_request(bool print_all) {
   }
 
   signed_claim_message *scm1 = trusted_measurements.add_claims();
-  if (!make_signed_claim("rsa-2048-sha256-pkcs-sign",
+  if (!make_signed_claim(Enc_method_rsa_2048_sha256_pkcs_sign,
                          cm1,
                          policy_private_key,
                          scm1)) {
@@ -838,7 +838,7 @@ bool test_sev_request(bool print_all) {
   }
 
   signed_claim_message *scm2 = trusted_platforms.add_claims();
-  if (!make_signed_claim("rsa-2048-sha256-pkcs-sign",
+  if (!make_signed_claim(Enc_method_rsa_2048_sha256_pkcs_sign,
                          cm2,
                          policy_private_key,
                          scm2)) {

--- a/utilities/cert_utility.cc
+++ b/utilities/cert_utility.cc
@@ -23,7 +23,7 @@ DEFINE_bool(print_all, false, "verbose");
 DEFINE_string(operation, "", "generate policy key and self-signed cert");
 
 DEFINE_string(policy_key_name, "policyKey", "key name");
-DEFINE_string(policy_key_type, "rsa-2048-private", "policy key type");
+DEFINE_string(policy_key_type, Enc_method_rsa_2048_private, "policy key type");
 DEFINE_string(policy_authority_name,
               "policyAuthority",
               "policy authority name");
@@ -33,7 +33,9 @@ DEFINE_string(policy_cert_output_file,
               "policy cert file");
 
 DEFINE_string(platform_key_name, "platformKey", "key name");
-DEFINE_string(platform_key_type, "rsa-2048-private", "platform key type");
+DEFINE_string(platform_key_type,
+              Enc_method_rsa_2048_private,
+              "platform key type");
 DEFINE_string(platform_authority_name,
               "platformAuthority",
               "platform authority name");
@@ -42,7 +44,7 @@ DEFINE_string(platform_key_output_file,
               "platform key file");
 
 DEFINE_string(attest_key_name, "attestKey", "key name");
-DEFINE_string(attest_key_type, "rsa-2048-private", "attest key type");
+DEFINE_string(attest_key_type, Enc_method_rsa_2048_private, "attest key type");
 DEFINE_string(attest_key_output_file, "attest_key_file.bin", "attest key file");
 DEFINE_string(attest_authority_name,
               "attestAuthority",
@@ -53,7 +55,7 @@ DEFINE_string(platform_attest_endorsement,
               "platform attest_endorsement platform key file");
 
 DEFINE_string(key_output_file, "output.bin", "output key file");
-DEFINE_string(key_type, "rsa-2048", "key type");
+DEFINE_string(key_type, Enc_method_rsa_2048, "key type");
 DEFINE_string(key_name, "anonymous", "key name");
 DEFINE_string(cert_output_file, "cert_file.bin", "cert file");
 
@@ -63,9 +65,9 @@ bool generate_test_keys() {
   key_message attest_key;
 
   int n = 2048;
-  if (FLAGS_platform_key_type == "rsa-2048-private")
+  if (FLAGS_platform_key_type == Enc_method_rsa_2048_private)
     n = 2048;
-  else if (FLAGS_platform_key_type == "rsa-1024-private")
+  else if (FLAGS_platform_key_type == Enc_method_rsa_1024_private)
     n = 1024;
   if (!make_certifier_rsa_key(n, &platform_key)) {
     return false;
@@ -81,9 +83,9 @@ bool generate_test_keys() {
     return false;
 
   n = 2048;
-  if (FLAGS_attest_key_type == "rsa-2048-private")
+  if (FLAGS_attest_key_type == Enc_method_rsa_2048_private)
     n = 2048;
-  else if (FLAGS_attest_key_type == "rsa-1024-private")
+  else if (FLAGS_attest_key_type == Enc_method_rsa_1024_private)
     n = 1024;
   if (!make_certifier_rsa_key(n, &attest_key)) {
     return false;
@@ -213,7 +215,7 @@ void test_sig() {
 
 bool generate_key(const string &type, const string &name, key_message *k) {
 
-  if (type == "rsa-1024") {
+  if (type == Enc_method_rsa_1024) {
     RSA *r = RSA_new();
     if (!generate_new_rsa_key(1024, r)) {
       printf("Can't generate rsa key\n");
@@ -223,8 +225,8 @@ bool generate_key(const string &type, const string &name, key_message *k) {
       printf("Can't convert rsa key to key\n");
       return false;
     }
-    k->set_key_type("rsa-1024-private");
-  } else if (type == "rsa-2048") {
+    k->set_key_type(Enc_method_rsa_1024_private);
+  } else if (type == Enc_method_rsa_2048) {
     RSA *r = RSA_new();
     if (!generate_new_rsa_key(2048, r)) {
       printf("Can't generate rsa key\n");
@@ -234,8 +236,8 @@ bool generate_key(const string &type, const string &name, key_message *k) {
       printf("Can't convert rsa key to key\n");
       return false;
     }
-    k->set_key_type("rsa-2048-private");
-  } else if (type == "rsa-3072") {
+    k->set_key_type(Enc_method_rsa_2048_private);
+  } else if (type == Enc_method_rsa_3072) {
     RSA *r = RSA_new();
     if (!generate_new_rsa_key(3072, r)) {
       printf("Can't generate rsa key\n");
@@ -245,8 +247,8 @@ bool generate_key(const string &type, const string &name, key_message *k) {
       printf("Can't convert rsa key to key\n");
       return false;
     }
-    k->set_key_type("rsa-3072-private");
-  } else if (type == "rsa-4096") {
+    k->set_key_type(Enc_method_rsa_3072_private);
+  } else if (type == Enc_method_rsa_4096) {
     RSA *r = RSA_new();
     if (!generate_new_rsa_key(4096, r)) {
       printf("Can't generate rsa key\n");
@@ -256,8 +258,8 @@ bool generate_key(const string &type, const string &name, key_message *k) {
       printf("Can't convert rsa key to key\n");
       return false;
     }
-    k->set_key_type("rsa-4096-private");
-  } else if (type == "ecc-384") {
+    k->set_key_type(Enc_method_rsa_4096_private);
+  } else if (type == Enc_method_ecc_384) {
     EC_KEY *ec = generate_new_ecc_key(384);
     if (ec == nullptr) {
       printf("Can't generate ecc key\n");
@@ -267,7 +269,7 @@ bool generate_key(const string &type, const string &name, key_message *k) {
       printf("Can't convert ecc key to key\n");
       return false;
     }
-    k->set_key_type("ecc-384-private");
+    k->set_key_type(Enc_method_ecc_384_private);
   } else {
     printf("Unknown key type\n");
     return false;

--- a/utilities/key_utility.cc
+++ b/utilities/key_utility.cc
@@ -22,7 +22,7 @@ DEFINE_bool(print_all, false, "verbose");
 
 DEFINE_bool(is_root, false, "verbose");
 DEFINE_string(key_name, "testKey", "key name");
-DEFINE_string(key_type, "rsa-2048-private", "test key type");
+DEFINE_string(key_type, Enc_method_rsa_2048_private, "test key type");
 DEFINE_string(authority_name, "testAuthority", "authority name");
 DEFINE_double(duration, 5.0 * 86400.0 * 365.0, "duration");
 DEFINE_uint64(serial_number, 1, "serial number");
@@ -39,19 +39,19 @@ bool generate_key(const string &name,
                   key_message * pub) {
 
   int n = 0;
-  if (type == "rsa-4096-private") {
+  if (type == Enc_method_rsa_4096_private) {
     if (!make_certifier_rsa_key(4096, priv)) {
       return false;
     }
-  } else if (type == "rsa-2048-private") {
+  } else if (type == Enc_method_rsa_2048_private) {
     if (!make_certifier_rsa_key(2048, priv)) {
       return false;
     }
-  } else if (type == "rsa-1024-private") {
+  } else if (type == Enc_method_rsa_1024_private) {
     if (!make_certifier_rsa_key(1024, priv)) {
       return false;
     }
-  } else if (type == "ecc-384-private") {
+  } else if (type == Enc_method_ecc_384_private) {
     if (!make_certifier_ecc_key(384, priv)) {
       return false;
     }
@@ -84,10 +84,10 @@ int main(int an, char **av) {
   key_message priv;
   key_message pub;
   string      serialized_key;
-  if (strcmp(FLAGS_key_type.c_str(), "rsa-1024-private") == 0
-      || strcmp(FLAGS_key_type.c_str(), "rsa-2048-private") == 0
-      || strcmp(FLAGS_key_type.c_str(), "rsa-4096-private") == 0
-      || strcmp(FLAGS_key_type.c_str(), "ecc-384-private") == 0) {
+  if (strcmp(FLAGS_key_type.c_str(), Enc_method_rsa_1024_private) == 0
+      || strcmp(FLAGS_key_type.c_str(), Enc_method_rsa_2048_private) == 0
+      || strcmp(FLAGS_key_type.c_str(), Enc_method_rsa_4096_private) == 0
+      || strcmp(FLAGS_key_type.c_str(), Enc_method_ecc_384_private) == 0) {
     if (!generate_key(FLAGS_key_name,
                       FLAGS_key_type,
                       FLAGS_authority_name,

--- a/utilities/make_signed_claim_from_vse_clause.cc
+++ b/utilities/make_signed_claim_from_vse_clause.cc
@@ -28,7 +28,9 @@ DEFINE_string(output, "signed_claim.bin", "output file");
 DEFINE_string(private_key_file, "", "signing key");
 DEFINE_double(duration, 24, "validity in hours");
 DEFINE_string(descipt, "", "descriptor");
-DEFINE_string(signing_alg, "rsa-2048-sha256-pkcs-sign", "signing algorithm");
+DEFINE_string(signing_alg,
+              Enc_method_rsa_2048_sha256_pkcs_sign,
+              "signing algorithm");
 
 bool get_clause_from_file(const string &in, vse_clause *cl) {
   int  in_size = file_size(in);

--- a/utilities/measurement_utility.cc
+++ b/utilities/measurement_utility.cc
@@ -46,7 +46,7 @@ int       hash_utility(string &input, string &output) {
     printf("Can't read %s\n", input.c_str());
     return 1;
   }
-  if (!digest_message("sha256", to_hash, in_size, out, out_len)) {
+  if (!digest_message(Digest_method_sha256, to_hash, in_size, out, out_len)) {
     free(to_hash);
     return 1;
   }

--- a/utilities/sample_sev_key_generation.cc
+++ b/utilities/sample_sev_key_generation.cc
@@ -137,8 +137,8 @@ int main(int an, char **av) {
   default_report.platform_version.raw = 0x03000000000008115ULL;
 
   // Generate keys and certs
-  string rsa_type("rsa-4096-private");
-  string ecc_type("ecc-384-private");
+  string rsa_type(Enc_method_rsa_4096_private);
+  string ecc_type(Enc_method_ecc_384_private);
   string ark_name("ARKKey");
   string ask_name("ASKKey");
   string vcek_name("VCEKKey");
@@ -300,7 +300,7 @@ int main(int an, char **av) {
   int  hash_len = 48;
   byte user_data_hash[hash_len];
 
-  if (!digest_message("sha-384",
+  if (!digest_message(Digest_method_sha_384,
                       (byte *)said_str.data(),
                       said_str.size(),
                       user_data_hash,
@@ -317,7 +317,7 @@ int main(int an, char **av) {
 
   int  sig_digest_len = 48;
   byte sig_digest[sig_digest_len];
-  if (!digest_message("sha-384",
+  if (!digest_message(Digest_method_sha_384,
                       (byte *)&default_report,
                       sizeof(attestation_report) - sizeof(signature),
                       sig_digest,

--- a/utilities/simulated_sev_attest.cc
+++ b/utilities/simulated_sev_attest.cc
@@ -149,7 +149,7 @@ int main(int an, char **av) {
     return 1;
   }
   int size_out = sizeof(signature);
-  if (!ecc_sign("sha-384",
+  if (!ecc_sign(Digest_method_sha_384,
                 eck,
                 sizeof(attestation_report) - sizeof(signature),
                 (byte *)&default_report,

--- a/utilities/simulated_sev_key_generation.cc
+++ b/utilities/simulated_sev_key_generation.cc
@@ -74,8 +74,8 @@ int main(int an, char **av) {
          "--vcek_key_file=ec-secp384r1-pub-key.pem\n");
 
   // Generate keys and certs
-  string rsa_type("rsa-4096-private");
-  string ecc_type("ecc-384-private");
+  string rsa_type(Enc_method_rsa_4096_private);
+  string ecc_type(Enc_method_ecc_384_private);
   string ark_name("ARKKey");
   string ask_name("ASKKey");
   string vcek_name("VCEKKey");


### PR DESCRIPTION
 This commit lays down the groundwork to do the replacement of hard-coded algorithm names with string constants.

- Add `CI/scripts/replace_algname.sh`, `algorithm_names_map.dat` mapping file. Script drives off the mapping list
    provided by the dat file to do the replacement in source files.

- Add empty certifier_algorithms.h/.cc files
- Fix some #include lists, so that builds can succeed after replacement script is run.
---

NOTE: To the reviewers: There are 3 commits, just to show the mechanics of how these changes were applied:

1. Core changes, including driver script, just to see what edits were needed to absorb changes from (2)
2. Application of string replacement, done by script. -Plus- clang-format fixes
3. Final manual edit of `src/support.cc` to neaten-up indentation of static string arrays.

Eventually, all commits will be squashed into one single commit.

The important files to review and talk through are:

1. Driver tooling: `scripts/algorithm_names_map.dat` and `CI/scripts/replace_algname.sh`. (These are one-off scripts used only to automate this process. They will not be run in CI in future. I'd like to check them in so we have a record of the tooling used to generate these changes.)
2. `include/certifier_algorithms.h`, and `src/certifier_algorithms.cc`
3. `include/certifier_framework.h` (Changed to now `#include certifier_algorithms.h`)
4. `src/support.cc`: Changed to now `#include certifier_algorithms.cc`. This way all other programs that build with support.cc do not need to explicitly compile and link `certifier_algorithms.o`.