### PR TITLE
Add Go wrappers for Certifier TEE primitives

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -181,6 +181,9 @@ jobs:
         cd ../isletlib/
         make dummy
 
+        cd ../teelib
+        make
+
         cd ../certprotos
         protoc --go_opt=paths=source_relative --go_out=. --go_opt=Mcertifier.proto= ./certifier.proto
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -113,7 +113,7 @@ $CERTIFIER/utilities/cert_utility.exe                 \
    --attest_key_output_file=attest_key_file.bin
 ```
 
-Setup dummy libraries for Certifier Service to link with:
+Setup libraries for Certifier Service to link with:
 
 ```shell
 cd $CERTIFIER/certifier_service/graminelib
@@ -124,6 +124,9 @@ make dummy
 
 cd ../isletlib/
 make dummy
+
+cd ../teelib/
+make
 ```
 
 To compile the Certlib tests:

--- a/certifier_service/certlib/cert1_test.go
+++ b/certifier_service/certlib/cert1_test.go
@@ -38,6 +38,51 @@ import (
 	certprotos "github.com/vmware-research/certifier-framework-for-confidential-computing/certifier_service/certprotos"
 )
 
+/*
+func TestTEEAttest(t *testing.T) {
+	fmt.Print("\nTestTEEAttest\n")
+
+	var what_to_say []byte
+	what_to_say = make([]byte, 256)
+	for i := 0; i < 256; i++ {
+		what_to_say[i] = byte(i)
+	}
+	evidence, err := TEEAttest("sev-enclave", what_to_say)
+	if err != nil {
+		fmt.Printf("TEEAttest failed: %s\n", err.Error())
+		t.Errorf("TestTEEAttest failed")
+	}
+	fmt.Printf("evidence length: %d\n", len(evidence))
+}
+
+func TestTEESeal(t *testing.T) {
+	fmt.Print("\nTestTEESeal\n")
+
+	var in []byte
+	in = make([]byte, 32)
+	for i := 0; i < 32; i++ {
+		in[i] = byte((7 * i) % 16)
+	}
+	cipher, err := TEESeal("sev-enclave", "test-enclave", in, 256)
+	if err != nil {
+		fmt.Printf("TEESeal failed: %s\n", err.Error())
+		t.Errorf("TestTEESeal failed")
+	}
+	fmt.Printf("Cipher text length: %d\n", len(cipher))
+
+	clear, err := TEEUnSeal("sev-enclave", "test-enclave", cipher, 128)
+	if err != nil {
+		fmt.Printf("TEEUnseal failed: %s\n", err.Error())
+		t.Errorf("TestTEESeal failed")
+	}
+	fmt.Printf("Clear text length: %d\n", len(clear))
+	if !bytes.Equal(in, clear) {
+		fmt.Printf("Clear text mismatch\n")
+		t.Errorf("TestTEESeal failed")
+	}
+}
+*/
+
 func TestEntity(t *testing.T) {
 	fmt.Print("\nTestEntity\n")
 	m := make([]byte, 32)

--- a/certifier_service/certlib/certlib_primitives.go
+++ b/certifier_service/certlib/certlib_primitives.go
@@ -1,0 +1,87 @@
+//  Copyright (c) 2023, VMware Inc, and the Certifier Authors.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package certlib
+
+/*
+#cgo CFLAGS: -g -Wall -I../teelib
+#cgo LDFLAGS: -L../teelib -ltee -Wl,-rpath=teelib:../../certifier_service/teelib/:../../../certifier_service/teelib
+#include "tee_primitives.h"
+*/
+import "C"
+import (
+	"fmt"
+	"unsafe"
+)
+
+func TEEAttest(enclave_type string, what_to_say []byte) ([]byte, error) {
+	what_to_say_ptr := C.CBytes(what_to_say)
+	defer C.free(what_to_say_ptr)
+	etype := C.CString(enclave_type)
+	defer C.free(unsafe.Pointer(etype))
+	outSize := C.int(16000)
+	out := C.malloc(C.ulong(outSize))
+	defer C.free(unsafe.Pointer(out))
+
+	ret := C.tee_Attest(etype, C.int(len(what_to_say)), (*C.uchar)(what_to_say_ptr),
+		&outSize, (*C.uchar)(out))
+	if !ret {
+		return nil, fmt.Errorf("tee_Attest failed")
+	}
+	evidence := C.GoBytes(unsafe.Pointer(out),
+		C.int(outSize))
+	return evidence, nil
+}
+
+func TEESeal(enclave_type string, enclave_id string, in []byte, outMax int) ([]byte, error) {
+	in_ptr := C.CBytes(in)
+	defer C.free(in_ptr)
+	etype := C.CString(enclave_type)
+	defer C.free(unsafe.Pointer(etype))
+	eid := C.CString(enclave_id)
+	defer C.free(unsafe.Pointer(eid))
+	outSize := C.int(outMax)
+	out := C.malloc(C.ulong(outSize))
+	defer C.free(unsafe.Pointer(out))
+
+	ret := C.tee_Seal(etype, eid, C.int(len(in)), (*C.uchar)(in_ptr),
+		&outSize, (*C.uchar)(out))
+	if !ret {
+		return nil, fmt.Errorf("tee_Seal failed")
+	}
+	cipher := C.GoBytes(unsafe.Pointer(out),
+		C.int(outSize))
+	return cipher, nil
+}
+
+func TEEUnSeal(enclave_type string, enclave_id string, in []byte, outMax int) ([]byte, error) {
+	in_ptr := C.CBytes(in)
+	defer C.free(in_ptr)
+	etype := C.CString(enclave_type)
+	defer C.free(unsafe.Pointer(etype))
+	eid := C.CString(enclave_id)
+	defer C.free(unsafe.Pointer(eid))
+	outSize := C.int(outMax)
+	out := C.malloc(C.ulong(outSize))
+	defer C.free(unsafe.Pointer(out))
+
+	ret := C.tee_Unseal(etype, eid, C.int(len(in)), (*C.uchar)(in_ptr),
+		&outSize, (*C.uchar)(out))
+	if !ret {
+		return nil, fmt.Errorf("tee_Unseal failed")
+	}
+	clear := C.GoBytes(unsafe.Pointer(out),
+		C.int(outSize))
+	return clear, nil
+}

--- a/certifier_service/teelib/Makefile
+++ b/certifier_service/teelib/Makefile
@@ -1,0 +1,91 @@
+#
+# certifier_service/teelib/Makefile
+#
+
+LOCAL_LIB=/usr/local/lib
+PROTO=protoc
+
+# CERTIFIER_ROOT will be certifier-framework-for-confidential-computing/ dir
+CERTIFIER_ROOT = ../..
+
+CERTIFIER_INCLUDE = -I . -I $(CERTIFIER_ROOT)/include -I $(CERTIFIER_ROOT)/src/sev-snp
+CERTIFIER_CFLAGS = $(CERTIFIER_INCLUDE)
+CERTIFIER_LDFLAGS =
+CERTIFIER_LDFLAGS += -lcrypto -lssl
+
+CFLAGS += $(CERTIFIER_CFLAGS)
+CFLAGS += -O3 -g -Wall -std=c++11 -Wno-unused-variable -Werror -Wno-missing-braces -DSEV_SNP
+LDFLAGS=
+LDFLAGS += -L $(LOCAL_LIB) -ldl -lprotobuf -lgtest -lgflags -pthread $(CERTIFIER_LDFLAGS)
+
+TEE_PRIMITIVE_LIB = libtee.so
+
+CP = $(CERTIFIER_ROOT)/certifier_service/certprotos
+
+CS = $(CERTIFIER_ROOT)/src
+S = $(CERTIFIER_ROOT)/certifier_service/teelib
+
+OBJ_DIR = .
+O = $(OBJ_DIR)
+I = $(CERTIFIER_ROOT)/include
+
+dobj = $(O)/certifier.pb.o $(O)/tee_primitives.o $(O)/certifier.o $(O)/support.o \
+	$(O)/sev_support.o $(O)/sev_report.o $(O)/simulated_enclave.o \
+	$(O)/application_enclave.o $(O)/certifier_proofs.o
+
+.PHONY: all build dummy clean
+
+all: build
+
+build: $(TEE_PRIMITIVE_LIB)
+	@echo " \nCompilers used: $(CC), $(CXX). Linking $<"
+	$(CXX) -shared -o $(TEE_PRIMITIVE_LIB) $(dobj) $(LDFLAGS)
+
+$(TEE_PRIMITIVE_LIB): $(dobj)
+
+$(I)/certifier.pb.h: $(S)/certifier.pb.cc
+$(S)/certifier.pb.cc: $(CP)/certifier.proto
+	@echo "\nGenerate protobuf files"
+	$(PROTO) --proto_path=$(CP) --cpp_out=$(S) $<
+	mv $(S)/certifier.pb.h $(I)
+
+$(O)/certifier.pb.o: $(S)/certifier.pb.cc $(I)/certifier.pb.h
+	@echo " \nCompiling $<"
+	$(CC) -fPIC $(CFLAGS) -Wno-array-bounds -c $< -o $@
+
+$(O)/tee_primitives.o: $(S)/tee_primitives.cc
+	@ echo " \nCompiling $<"
+	$(CXX) -fPIC $(CFLAGS) -c $< -o $@
+
+$(O)/certifier.o: $(CS)/certifier.cc
+	@ echo " \nCompiling $<"
+	$(CXX) -fPIC $(CFLAGS) -Wno-deprecated-declarations -c $< -o $@
+
+$(O)/support.o: $(CS)/support.cc
+	@ echo " \nCompiling $<"
+	$(CXX) -fPIC $(CFLAGS) -Wno-deprecated-declarations -c $< -o $@
+
+$(O)/sev_support.o: $(CS)/sev-snp/sev_support.cc
+	@ echo " \nCompiling $<"
+	$(CXX) -fPIC $(CFLAGS) -Wno-deprecated-declarations -c $< -o $@
+
+$(O)/sev_report.o: $(CS)/sev-snp/sev_report.cc
+	@ echo " \nCompiling $<"
+	$(CXX) -fPIC $(CFLAGS) -Wno-deprecated-declarations -c $< -o $@
+
+$(O)/simulated_enclave.o: $(CS)/simulated_enclave.cc
+	@ echo " \nCompiling $<"
+	$(CXX) -fPIC $(CFLAGS) -Wno-deprecated-declarations -c $< -o $@
+
+$(O)/application_enclave.o: $(CS)/application_enclave.cc
+	@ echo " \nCompiling $<"
+	$(CXX) -fPIC $(CFLAGS) -Wno-deprecated-declarations -c $< -o $@
+
+$(O)/certifier_proofs.o: $(CS)/certifier_proofs.cc
+	@ echo " \nCompiling $<"
+	$(CXX) -fPIC $(CFLAGS) -Wno-deprecated-declarations -c $< -o $@
+
+clean:
+	@echo "Removing generated files"
+	rm -rf $(I)/certifier.pb.h $(S)/certifier.pb.h $(S)/certifier.pb.cc
+	rm -rf *.o $(TEE_PRIMITIVE_LIB)

--- a/certifier_service/teelib/tee_primitives.cc
+++ b/certifier_service/teelib/tee_primitives.cc
@@ -1,0 +1,51 @@
+//  Copyright (c) 2023, VMware Inc, and the Certifier Authors.  All rights
+//  reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "tee_primitives.h"
+#include "certifier_framework.h"
+
+using namespace certifier::framework;
+using namespace std;
+
+bool tee_Attest(const char *enclave_type,
+                int         what_to_say_size,
+                byte *      what_to_say,
+                int *       size_out,
+                byte *      out) {
+  string enc_type(enclave_type);
+  return Attest(enc_type, what_to_say_size, what_to_say, size_out, out);
+}
+
+bool tee_Seal(const char *enclave_type,
+              const char *enclave_id,
+              int         in_size,
+              byte *      in,
+              int *       size_out,
+              byte *      out) {
+  string enc_type(enclave_type);
+  string enc_id(enclave_id);
+  return Seal(enc_type, enc_id, in_size, in, size_out, out);
+}
+
+bool tee_Unseal(const char *enclave_type,
+                const char *enclave_id,
+                int         in_size,
+                byte *      in,
+                int *       size_out,
+                byte *      out) {
+  string enc_type(enclave_type);
+  string enc_id(enclave_id);
+  return Unseal(enc_type, enc_id, in_size, in, size_out, out);
+}

--- a/certifier_service/teelib/tee_primitives.h
+++ b/certifier_service/teelib/tee_primitives.h
@@ -1,0 +1,51 @@
+//  Copyright (c) 2023, VMware Inc, and the Certifier Authors.  All rights
+//  reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdbool.h>
+
+#ifndef byte
+typedef unsigned char byte;
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+bool tee_Attest(const char *enclave_type,
+                int         what_to_say_size,
+                byte *      what_to_say,
+                int *       size_out,
+                byte *      out);
+
+bool tee_Seal(const char *enclave_type,
+              const char *enclave_id,
+              int         in_size,
+              byte *      in,
+              int *       size_out,
+              byte *      out);
+
+bool tee_Unseal(const char *enclave_type,
+                const char *enclave_id,
+                int         in_size,
+                byte *      in,
+                int *       size_out,
+                byte *      out);
+
+#ifdef __cplusplus
+}
+#endif

--- a/sample_apps/multidomain_simple_app/instructions.md
+++ b/sample_apps/multidomain_simple_app/instructions.md
@@ -227,6 +227,13 @@ make
 make dummy
 ```
 
