### PR TITLE
(#173) Purge warm-restart as sample-app op. Rename op to 'get-certified'.

### DIFF
--- a/sample_apps/analytics_example/README.md
+++ b/sample_apps/analytics_example/README.md
@@ -156,14 +156,14 @@ On the client's terminal, run
 ```bash
 cd $EXAMPLE_DIR
 ./host/host ./enclave/enclave.signed cold-init $EXAMPLE_DIR/app1_data --simulate
-./host/host ./enclave/enclave.signed get-certifier $EXAMPLE_DIR/app1_data --simulate
+./host/host ./enclave/enclave.signed get-certified $EXAMPLE_DIR/app1_data --simulate
 ```
 
 On the server's terminal, run 
 ```bash
 cd $EXAMPLE_DIR
 ./host/host ./enclave/enclave.signed cold-init $EXAMPLE_DIR/app2_data --simulate
-./host/host ./enclave/enclave.signed get-certifier $EXAMPLE_DIR/app2_data/ --simulate
+./host/host ./enclave/enclave.signed get-certified $EXAMPLE_DIR/app2_data/ --simulate
 ```
 
 Step 11:  Run the apps to test trusted services

--- a/sample_apps/analytics_example/host/host.cc
+++ b/sample_apps/analytics_example/host/host.cc
@@ -93,7 +93,7 @@ int main(int argc, const char *argv[]) {
               result,
               oe_result_str(result));
     }
-  } else if (strcmp(argv[2], "get-certifier") == 0) {
+  } else if (strcmp(argv[2], "get-certified") == 0) {
     result = certify_me(enclave, &ret);
     if (result != OE_OK) {
       fprintf(stderr,

--- a/sample_apps/multidomain_simple_app/instructions.md
+++ b/sample_apps/multidomain_simple_app/instructions.md
@@ -301,7 +301,7 @@ $EXAMPLE_DIR/example_app.exe                       \
 
 $EXAMPLE_DIR/example_app.exe                       \
       --data_dir=./app1_data/                      \
-      --operation=get-certifier                    \
+      --operation=get-certified                    \
       --measurement_file="example_app.measurement" \
       --policy_store_file=policy_store             \
       --print_all=true
@@ -321,7 +321,7 @@ $EXAMPLE_DIR/example_app.exe                       \
 
 $EXAMPLE_DIR/example_app.exe                       \
       --data_dir=./app2_data/                      \
-      --operation=get-certifier                    \
+      --operation=get-certified                    \
       --measurement_file="example_app.measurement" \
       --policy_store_file=policy_store             \
       --print_all=true
@@ -406,7 +406,7 @@ https://github.com/intel/linux-sgx/blob/master/sdk/sign_tool/SignTool/sign_tool.
 
 Other commands that can be run in the app-as-a-client terminal.
 
-The operations are: _cold-init_, _warm-restart_, _get-certifier_ and _run-app-as-client_.
+The operations are: _cold-init_, _get-certified_ and _run-app-as-client_.
 
 **NOTE: --data_dir=./app1_data/** in these examples.
 
@@ -420,14 +420,7 @@ The operations are: _cold-init_, _warm-restart_, _get-certifier_ and _run-app-as
 
 ./example_app.exe                               \
       --data_dir=./app1_data/                   \
-      --operation=warm-restart                  \
-      --policy_cert_file=policy_cert_file.bin   \
-      --policy_store_file=policy_store          \
-      --print_all=true
-
-./example_app.exe                               \
-      --data_dir=./app1_data/                   \
-      --operation=get-certifier                 \
+      --operation=get-certified                 \
       --policy_cert_file=policy_cert_file.bin   \
       --policy_store_file=policy_store          \
       --print_all=true
@@ -458,14 +451,7 @@ example_app.exe                                 \
 
 ./example_app.exe                               \
       --data_dir=./app2_data/                   \
-      --operation=warm-restart                  \
-      --policy_cert_file=policy_cert_file.bin   \
-      --policy_store_file=policy_store          \
-      --print_all=true
-
-./example_app.exe                               \
-      --data_dir=./app2_data/                   \
-      --operation=get-certifier                 \
+      --operation=get-certified                 \
       --policy_cert_file=policy_cert_file.bin   \
       --policy_store_file=policy_store          \
       --print_all=true

--- a/sample_apps/multidomain_simple_app/multidomain_client_app.cc
+++ b/sample_apps/multidomain_simple_app/multidomain_client_app.cc
@@ -34,8 +34,7 @@
 using namespace certifier::framework;
 using namespace certifier::utilities;
 
-// operations are: cold-init, warm-restart, get-certifier, run-app-as-client,
-// run-app-as-server
+// Ops are: cold-init, get-certified, run-app-as-client, run-app-as-server
 DEFINE_bool(print_all, false, "verbose");
 DEFINE_string(operation, "", "operation");
 
@@ -65,9 +64,10 @@ DEFINE_string(measurement_file, "example_app.measurement", "measurement");
 
 // The test app performs five possible roles
 //    cold-init: This creates application keys and initializes the policy store.
-//    warm-restart:  This retrieves the policy store data.
-//    get-certifier: This obtains the app admission cert naming the public app
+//    get-certified: This obtains the app admission cert naming the public app
 //    key from the service. run-app-as-client: This runs the app as a client
+//    warm-restart:  This retrieves the policy store data. Operation is subsumed
+//      under other ops.
 
 #include "client_policy_key.cc"
 cc_trust_data *app_trust_data = nullptr;
@@ -111,8 +111,7 @@ int main(int an, char **av) {
            "--server_app_port=server-host-port\n");
     printf("\t--policy_cert_file=self-signed-policy-cert-file-name "
            "--policy_store_file=policy-store-file-name\n");
-    printf("Operations are: cold-init, warm-restart, get-certifier, "
-           "run-app-as-client\n");
+    printf("Operations are: cold-init, get-certified, run-app-as-client\n");
     return 0;
   }
 
@@ -179,14 +178,7 @@ int main(int an, char **av) {
     }
     // Debug
     app_trust_data->print_trust_data();
-  } else if (FLAGS_operation == "warm-restart") {
-    if (!app_trust_data->warm_restart()) {
-      printf("%s() error, line %d, warm-restart failed\n", __func__, __LINE__);
-      ret = 1;
-      goto done;
-    }
-
-  } else if (FLAGS_operation == "get-certifier") {
+  } else if (FLAGS_operation == "get-certified") {
 
     // Certifier in home domain and server domain
 

--- a/sample_apps/multidomain_simple_app/multidomain_server_app.cc
+++ b/sample_apps/multidomain_simple_app/multidomain_server_app.cc
@@ -32,8 +32,7 @@
 
 using namespace certifier::framework;
 
-// operations are: cold-init, warm-restart, get-certifier, run-app-as-client,
-// run-app-as-server
+// Ops are: cold-init, get-certified, run-app-as-client, run-app-as-server
 DEFINE_bool(print_all, false, "verbose");
 DEFINE_string(operation, "", "operation");
 
@@ -55,10 +54,11 @@ DEFINE_string(measurement_file, "example_app.measurement", "measurement");
 
 // The test app performs five possible roles
 //    cold-init: This creates application keys and initializes the policy store.
-//    warm-restart:  This retrieves the policy store data.
-//    get-certifier: This obtains the app admission cert naming the public app
+//    get-certified: This obtains the app admission cert naming the public app
 //    key from the service. run-app-as-client: This runs the app as a server.
 //    run-app-as-server: This runs the app as a client
+//    warm-restart:  This retrieves the policy store data. Operation is subsumed
+//      under other ops.
 
 #include "server_policy_key.cc"
 cc_trust_data *app_trust_data = nullptr;
@@ -100,8 +100,7 @@ int main(int an, char **av) {
            "--server_app_port=server-host-port\n");
     printf("\t --policy_cert_file=self-signed-policy-cert-file-name "
            "--policy_store_file=policy-store-file-name\n");
-    printf("Operations are: cold-init, warm-restart, get-certifier, "
-           "run-app-as-server\n");
+    printf("Operations are: cold-init, get-certified, run-app-as-server\n");
     return 0;
   }
 
@@ -167,13 +166,7 @@ int main(int an, char **av) {
     }
     // Debug
     app_trust_data->print_trust_data();
-  } else if (FLAGS_operation == "warm-restart") {
-    if (!app_trust_data->warm_restart()) {
-      printf("%s() error, line %d, warm-restart failed\n", __func__, __LINE__);
-      ret = 1;
-    }
-
-  } else if (FLAGS_operation == "get-certifier") {
+  } else if (FLAGS_operation == "get-certified") {
     if (!app_trust_data->warm_restart()) {
       printf("%s() error, line %d, warm-restart failed\n", __func__, __LINE__);
       ret = 1;

--- a/sample_apps/multidomain_simple_app/script
+++ b/sample_apps/multidomain_simple_app/script
@@ -198,7 +198,7 @@ $MULTIDOMAIN_EXAMPLE_DIR/multidomain_server_app.exe --print_all=true \
 # get server app certified
 cd $MULTIDOMAIN_EXAMPLE_DIR
 $MULTIDOMAIN_EXAMPLE_DIR/multidomain_server_app.exe --print_all=true \
-	--operation=get-certifier --data_dir=./app2_data/ \
+	--operation=get-certified --data_dir=./app2_data/ \
 	--measurement_file="multidomain_server_app.measurement" \
 	--policy_store_file=policy_store --policy_port=8121
 
@@ -212,7 +212,7 @@ $MULTIDOMAIN_EXAMPLE_DIR/multidomain_client_app.exe --print_all=true \
 # get client app certified
 cd $MULTIDOMAIN_EXAMPLE_DIR
 $MULTIDOMAIN_EXAMPLE_DIR/multidomain_client_app.exe --print_all=true \
-	--operation=get-certifier --data_dir=./app1_data/ \
+	--operation=get-certified --data_dir=./app1_data/ \
 	--measurement_file="multidomain_client_app.measurement" \
 	--policy_store_file=policy_store \
 	--primary_policy_port=8122 --secondary_policy_port=8121 \

--- a/sample_apps/run_example.sh
+++ b/sample_apps/run_example.sh
@@ -1848,7 +1848,7 @@ function run_app_by_name_as_server_talk_to_Cert_Service() {
 
     run_cmd "${EXAMPLE_DIR}/${app_name_exe}"                    \
                 --data_dir="./${Srvr_app_data}/"                \
-                --operation=get-certifier                       \
+                --operation=get-certified                       \
                 --measurement_file="example_app.measurement"    \
                 --policy_store_file=policy_store                \
                 --print_all=true
@@ -1870,7 +1870,7 @@ function run_simple_app_under_oe_as_server_talk_to_Cert_Service() {
 
     run_cmd ./host/host                             \
                 enclave/enclave.signed              \
-                get-certifier                       \
+                get-certified                       \
                 "${EXAMPLE_DIR}"/${Srvr_app_data}
 
     run_popd
@@ -1896,7 +1896,7 @@ function run_simple_app_under_gramine_as_server_talk_to_Cert_Service() {
 
     run_cmd gramine-sgx gramine_example_app         \
                 --data_dir="./${Srvr_app_data}/"    \
-                --operation=get-certifier           \
+                --operation=get-certified           \
                 --policy_store_file=policy_store    \
                 --print_all=true || 0
 
@@ -1916,7 +1916,7 @@ function run_simple_app_under_sev_as_server_talk_to_Cert_Service() {
 
     run_cmd "${EXAMPLE_DIR}"/sev_example_app.exe    \
                 --data_dir="./${Srvr_app_data}/"    \
-                --operation=get-certifier           \
+                --operation=get-certified           \
                 --policy_store_file=policy_store    \
                 --print_all=true
 
@@ -1969,7 +1969,7 @@ function run_app_by_name_as_client_talk_to_Cert_Service() {
 
     run_cmd "${EXAMPLE_DIR}/${app_name_exe}"                    \
                 --data_dir="./${Client_app_data}/"              \
-                --operation=get-certifier                       \
+                --operation=get-certified                       \
                 --measurement_file="example_app.measurement"    \
                 --policy_store_file=policy_store                \
                 --print_all=true
@@ -1991,7 +1991,7 @@ function run_simple_app_under_oe_as_client_talk_to_Cert_Service() {
 
     run_cmd ./host/host                             \
                 enclave/enclave.signed              \
-                get-certifier                       \
+                get-certified                       \
                 "${EXAMPLE_DIR}"/${Client_app_data}
 
     run_popd
@@ -2012,7 +2012,7 @@ function run_simple_app_under_gramine_as_client_talk_to_Cert_Service() {
 
     run_cmd gramine-sgx gramine_example_app         \
                 --data_dir="./${Client_app_data}/"  \
-                --operation=get-certifier           \
+                --operation=get-certified           \
                 --policy_store_file=policy_store    \
                 --print_all=true || 0
 
@@ -2035,7 +2035,7 @@ function run_simple_app_under_sev_as_client_talk_to_Cert_Service() {
 
     run_cmd "${EXAMPLE_DIR}"/sev_example_app.exe    \
                 --data_dir="./${Client_app_data}/"  \
-                --operation=get-certifier           \
+                --operation=get-certified           \
                 --policy_store_file=policy_store    \
                 --print_all=true
     run_popd
@@ -2597,7 +2597,7 @@ function run_simple_app_under_app_service_as_server_talk_to_Cert_Service() {
 
     run_cmd "${EXAMPLE_DIR}"/start_program.exe                              \
             --executable="${EXAMPLE_DIR}"/service_example_app.exe   \
-            --args="--print_all=true,--operation=get-certifier,--data_dir=${EXAMPLE_DIR}/${Srvr_app_data}/,--measurement_file=example_app.measurement,--policy_store_file=policy_store,--parent_enclave=simulated-enclave"
+            --args="--print_all=true,--operation=get-certified,--data_dir=${EXAMPLE_DIR}/${Srvr_app_data}/,--measurement_file=example_app.measurement,--policy_store_file=policy_store,--parent_enclave=simulated-enclave"
 
     run_popd
 }
@@ -2619,7 +2619,7 @@ function run_simple_app_under_app_service_as_client_talk_to_Cert_Service() {
 
     run_cmd "${EXAMPLE_DIR}"/start_program.exe                              \
             --executable="${EXAMPLE_DIR}"/service_example_app.exe   \
-            --args="--print_all=true,--operation=get-certifier,--data_dir=${EXAMPLE_DIR}/${Client_app_data}/,--measurement_file=example_app.measurement,--policy_store_file=policy_store,--parent_enclave=simulated-enclave"
+            --args="--print_all=true,--operation=get-certified,--data_dir=${EXAMPLE_DIR}/${Client_app_data}/,--measurement_file=example_app.measurement,--policy_store_file=policy_store,--parent_enclave=simulated-enclave"
 
     run_popd
 }

--- a/sample_apps/simple_app/example_app.cc
+++ b/sample_apps/simple_app/example_app.cc
@@ -32,8 +32,7 @@
 
 using namespace certifier::framework;
 
-// operations are: cold-init, warm-restart, get-certifier, run-app-as-client,
-// run-app-as-server
+// Ops are: cold-init, get-certified, run-app-as-client, run-app-as-server
 DEFINE_bool(print_all, false, "verbose");
 DEFINE_string(operation, "", "operation");
 
@@ -55,10 +54,11 @@ DEFINE_string(measurement_file, "example_app.measurement", "measurement");
 
 // The test app performs five possible roles
 //    cold-init: This creates application keys and initializes the policy store.
-//    warm-restart:  This retrieves the policy store data.
-//    get-certifier: This obtains the app admission cert naming the public app
+//    get-certified: This obtains the app admission cert naming the public app
 //    key from the service. run-app-as-client: This runs the app as a client.
 //    run-app-as-server: This runs the app as server.
+//    warm-restart:  This retrieves the policy store data. Operation is subsumed
+//      under other ops.
 
 #include "policy_key.cc"
 cc_trust_data *app_trust_data = nullptr;
@@ -120,7 +120,7 @@ int main(int an, char **av) {
            "--server_app_port=server-host-port\n");
     printf("\t --policy_cert_file=self-signed-policy-cert-file-name "
            "--policy_store_file=policy-store-file-name\n");
-    printf("Operations are: cold-init, warm-restart, get-certifier, "
+    printf("Operations are: cold-init, get-certified, "
            "run-app-as-client, run-app-as-server\n");
     return 0;
   }
@@ -188,14 +188,7 @@ int main(int an, char **av) {
     }
     // Debug
     app_trust_data->print_trust_data();
-  } else if (FLAGS_operation == "warm-restart") {
-    if (!app_trust_data->warm_restart()) {
-      printf("%s() error, line %d, warm-restart failed\n", __func__, __LINE__);
-      ret = 1;
-      goto done;
-    }
-
-  } else if (FLAGS_operation == "get-certifier") {
+  } else if (FLAGS_operation == "get-certified") {
     if (!app_trust_data->warm_restart()) {
       printf("%s() error, line %d, warm-restart failed\n", __func__, __LINE__);
       ret = 1;

--- a/sample_apps/simple_app/example_key_rotation.cc
+++ b/sample_apps/simple_app/example_key_rotation.cc
@@ -34,8 +34,7 @@
 using namespace certifier::framework;
 using namespace certifier::utilities;
 
-// operations are: cold-init, warm-restart, get-certifier, run-app-as-client,
-// run-app-as-server
+// Ops are: cold-init, get-certified, run-app-as-client, run-app-as-server
 DEFINE_bool(print_all, false, "verbose");
 DEFINE_string(operation, "", "operation");
 
@@ -119,12 +118,6 @@ int main(int an, char **av) {
   }
 
   int ret = 0;
-  if (FLAGS_operation == "warm-restart") {
-    if (!app_trust_data->warm_restart()) {
-      printf("%s() error, line %d, warm-restart failed\n", __func__, __LINE__);
-      ret = 1;
-    }
-  }
 
   // Get certificate
   string der_cert;

--- a/sample_apps/simple_app/instructions.md
+++ b/sample_apps/simple_app/instructions.md
@@ -286,7 +286,7 @@ $EXAMPLE_DIR/example_app.exe                       \
 
 $EXAMPLE_DIR/example_app.exe                       \
       --data_dir=./app1_data/                      \
-      --operation=get-certifier                    \
+      --operation=get-certified                    \
       --measurement_file="example_app.measurement" \
       --policy_store_file=policy_store             \
       --print_all=true
@@ -306,7 +306,7 @@ $EXAMPLE_DIR/example_app.exe                       \
 
 $EXAMPLE_DIR/example_app.exe                       \
       --data_dir=./app2_data/                      \
-      --operation=get-certifier                    \
+      --operation=get-certified                    \
       --measurement_file="example_app.measurement" \
       --policy_store_file=policy_store             \
       --print_all=true
@@ -391,7 +391,7 @@ https://github.com/intel/linux-sgx/blob/master/sdk/sign_tool/SignTool/sign_tool.
 
 Other commands that can be run in the app-as-a-client terminal.
 
-The operations are: _cold-init_, _warm-restart_, _get-certifier_ and _run-app-as-client_.
+The operations are: _cold-init_, _get-certified_ and _run-app-as-client_.
 
 **NOTE: --data_dir=./app1_data/** in these examples.
 
@@ -405,14 +405,7 @@ The operations are: _cold-init_, _warm-restart_, _get-certifier_ and _run-app-as
 
 ./example_app.exe                               \
       --data_dir=./app1_data/                   \
-      --operation=warm-restart                  \
-      --policy_cert_file=policy_cert_file.bin   \
-      --policy_store_file=policy_store          \
-      --print_all=true
-
-./example_app.exe                               \
-      --data_dir=./app1_data/                   \
-      --operation=get-certifier                 \
+      --operation=get-certified                 \
       --policy_cert_file=policy_cert_file.bin   \
       --policy_store_file=policy_store          \
       --print_all=true
@@ -443,14 +436,7 @@ example_app.exe                                 \
 
 ./example_app.exe                               \
       --data_dir=./app2_data/                   \
-      --operation=warm-restart                  \
-      --policy_cert_file=policy_cert_file.bin   \
-      --policy_store_file=policy_store          \
-      --print_all=true
-
-./example_app.exe                               \
-      --data_dir=./app2_data/                   \
-      --operation=get-certifier                 \
+      --operation=get-certified                 \
       --policy_cert_file=policy_cert_file.bin   \
       --policy_store_file=policy_store          \
       --print_all=true

--- a/sample_apps/simple_app/script
+++ b/sample_apps/simple_app/script
@@ -102,7 +102,7 @@ $EXAMPLE_DIR/example_app.exe --print_all=true \
       --policy_store_file=policy_store
 # get client app certified
 $EXAMPLE_DIR/example_app.exe --print_all=true \
-      --operation=get-certifier --data_dir=./app1_data/ --measurement_file="example_app.measurement" \
+      --operation=get-certified --data_dir=./app1_data/ --measurement_file="example_app.measurement" \
       --policy_store_file=policy_store
 
 # initialize server app
@@ -111,7 +111,7 @@ $EXAMPLE_DIR/example_app.exe --print_all=true \
       --policy_store_file=policy_store
 # get server app certified
 $EXAMPLE_DIR/example_app.exe --print_all=true \
-      --operation=get-certifier --data_dir=./app2_data/ --measurement_file="example_app.measurement" \
+      --operation=get-certified --data_dir=./app2_data/ --measurement_file="example_app.measurement" \
        --policy_store_file=policy_store
 
 #run the app

--- a/sample_apps/simple_app_under_app_service/instructions.md
+++ b/sample_apps/simple_app_under_app_service/instructions.md
@@ -444,7 +444,7 @@ $SERVICE_EXAMPLE_DIR/start_program.exe                              \
 
 $SERVICE_EXAMPLE_DIR/start_program.exe                              \
         --executable=$SERVICE_EXAMPLE_DIR/service_example_app.exe   \
-        --args="--print_all=true,--operation=get-certifier,--data_dir=./app1_data/,--measurement_file=example_app.measurement,--policy_store_file=policy_store"
+        --args="--print_all=true,--operation=get-certified,--data_dir=./app1_data/,--measurement_file=example_app.measurement,--policy_store_file=policy_store"
 
 $SERVICE_EXAMPLE_DIR/start_program.exe                              \
         --executable=$SERVICE_EXAMPLE_DIR/service_example_app.exe   \
@@ -452,7 +452,7 @@ $SERVICE_EXAMPLE_DIR/start_program.exe                              \
 
 $SERVICE_EXAMPLE_DIR/start_program.exe                              \
         --executable=$SERVICE_EXAMPLE_DIR/service_example_app.exe   \
-        --args="--print_all=true,--operation=get-certifier,--data_dir=./app2_data/,--measurement_file=example_app.measurement,--policy_store_file=policy_store"
+        --args="--print_all=true,--operation=get-certified,--data_dir=./app2_data/,--measurement_file=example_app.measurement,--policy_store_file=policy_store"
 ```
 
 

--- a/sample_apps/simple_app_under_app_service/script
+++ b/sample_apps/simple_app_under_app_service/script
@@ -164,7 +164,7 @@ arg1_str="--print_all=true,--operation=cold-init,--data_dir="$SERVICE_EXAMPLE_DI
 $SERVICE_EXAMPLE_DIR/start_program.exe --executable=$SERVICE_EXAMPLE_DIR/service_example_app.exe \
     --args=\"$arg1_str\"
 
-arg2_str="--print_all=true,--operation=get-certifier,--data_dir="$SERVICE_EXAMPLE_DIR"/app1_data/,--measurement_file=service_example_app.measurement,--policy_store_file=policy_store"
+arg2_str="--print_all=true,--operation=get-certified,--data_dir="$SERVICE_EXAMPLE_DIR"/app1_data/,--measurement_file=service_example_app.measurement,--policy_store_file=policy_store"
 
 $SERVICE_EXAMPLE_DIR/start_program.exe --executable=$SERVICE_EXAMPLE_DIR/service_example_app.exe \
     --args=\"$arg2_str\"
@@ -174,7 +174,7 @@ arg3_str="--print_all=true,--operation=cold-init,--data_dir="$SERVICE_EXAMPLE_DI
 $SERVICE_EXAMPLE_DIR/start_program.exe --executable=$SERVICE_EXAMPLE_DIR/service_example_app.exe \
     --args=\"$arg3_str\"
 
-arg4_str="--print_all=true,--operation=get-certifier,--data_dir="$SERVICE_EXAMPLE_DIR"/app2_data/,--measurement_file=service_example_app.measurement,--policy_store_file=policy_store"
+arg4_str="--print_all=true,--operation=get-certified,--data_dir="$SERVICE_EXAMPLE_DIR"/app2_data/,--measurement_file=service_example_app.measurement,--policy_store_file=policy_store"
 
 $SERVICE_EXAMPLE_DIR/start_program.exe --executable=$SERVICE_EXAMPLE_DIR/service_example_app.exe \
     --args=\"$arg4_str\"
@@ -190,10 +190,4 @@ arg6_str="--print_all=true,--operation=run-app-as-client,--data_dir="$SERVICE_EX
 
 $SERVICE_EXAMPLE_DIR/start_program.exe --executable=$SERVICE_EXAMPLE_DIR/service_example_app.exe \
     --args=\"$arg6_str\"
-
-
-arg7_str="--print_all=true,--operation=warm-restart,--data_dir="$SERVICE_EXAMPLE_DIR"/app1_data/,--measurement_file=service_example_app.measurement,--policy_store_file=policy_store"
-
-$SERVICE_EXAMPLE_DIR/start_program.exe --executable=$SERVICE_EXAMPLE_DIR/service_example_app.exe \
-    --args=\"$arg7_str\"
 

--- a/sample_apps/simple_app_under_app_service/service_example_app.cc
+++ b/sample_apps/simple_app_under_app_service/service_example_app.cc
@@ -34,8 +34,7 @@
 using namespace certifier::framework;
 using namespace certifier::utilities;
 
-// operations are: cold-init, warm-restart, get-certifier, run-app-as-client,
-// run-app-as-server
+// Ops are: cold-init, get-certified, run-app-as-client, run-app-as-server
 DEFINE_bool(print_all, false, "verbose");
 DEFINE_string(operation, "", "operation");
 DEFINE_string(parent_enclave, "simulatd-enclave", "parent enclave");
@@ -58,10 +57,11 @@ DEFINE_string(measurement_file, "example_app.measurement", "measurement");
 
 // The test app performs five possible roles
 //    cold-init: This creates application keys and initializes the policy store.
-//    warm-restart:  This retrieves the policy store data.
-//    get-certifier: This obtains the app admission cert naming the public app
+//    get-certified: This obtains the app admission cert naming the public app
 //    key from the service. run-app-as-client: This runs the app as a server.
 //    run-app-as-server: This runs the app as a client
+//    warm-restart:  This retrieves the policy store data. Operation is subsumed
+//      under other ops.
 
 #include "policy_key.cc"
 cc_trust_data *app_trust_data = nullptr;
@@ -148,7 +148,7 @@ int main(int an, char **av) {
            "--server_app_port=server-host-port\n");
     printf("\t --policy_cert_file=self-signed-policy-cert-file-name "
            "--policy_store_file=policy-store-file-name\n");
-    printf("Operations are: cold-init, warm-restart, get-certifier, "
+    printf("Operations are: cold-init, get-certified, "
            "run-app-as-client, run-app-as-server\n");
     return 0;
   }
@@ -203,14 +203,7 @@ int main(int an, char **av) {
       ret = 1;
       goto done;
     }
-  } else if (FLAGS_operation == "warm-restart") {
-    if (!app_trust_data->warm_restart()) {
-      printf("%s() error, line %d, warm-restart failed\n", __func__, __LINE__);
-      ret = 1;
-      goto done;
-    }
-
-  } else if (FLAGS_operation == "get-certifier") {
+  } else if (FLAGS_operation == "get-certified") {
     if (!app_trust_data->warm_restart()) {
       printf("%s() error, line %d, warm-restart failed\n", __func__, __LINE__);
       ret = 1;
@@ -275,7 +268,6 @@ int main(int an, char **av) {
       ret = 1;
       goto done;
     }
-
 
     printf("running as server\n");
     server_dispatch(FLAGS_server_app_host,

--- a/sample_apps/simple_app_under_gramine/gramine_example_app.cc
+++ b/sample_apps/simple_app_under_gramine/gramine_example_app.cc
@@ -28,8 +28,7 @@
 using namespace certifier::framework;
 using namespace certifier::utilities;
 
-// operations are: cold-init, warm-restart, get-certifier, run-app-as-client,
-// run-app-as-server
+// Ops are: cold-init, get-certified, run-app-as-client, run-app-as-server
 DEFINE_bool(print_all, false, "verbose");
 DEFINE_string(operation, "", "operation");
 
@@ -45,10 +44,11 @@ DEFINE_string(gramine_cert_file, "sgx.cert.der", "certificate file name");
 
 // The test app performs five possible roles
 //    cold-init: This creates application keys and initializes the policy store.
-//    warm-restart:  This retrieves the policy store data.
-//    get-certifier: This obtains the app admission cert naming the public app
+//    get-certified: This obtains the app admission cert naming the public app
 //    key from the service. run-app-as-client: This runs the app as a server.
 //    run-app-as-server: This runs the app as a client
+//    warm-restart:  This retrieves the policy store data. Operation is subsumed
+//      under other ops.
 
 #include "policy_key.cc"
 cc_trust_data *app_trust_data = nullptr;
@@ -120,7 +120,7 @@ int main(int an, char **av) {
     printf("\t --policy_cert_file=self-signed-policy-cert-file-name "
            "--policy_store_file=policy-store-file-name\n");
     printf("\t --gramine_cert_file=sgx.cert.der\n");
-    printf("Operations are: cold-init, warm-restart, get-certifier, "
+    printf("Operations are: cold-init, get-certified, "
            "run-app-as-client, run-app-as-server\n");
     return 0;
   }
@@ -196,13 +196,7 @@ int main(int an, char **av) {
       printf("%s() error, line %d, cold-init failed\n", __func__, __LINE__);
       ret = 1;
     }
-  } else if (FLAGS_operation == "warm-restart") {
-    if (!app_trust_data->warm_restart()) {
-      printf("%s() error, line %d, warm-restart failed\n", __func__, __LINE__);
-      ret = 1;
-    }
-
-  } else if (FLAGS_operation == "get-certifier") {
+  } else if (FLAGS_operation == "get-certified") {
     if (!app_trust_data->warm_restart()) {
       printf("%s() error, line %d, warm-restart failed\n", __func__, __LINE__);
       ret = 1;

--- a/sample_apps/simple_app_under_gramine/instructions.md
+++ b/sample_apps/simple_app_under_gramine/instructions.md
@@ -410,7 +410,7 @@ gramine-sgx gramine_example_app         \
 
 gramine-sgx gramine_example_app         \
     --data_dir=./app2_data/             \
-    --operation=get-certifier           \
+    --operation=get-certified           \
     --policy_store_file=policy_store
     --print_all=true
 ```
@@ -428,7 +428,7 @@ gramine-sgx gramine_example_app         \
 
 gramine-sgx gramine_example_app         \
     --data_dir=./app1_data/             \
-    --operation=get-certifier           \
+    --operation=get-certified           \
     --policy_store_file=policy_store    \
     --print_all=true
 ```

--- a/sample_apps/simple_app_under_gramine/script
+++ b/sample_apps/simple_app_under_gramine/script
@@ -82,7 +82,7 @@ gramine-sgx gramine_example_app --print_all=true \
       --operation=cold-init --data_dir=./app1_data/ --policy_store_file=policy_store
 # get client app certified
 gramine-sgx gramine_example_app --print_all=true \
-      --operation=get-certifier --data_dir=./app1_data/ --policy_store_file=policy_store
+      --operation=get-certified --data_dir=./app1_data/ --policy_store_file=policy_store
 
 # initialize server app
 cd $GRAMINE_EXAMPLE_DIR
@@ -90,7 +90,7 @@ gramine-sgx gramine_example_app --print_all=true \
       --operation=cold-init --data_dir=./app2_data/ --policy_store_file=policy_store
 # get server app certified
 gramine-sgx gramine_example_app --print_all=true \
-      --operation=get-certifier --data_dir=./app2_data/ --policy_store_file=policy_store
+      --operation=get-certified --data_dir=./app2_data/ --policy_store_file=policy_store
 
 # Run the apps to test trusted services
 # In app as a server terminal run the following:

--- a/sample_apps/simple_app_under_islet/instructions.md
+++ b/sample_apps/simple_app_under_islet/instructions.md
@@ -276,7 +276,7 @@ $EXAMPLE_DIR/islet_example_app.exe                       \
 
 $EXAMPLE_DIR/islet_example_app.exe                       \
       --data_dir=./app2_data/                      \
-      --operation=get-certifier                    \
+      --operation=get-certified                    \
       --measurement_file="example_app.measurement" \
       --policy_store_file=policy_store             \
       --print_all=true
@@ -296,7 +296,7 @@ $EXAMPLE_DIR/islet_example_app.exe                       \
 
 $EXAMPLE_DIR/islet_example_app.exe                       \
       --data_dir=./app1_data/                      \
-      --operation=get-certifier                    \
+      --operation=get-certified                    \
       --measurement_file="example_app.measurement" \
       --policy_store_file=policy_store             \
       --print_all=true

--- a/sample_apps/simple_app_under_islet/islet_example_app.cc
+++ b/sample_apps/simple_app_under_islet/islet_example_app.cc
@@ -32,8 +32,7 @@
 
 using namespace certifier::framework;
 
-// operations are: cold-init, warm-restart, get-certifier, run-app-as-client,
-// run-app-as-server
+// Ops are: cold-init, get-certified, run-app-as-client, run-app-as-server
 DEFINE_bool(print_all, false, "verbose");
 DEFINE_string(operation, "", "operation");
 
@@ -55,10 +54,11 @@ DEFINE_string(measurement_file, "example_app.measurement", "measurement");
 
 // The test app performs five possible roles
 //    cold-init: This creates application keys and initializes the policy store.
-//    warm-restart:  This retrieves the policy store data.
-//    get-certifier: This obtains the app admission cert from the service,
+//    get-certified: This obtains the app admission cert from the service,
 //    naming the public app key. run-app-as-client: This runs the app as a
 //    server. run-app-as-server: This runs the app as a client
+//    warm-restart:  This retrieves the policy store data. Operation is subsumed
+//      under other ops.
 
 #include "policy_key.cc"  // generated file
 
@@ -127,7 +127,7 @@ int main(int an, char **av) {
                       --policy_cert_file=self-signed-policy-cert-file-name \n\
                       --policy_store_file=policy-store-file-name\n\n",
            av[0]);
-    printf("Operations are: cold-init, warm-restart, get-certifier, "
+    printf("Operations are: cold-init, get-certified, "
            "run-app-as-client, run-app-as-server\n");
     return 0;
   }
@@ -189,14 +189,7 @@ int main(int an, char **av) {
       ret = 1;
       goto done;
     }
-  } else if (FLAGS_operation == "warm-restart") {
-    if (!app_trust_data->warm_restart()) {
-      printf("%s() error, line %d, warm-restart failed\n", __func__, __LINE__);
-      ret = 1;
-      goto done;
-    }
-
-  } else if (FLAGS_operation == "get-certifier") {
+  } else if (FLAGS_operation == "get-certified") {
     if (!app_trust_data->warm_restart()) {
       printf("%s() error, line %d, warm-restart failed\n", __func__, __LINE__);
       ret = 1;

--- a/sample_apps/simple_app_under_islet/script
+++ b/sample_apps/simple_app_under_islet/script
@@ -147,7 +147,7 @@ sleep 5
 
 # Get client app certified (need to build libislet_sdk.so)
 $ISLET_EXAMPLE_DIR/islet_example_app.exe --print_all=true \
-      --operation=get-certifier --data_dir=./app1_data/ --measurement_file="example_app.measurement" \
+      --operation=get-certified --data_dir=./app1_data/ --measurement_file="example_app.measurement" \
       --policy_store_file=policy_store
 
 sleep 5
@@ -161,7 +161,7 @@ sleep 5
 
 # Get server app certified
 $ISLET_EXAMPLE_DIR/islet_example_app.exe --print_all=true \
-      --operation=get-certifier --data_dir=./app2_data/ --measurement_file="example_app.measurement" \
+      --operation=get-certified --data_dir=./app2_data/ --measurement_file="example_app.measurement" \
       --policy_store_file=policy_store
 
 sleep 5

--- a/sample_apps/simple_app_under_keystone/keystone_example_app.cc
+++ b/sample_apps/simple_app_under_keystone/keystone_example_app.cc
@@ -32,8 +32,7 @@
 
 using namespace certifier::framework;
 
-// operations are: cold-init, warm-restart, get-certifier, run-app-as-client,
-// run-app-as-server
+// Ops are: cold-init, get-certified, run-app-as-client, run-app-as-server
 DEFINE_bool(print_all, false, "verbose");
 DEFINE_string(operation, "", "operation");
 
@@ -55,10 +54,11 @@ DEFINE_string(measurement_file, "example_app.measurement", "measurement");
 
 // The test app performs five possible roles
 //    cold-init: This creates application keys and initializes the policy store.
-//    warm-restart:  This retrieves the policy store data.
-//    get-certifier: This obtains the app admission cert naming the public app
+//    get-certified: This obtains the app admission cert naming the public app
 //    key from the service. run-app-as-client: This runs the app as a server.
 //    run-app-as-server: This runs the app as a client
+//    warm-restart:  This retrieves the policy store data. Operation is subsumed
+//      under other ops.
 
 #include "policy_key.cc"
 cc_trust_data *app_trust_data = nullptr;
@@ -122,7 +122,7 @@ int main(int an, char **av) {
            "--server_app_port=server-host-port\n");
     printf("\t --policy_cert_file=self-signed-policy-cert-file-name "
            "--policy_store_file=policy-store-file-name\n");
-    printf("Operations are: cold-init, warm-restart, get-certifier, "
+    printf("Operations are: cold-init, get-certified, "
            "run-app-as-client, run-app-as-server\n");
     return 0;
   }
@@ -186,14 +186,7 @@ int main(int an, char **av) {
       ret = 1;
       goto done;
     }
-  } else if (FLAGS_operation == "warm-restart") {
-    if (!app_trust_data->warm_restart()) {
-      printf("%s() error, line %d, warm-restart failed\n", __func__, __LINE__);
-      ret = 1;
-      goto done;
-    }
-
-  } else if (FLAGS_operation == "get-certifier") {
+  } else if (FLAGS_operation == "get-certified") {
     if (!app_trust_data->warm_restart()) {
       printf("%s() error, line %d, warm-restart failed\n", __func__, __LINE__);
       ret = 1;

--- a/sample_apps/simple_app_under_keystone/script
+++ b/sample_apps/simple_app_under_keystone/script
@@ -137,7 +137,7 @@ sleep 5
 
 # get client app certified
 $KEYSTONE_EXAMPLE_DIR/keystone_example_app.exe --print_all=true \
-      --operation=get-certifier --data_dir=./app1_data/ --measurement_file="example_app.measurement" \
+      --operation=get-certified --data_dir=./app1_data/ --measurement_file="example_app.measurement" \
       --policy_store_file=policy_store
 
 sleep 5
@@ -151,7 +151,7 @@ sleep 5
 
 # get server app certified
 $KEYSTONE_EXAMPLE_DIR/keystone_example_app.exe --print_all=true \
-      --operation=get-certifier --data_dir=./app2_data/ --measurement_file="example_app.measurement" \
+      --operation=get-certified --data_dir=./app2_data/ --measurement_file="example_app.measurement" \
        --policy_store_file=policy_store
 
 sleep 5

--- a/sample_apps/simple_app_under_oe/host/host.cc
+++ b/sample_apps/simple_app_under_oe/host/host.cc
@@ -112,7 +112,7 @@ int main(int argc, const char *argv[]) {
               result,
               oe_result_str(result));
     }
-  } else if (strcmp(argv[2], "get-certifier") == 0) {
+  } else if (strcmp(argv[2], "get-certified") == 0) {
     result = certify_me(enclave, &ret);
     printf("certify_me(): result=%d, ret=%d\n", result, ret);
     if (result != OE_OK) {

--- a/sample_apps/simple_app_under_oe/instructions.md
+++ b/sample_apps/simple_app_under_oe/instructions.md
@@ -266,7 +266,7 @@ In app-as-a-client terminal run the following:
 ```shell
 cd $EXAMPLE_DIR
 ./host/host enclave/enclave.signed cold-init $EXAMPLE_DIR/app1_data
-./host/host enclave/enclave.signed get-certifier $EXAMPLE_DIR/app1_data
+./host/host enclave/enclave.signed get-certified $EXAMPLE_DIR/app1_data
 ```
 
 In app-as-a-server terminal run the following:
@@ -274,7 +274,7 @@ In app-as-a-server terminal run the following:
 ```shell
 cd $EXAMPLE_DIR
 ./host/host enclave/enclave.signed cold-init $EXAMPLE_DIR/app2_data
-./host/host enclave/enclave.signed get-certifier $EXAMPLE_DIR/app2_data
+./host/host enclave/enclave.signed get-certified $EXAMPLE_DIR/app2_data
 ```
 
 At this point, both versions of the app have their admission certificates.  You can look at

--- a/sample_apps/simple_app_under_oe/script
+++ b/sample_apps/simple_app_under_oe/script
@@ -70,12 +70,12 @@ $CERTIFIER_PROTOTYPE/certifier_service/simpleserver \
 cd $EXAMPLE_DIR
 ./host/host enclave/enclave.signed cold-init $EXAMPLE_DIR/app1_data
 # get client app certified
-./host/host enclave/enclave.signed get-certifier $EXAMPLE_DIR/app1_data
+./host/host enclave/enclave.signed get-certified $EXAMPLE_DIR/app1_data
 
 # initialize server app
 ./host/host enclave/enclave.signed cold-init $EXAMPLE_DIR/app2_data
 # get server app certified
-./host/host enclave/enclave.signed get-certifier $EXAMPLE_DIR/app2_data
+./host/host enclave/enclave.signed get-certified $EXAMPLE_DIR/app2_data
 
 #run the app
 cd $EXAMPLE_DIR

--- a/sample_apps/simple_app_under_sev/instructions.md
+++ b/sample_apps/simple_app_under_sev/instructions.md
@@ -463,7 +463,7 @@ $EXAMPLE_DIR/sev_example_app.exe            \
 
 $EXAMPLE_DIR/sev_example_app.exe            \
         --data_dir=./app1_data/             \
-        --operation=get-certifier           \
+        --operation=get-certified           \
         --policy_store_file=policy_store    \
         --print_all=true
 ```
@@ -480,7 +480,7 @@ $EXAMPLE_DIR/sev_example_app.exe            \
 
 $EXAMPLE_DIR/sev_example_app.exe            \
         --data_dir=./app2_data/             \
-        --operation=get-certifier           \
+        --operation=get-certified           \
         --policy_store_file=policy_store    \
         --print_all=true
 ```

--- a/sample_apps/simple_app_under_sev/script
+++ b/sample_apps/simple_app_under_sev/script
@@ -127,14 +127,14 @@ $SEV_EXAMPLE_DIR/sev_example_app.exe --print_all=true \
       --operation=cold-init --data_dir=./app1_data/ --policy_store_file=policy_store
 # get client app certified
 $SEV_EXAMPLE_DIR/sev_example_app.exe --print_all=true \
-      --operation=get-certifier --data_dir=./app1_data/ --policy_store_file=policy_store
+      --operation=get-certified --data_dir=./app1_data/ --policy_store_file=policy_store
 
 # initialize server app
 $SEV_EXAMPLE_DIR/sev_example_app.exe --print_all=true \
       --operation=cold-init --data_dir=./app2_data/ --policy_store_file=policy_store
 # get server app certified
 $SEV_EXAMPLE_DIR/sev_example_app.exe --print_all=true \
-      --operation=get-certifier --data_dir=./app2_data/ --policy_store_file=policy_store
+      --operation=get-certified --data_dir=./app2_data/ --policy_store_file=policy_store
 
 #run the app
 cd $SEV_EXAMPLE_DIR

--- a/sample_apps/simple_app_under_sev/sev_example_app.cc
+++ b/sample_apps/simple_app_under_sev/sev_example_app.cc
@@ -32,8 +32,7 @@
 
 using namespace certifier::framework;
 
-// operations are: cold-init, warm-restart, get-certifier, run-app-as-client,
-// run-app-as-server
+// Ops are: cold-init, get-certified, run-app-as-client, run-app-as-server
 DEFINE_bool(print_all, false, "verbose");
 DEFINE_string(operation, "", "operation");
 
@@ -52,10 +51,11 @@ DEFINE_string(vcek_cert_file, "./service/vcek_cert.der", "vcek cert file name");
 
 // The test app performs five possible roles
 //    cold-init: This creates application keys and initializes the policy store.
-//    warm-restart:  This retrieves the policy store data.
-//    get-certifier: This obtains the app admission cert naming the public app
+//    get-certified: This obtains the app admission cert naming the public app
 //    key from the service. run-app-as-client: This runs the app as a server.
 //    run-app-as-server: This runs the app as a client
+//    warm-restart:  This retrieves the policy store data. Operation is subsumed
+//      under other ops.
 
 #include "policy_key.cc"
 cc_trust_data *app_trust_data = nullptr;
@@ -124,7 +124,7 @@ int main(int an, char **av) {
     printf("\t --ark_cert_file=./service/milan_ark_cert.der "
            "--ask_cert_file=./service/milan_ask_cert.der "
            "--vcek_cert_file=./service/milan_vcek_cert.der\n");
-    printf("Operations are: cold-init, warm-restart, get-certifier, "
+    printf("Operations are: cold-init, get-certified, "
            "run-app-as-client, run-app-as-server\n");
     return 0;
   }
@@ -178,14 +178,7 @@ int main(int an, char **av) {
       ret = 1;
       goto done;
     }
-  } else if (FLAGS_operation == "warm-restart") {
-    if (!app_trust_data->warm_restart()) {
-      printf("%s() error, line %d, warm-restart failed\n", __func__, __LINE__);
-      ret = 1;
-      goto done;
-    }
-
-  } else if (FLAGS_operation == "get-certifier") {
+  } else if (FLAGS_operation == "get-certified") {
     if (!app_trust_data->warm_restart()) {
       printf("%s() error, line %d, warm-restart failed\n", __func__, __LINE__);
       ret = 1;


### PR DESCRIPTION
This commit does a couple of minor clean-ups of sample-app command interfaces:

- Op 'get-certifier' is renamed to 'get-certified', to be consistent with what's actually going on.

- Op 'warm-restart' is never ever invoked as an external command. Instead, cc_trust_data()->warm_restart() is invoked as part of other ops. Hence, this tag is being removed from the external interface of most sample apps.

Updated docs and work-instructions appropriately.