+  Compile the teelib for running the certifier service inside a TEE
+```shell
+cd $CERTIFIER_PROTOTYPE/certifier_service/teelib
+
+make
+```
+
 This should produce a Go file for the certifier protobufs called certifier.pb.go in certprotos.
 Now build simpleserver:
 

--- a/sample_apps/multidomain_simple_app/script
+++ b/sample_apps/multidomain_simple_app/script
@@ -175,6 +175,8 @@ cd $CERTIFIER_PROTOTYPE/certifier_service/oelib
 make dummy
 cd $CERTIFIER_PROTOTYPE/certifier_service/isletlib
 make dummy
+cd $CERTIFIER_PROTOTYPE/certifier_service/teelib
+make
 cd $CERTIFIER_PROTOTYPE/certifier_service
 go build simpleserver.go
 

--- a/sample_apps/run_example.sh
+++ b/sample_apps/run_example.sh
@@ -1661,6 +1661,10 @@ function build_simple_server() {
     # shellcheck disable=SC2086
     run_cmd make -j "${NumMakeThreads}" ${make_arg}
 
+    run_cmd cd "${CERT_PROTO}"/certifier_service/teelib
+    # shellcheck disable=SC2086
+    run_cmd make -j "${NumMakeThreads}"
+
     # Now, build the simpleserver:
     run_cmd cd "${CERT_PROTO}"/certifier_service
     run_cmd rm -rf simpleserver

--- a/sample_apps/simple_app/instructions.md
+++ b/sample_apps/simple_app/instructions.md
@@ -212,6 +212,13 @@ make
 make dummy
 ```
 
+  Compile the teelib for running the certifier service inside a TEE
+```shell
+cd $CERTIFIER_PROTOTYPE/certifier_service/teelib
+
+make
+```
+
 This should produce a Go file for the certifier protobufs called certifier.pb.go in certprotos.
 Now build simpleserver:
 

--- a/sample_apps/simple_app/script
+++ b/sample_apps/simple_app/script
@@ -87,6 +87,8 @@ cd $CERTIFIER_PROTOTYPE/certifier_service/oelib
 make dummy
 cd $CERTIFIER_PROTOTYPE/certifier_service/isletlib
 make dummy
+cd $CERTIFIER_PROTOTYPE/certifier_service/teelib
+make
 cd $CERTIFIER_PROTOTYPE/certifier_service
 go build simpleserver.go
 

--- a/sample_apps/simple_app_under_app_service/instructions.md
+++ b/sample_apps/simple_app_under_app_service/instructions.md
@@ -308,6 +308,13 @@ If you do not have OE SDK installed or do not want to enable OE:
 make dummy
 ```
 
+Compile the teelib for running the certifier service inside a TEE
+```shell
+cd $CERTIFIER_PROTOTYPE/certifier_service/teelib
+
+make
+```
+
 This should produce a Go file for the certifier protobufs called certifier.pb.go in certprotos.
 
 Now build simpeserver:

--- a/sample_apps/simple_app_under_gramine/instructions.md
+++ b/sample_apps/simple_app_under_gramine/instructions.md
@@ -347,10 +347,14 @@ certifier.pb.go in certprotos.
 
 ```shell
 cd $CERTIFIER_PROTOTYPE/certifier_service/graminelib
-make dummy  # RESOLVE
+make
+cd $CERTIFIER_PROTOTYPE/certifier_service/oelib
+make dummy
+cd $CERTIFIER_PROTOTYPE/certifier_service/isletlib
+make dummy
+cd $CERTIFIER_PROTOTYPE/certifier_service/teelib
 make
 ```
-
 ### b. Now build simpleserver:
 ```shell
 cd $CERTIFIER_PROTOTYPE/certifier_service

--- a/sample_apps/simple_app_under_gramine/script
+++ b/sample_apps/simple_app_under_gramine/script
@@ -53,9 +53,13 @@ $CERTIFIER_PROTOTYPE/utilities/package_claims.exe --input=signed_claim_1.bin,sig
 cd $CERTIFIER_PROTOTYPE
 cd certifier_service/certprotos
 protoc --go_opt=paths=source_relative --go_out=. --go_opt=M=certifier.proto ./certifier.proto
-cd $CERTIFIER_PROTOTYPE/certifier_service/graminelib
-make dummy
 cd $CERTIFIER_PROTOTYPE/certifier_service/graminelib/
+make
+cd $CERTIFIER_PROTOTYPE/certifier_service/oelib
+make dummy
+cd $CERTIFIER_PROTOTYPE/certifier_service/isletlib
+make dummy
+cd $CERTIFIER_PROTOTYPE/certifier_service/teelib
 make
 
 # Build simpleserver

--- a/sample_apps/simple_app_under_islet/instructions.md
+++ b/sample_apps/simple_app_under_islet/instructions.md
@@ -217,6 +217,9 @@ make dummy
 
 cd $CERTIFIER_PROTOTYPE/certifier_service/isletlib
 make
+
+cd $CERTIFIER_PROTOTYPE/certifier_service/teelib
+make
 ```
 
 ### b. Now build simpleserver:

--- a/sample_apps/simple_app_under_islet/script
+++ b/sample_apps/simple_app_under_islet/script
@@ -114,6 +114,9 @@ make dummy
 cd $CERTIFIER_PROTOTYPE/certifier_service/isletlib
 make
 
+cd $CERTIFIER_PROTOTYPE/certifier_service/teelib
+make
+
 cd $CERTIFIER_PROTOTYPE/certifier_service
 
 go build simpleserver.go

--- a/sample_apps/simple_app_under_keystone/script
+++ b/sample_apps/simple_app_under_keystone/script
@@ -115,6 +115,12 @@ make dummy
 cd $CERTIFIER_PROTOTYPE/certifier_service/graminelib
 make dummy
 
+cd $CERTIFIER_PROTOTYPE/certifier_service/isletlib
+make dummy
+
+cd $CERTIFIER_PROTOTYPE/certifier_service/teelib
+make
+
 cd $CERTIFIER_PROTOTYPE/certifier_service
 
 go build simpleserver.go

--- a/sample_apps/simple_app_under_oe/instructions.md
+++ b/sample_apps/simple_app_under_oe/instructions.md
@@ -217,6 +217,13 @@ If you do not have OpenEnclave SDK installed or do not want to enable OpenEnclav
 make dummy
 ```
 
+Compile the teelib for running the certifier service inside a TEE
+```shell
+cd $CERTIFIER_PROTOTYPE/certifier_service/teelib
+
+make
+```
+
 This should produce a go file for the certifier protobufs called certifier.pb.go in certprotos.
 Now build simpeserver:
 

--- a/sample_apps/simple_app_under_sev/instructions.md
+++ b/sample_apps/simple_app_under_sev/instructions.md
@@ -398,6 +398,13 @@ If you do not have OE SDK installed or do not want to enable OE:
 make dummy
 ```
 
+Compile the teelib for running the certifier service inside a TEE
+```shell
+cd $CERTIFIER_PROTOTYPE/certifier_service/teelib
+
+make
+```
+
 This should produce a Go file for the certifier protobufs called certifier.pb.go in certprotos.
 
 Now build simpleserver:


### PR DESCRIPTION
This patch added Go wrappers for the Certifier TEE primitives. These include Attest/Seal/Unseal. We need these APIs to add support for running the Certifier service inside a TEE (e.g., SEV-SNP VM).