### PR TITLE
Add SEV-SNP extended guest request for platform certificates

### DIFF
--- a/application_service/app_service.mak
+++ b/application_service/app_service.mak
@@ -41,12 +41,12 @@ LINK=g++
 PROTO=protoc
 AR=ar
 #export LD_LIBRARY_PATH=/usr/local/lib
-LDFLAGS= -L $(LOCAL_LIB) -lprotobuf -lgtest -lgflags -lpthread -L/usr/local/opt/openssl@1.1/lib/ -lcrypto -lssl
+LDFLAGS= -L $(LOCAL_LIB) -lprotobuf -lgtest -lgflags -lpthread -L/usr/local/opt/openssl@1.1/lib/ -lcrypto -lssl -luuid
 
 dobj = $(O)/app_service.o $(O)/certifier.pb.o $(O)/certifier.o \
        $(O)/certifier_proofs.o $(O)/support.o $(O)/simulated_enclave.o \
        $(O)/application_enclave.o $(O)/cc_helpers.o $(O)/cc_useful.o \
-       $(O)/sev_support.o $(O)/sev_report.o
+       $(O)/sev_support.o $(O)/sev_cert_table.o $(O)/sev_report.o
 
 user_dobj = $(O)/test_user.o $(O)/certifier.pb.o $(O)/certifier.o \
             $(O)/certifier_proofs.o $(O)/support.o $(O)/simulated_enclave.o \
@@ -136,7 +136,13 @@ SEV_S=$(LIBSRC)/sev-snp
 $(O)/sev_support.o: $(SEV_S)/sev_support.cc \
                     $(I)/certifier.h $(I)/support.h \
                     $(SEV_S)/attestation.h  $(SEV_S)/sev_guest.h \
-                    $(SEV_S)/snp_derive_key.h
+                    $(SEV_S)/snp_derive_key.h \
+                    $(SEV_S)/sev_cert_table.h
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
+
+$(O)/sev_cert_table.o: $(SEV_S)/sev_cert_table.cc \
+                    $(SEV_S)/sev_cert_table.h
 	@echo "\ncompiling $<"
 	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 

--- a/certifier_service/teelib/Makefile
+++ b/certifier_service/teelib/Makefile
@@ -13,7 +13,7 @@ CERTIFIER_ROOT = ../..
 CERTIFIER_INCLUDE = -I . -I $(CERTIFIER_ROOT)/include -I $(CERTIFIER_ROOT)/src/sev-snp
 CERTIFIER_CFLAGS = $(CERTIFIER_INCLUDE)
 CERTIFIER_LDFLAGS =
-CERTIFIER_LDFLAGS += -lcrypto -lssl
+CERTIFIER_LDFLAGS += -lcrypto -lssl -luuid
 
 CFLAGS += $(CERTIFIER_CFLAGS)
 CFLAGS += -O3 -g -Wall -std=c++11 -Wno-unused-variable -Werror -Wno-missing-braces -DSEV_SNP
@@ -32,8 +32,8 @@ O = $(OBJ_DIR)
 I = $(CERTIFIER_ROOT)/include
 
 dobj = $(O)/certifier.pb.o $(O)/tee_primitives.o $(O)/certifier.o $(O)/support.o \
-	$(O)/sev_support.o $(O)/sev_report.o $(O)/simulated_enclave.o \
-	$(O)/application_enclave.o $(O)/certifier_proofs.o
+	$(O)/sev_support.o $(O)/sev_cert_table.o $(O)/sev_report.o \
+	$(O)/simulated_enclave.o $(O)/application_enclave.o $(O)/certifier_proofs.o
 
 .PHONY: all build dummy clean
 
@@ -68,6 +68,10 @@ $(O)/support.o: $(CS)/support.cc
 	$(CXX) -fPIC $(CFLAGS) -Wno-deprecated-declarations -c $< -o $@
 
 $(O)/sev_support.o: $(CS)/sev-snp/sev_support.cc
+	@ echo " \nCompiling $<"
+	$(CXX) -fPIC $(CFLAGS) -Wno-deprecated-declarations -c $< -o $@
+
+$(O)/sev_cert_table.o: $(CS)/sev-snp/sev_cert_table.cc
 	@ echo " \nCompiling $<"
 	$(CXX) -fPIC $(CFLAGS) -Wno-deprecated-declarations -c $< -o $@
 

--- a/sample_apps/simple_app_under_sev/sev_example_app.mak
+++ b/sample_apps/simple_app_under_sev/sev_example_app.mak
@@ -43,14 +43,14 @@ LINK=g++
 PROTO=protoc
 AR=ar
 #export LD_LIBRARY_PATH=/usr/local/lib
-LDFLAGS= -L $(LOCAL_LIB) -lprotobuf -lgtest -lgflags -lpthread -L/usr/local/opt/openssl@1.1/lib/ -lcrypto -lssl
+LDFLAGS= -L $(LOCAL_LIB) -lprotobuf -lgtest -lgflags -lpthread -L/usr/local/opt/openssl@1.1/lib/ -lcrypto -lssl -luuid
 
 # Note:  You can omit all the files below in d_obj except $(O)/example_app.o,
 #  if you link in the certifier library certifier.a.
 dobj = $(O)/sev_example_app.o $(O)/certifier.pb.o $(O)/certifier.o \
        $(O)/certifier_proofs.o $(O)/support.o $(O)/application_enclave.o \
-       $(O)/simulated_enclave.o  $(O)/sev_support.o $(O)/sev_report.o \
-       $(O)/cc_helpers.o $(O)/cc_useful.o
+       $(O)/simulated_enclave.o  $(O)/sev_support.o $(O)/sev_cert_table.o \
+       $(O)/sev_report.o $(O)/cc_helpers.o $(O)/cc_useful.o
 
 all:	sev_example_app.exe
 clean:
@@ -111,6 +111,11 @@ SEV_S=$(S)/sev-snp
 $(O)/sev_support.o: $(SEV_S)/sev_support.cc \
                     $(I)/certifier.h $(I)/support.h $(SEV_S)/attestation.h \
                     $(SEV_S)/sev_guest.h $(SEV_S)/snp_derive_key.h
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
+
+$(O)/sev_cert_table.o: $(SEV_S)/sev_cert_table.cc \
+                    $(SEV_S)/sev_cert_table.h
 	@echo "\ncompiling $<"
 	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 

--- a/src/cc_helpers.cc
+++ b/src/cc_helpers.cc
@@ -43,6 +43,10 @@
 #  include "islet_api.h"
 #endif  // ISLET_CERTIFIER
 
+#ifdef SEV_SNP
+#  include "sev_support.h"
+#endif  // SEV_SNP
+
 using namespace certifier::framework;
 using namespace certifier::utilities;
 
@@ -148,15 +152,22 @@ bool certifier::framework::cc_trust_manager::initialize_enclave(
   } else if (enclave_type_ == "sev-enclave") {
 
     if (n == 0) {
-      // Fetch params
-      printf(
-          "%s() error, line %d, Can't fetch sev parameters automatically yet\n",
-          __func__,
-          __LINE__);
+#ifdef SEV_SNP
+      // Fetch platform certificates using extended guest request
+      string ark, ask, vcek;
+      if (sev_get_platform_certs(&vcek, &ask, &ark) != EXIT_SUCCESS) {
+        printf("%s() error, line %d, Failed to fetch platform certs\n",
+               __func__,
+               __LINE__);
+      }
+      return initialize_sev_enclave(ark, ask, vcek);
+#else
+      printf("%s() error, line %d, Wrong number of sev parameters\n",
+             __func__,
+             __LINE__);
       return false;
-    }
-
-    if (n < 3) {
+#endif  // SEV_SNP
+    } else if (n < 3) {
       printf("%s() error, line %d, Wrong number of sev parameters\n",
              __func__,
              __LINE__);

--- a/src/certifier.cc
+++ b/src/certifier.cc
@@ -424,12 +424,7 @@ bool PublicKeyFromCert(const string &cert, key_message *k) {
   // extensions.
   k->set_snp_tcb_version(get_tcb_version_from_vcek(x));
   memset(chipid, 0, CHIP_ID_SIZE);
-  if (!get_chipid_from_vcek(x, chipid, CHIP_ID_SIZE)) {
-    printf("%s() Info, line %d, Failed to retrieve HWID from VCEK extensions."
-           " Setting chip ID to 0.\n",
-           __func__,
-           __LINE__);
-  }
+  get_chipid_from_vcek(x, chipid, CHIP_ID_SIZE);
   k->set_snp_chipid(chipid, CHIP_ID_SIZE);
 #endif  // SEV_SNP
 

--- a/src/certifier.mak
+++ b/src/certifier.mak
@@ -88,7 +88,7 @@ FIX_SWIG_SCRIPT = $(CERTIFIER_ROOT)/CI/scripts/fix_swig_wrap.sh
 PY_INCLUDE = -I /usr/include/python3.10/
 
 #export LD_LIBRARY_PATH=/usr/local/lib
-LDFLAGS = -L $(LOCAL_LIB) -lprotobuf -lgtest -lgflags -lpthread -L/usr/local/opt/openssl@1.1/lib/ -lcrypto -lssl
+LDFLAGS = -L $(LOCAL_LIB) -lprotobuf -lgtest -lgflags -lpthread -L/usr/local/opt/openssl@1.1/lib/ -lcrypto -lssl -luuid
 LDFLAGS_SWIGPYTEST = -L $(LOCAL_LIB) -l protobuf
 
 # ----------------------------------------------------------------------
@@ -100,7 +100,7 @@ dobj = $(O)/certifier.pb.o $(O)/certifier.o $(O)/certifier_proofs.o        \
        $(O)/cc_helpers.o $(O)/cc_useful.o $(O)/keystone_shim.o
 
 ifdef ENABLE_SEV
-dobj += $(O)/sev_support.o $(O)/sev_report.o
+dobj += $(O)/sev_support.o $(O)/sev_report.o $(O)/sev_cert_table.o
 endif
 
 # Objs needed to build Certifer Framework shared lib for use by Python module
@@ -220,6 +220,11 @@ SEV_S=$(S)/sev-snp
 $(O)/sev_support.o: $(SEV_S)/sev_support.cc \
                     $(I)/certifier.h $(I)/support.h $(SEV_S)/attestation.h  \
                     $(SEV_S)/sev_guest.h  $(SEV_S)/snp_derive_key.h
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
+
+$(O)/sev_cert_table.o: $(SEV_S)/sev_cert_table.cc \
+                    $(SEV_S)/sev_cert_table.h
 	@echo "\ncompiling $<"
 	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 

--- a/src/certifier_tests.mak
+++ b/src/certifier_tests.mak
@@ -77,7 +77,7 @@ SWIG_CERT_TESTS_INTERFACE = certifier_tests
 PY_INCLUDE = -I /usr/include/python3.10/
 
 #export LD_LIBRARY_PATH=/usr/local/lib
-LDFLAGS= -L $(LOCAL_LIB) -lprotobuf -lgtest -lgflags -lpthread -L/usr/local/opt/openssl@1.1/lib/ -lcrypto -lssl
+LDFLAGS= -L $(LOCAL_LIB) -lprotobuf -lgtest -lgflags -lpthread -L/usr/local/opt/openssl@1.1/lib/ -lcrypto -lssl -luuid
 
 # ----------------------------------------------------------------------
 # Define list of objects for common case which will be extended for
@@ -104,7 +104,7 @@ channel_dobj = $(O)/test_channel.o $(common_objs) \
 pipe_read_dobj = $(O)/pipe_read_test.o $(common_objs)
 
 ifdef ENABLE_SEV
-sev_common_objs = $(O)/sev_support.o $(O)/sev_report.o
+sev_common_objs = $(O)/sev_support.o $(O)/sev_report.o $(O)/sev_cert_table.o
 
 dobj +=	$(O)/sev_tests.o $(sev_common_objs)
 
@@ -228,6 +228,11 @@ SEV_S=$(S)/sev-snp
 $(O)/sev_support.o: $(SEV_S)/sev_support.cc \
 $(I)/certifier.h $(I)/support.h $(SEV_S)/attestation.h  $(SEV_S)/sev_guest.h  \
 $(SEV_S)/snp_derive_key.h
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
+
+$(O)/sev_cert_table.o: $(SEV_S)/sev_cert_table.cc \
+$(SEV_S)/sev_cert_table.h
 	@echo "\ncompiling $<"
 	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
 

--- a/src/sev-snp/sev_cert_table.cc
+++ b/src/sev-snp/sev_cert_table.cc
@@ -1,0 +1,290 @@
+/* Copyright (C) 2021 Advanced Micro Devices, Inc. */
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdbool.h>
+#include <errno.h>
+#include <string.h>
+#include <uuid/uuid.h>
+#include <sev_cert_table.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cpplusplus */
+
+const char vcek_guid[] = "63da758d-e664-4564-adc5-f4b93be8accd";
+const char ask_guid[] = "4ab7b379-bbac-4fe4-a02f-05aef327c782";
+const char ark_guid[] = "c0b406a4-a803-4952-9743-3fb6014cd0ae";
+
+static const struct cert_table_entry terminator = {
+    .guid = {0},
+    .offset = 0,
+    .length = 0,
+};
+
+int cert_table_alloc(struct cert_table *table, size_t nr_entries) {
+#define MIN_NR_ENTRIES (1) /* Terminator entry, all zeros */
+
+  int    rc = EXIT_FAILURE;
+  size_t entry_size = sizeof(*table->entry);
+
+  if (!table || nr_entries < MIN_NR_ENTRIES) {
+    rc = EINVAL;
+    goto out;
+  }
+
+  /* Check that the requested table size will not overflow */
+  if ((entry_size * (nr_entries + 1)) < entry_size
+      || (entry_size * (nr_entries + 1)) < nr_entries) {
+    rc = EOVERFLOW;
+    goto out;
+  }
+
+  /* Include an additional empty entry as a terminator */
+  table->entry = (struct cert_table_entry *)calloc(entry_size, nr_entries + 1);
+  if (!table->entry) {
+    rc = ENOMEM;
+    goto out;
+  }
+
+  /* The offset of the first certificate is simply the size of the table */
+  table->entry[0].offset = entry_size * (nr_entries + 1);
+
+  /*
+   * To simplify iterating over the table entries, initialize the guids
+   * to non-zero values in order to differentiate them from the last, all-
+   * zeros entry.
+   */
+  for (size_t i = 0; i < nr_entries; i++) {
+    struct cert_table_entry *entry = table->entry + i;
+
+    memset(&entry->guid, 0xff, sizeof(entry->guid));
+  }
+
+  rc = EXIT_SUCCESS;
+out:
+  return rc;
+}
+
+void cert_table_free(struct cert_table *table) {
+  if (table) {
+    free(table->entry);
+    table->entry = NULL;
+  }
+}
+
+size_t cert_table_get_size(const struct cert_table *table) {
+  return table ? table->entry[0].offset : 0;
+}
+
+static inline bool entry_is_empty(struct cert_table_entry *entry) {
+  return entry->length == 0;
+}
+
+static bool entry_is_terminator(struct cert_table_entry *entry) {
+  return memcmp(entry, &terminator, sizeof(terminator)) == 0;
+}
+
+int cert_table_add_entry(struct cert_table *table,
+                         const char *       guid,
+                         size_t             cert_size) {
+  int    rc = -EXIT_FAILURE;
+  size_t offset = 0;
+
+  if (!table || !table->entry || !guid || cert_size == 0) {
+    rc = -EINVAL;
+    goto out;
+  }
+
+  offset = cert_table_get_size(table);
+  if (offset == 0) {
+    rc = ENODATA;
+    goto out;
+  }
+
+  for (size_t i = 0; !entry_is_terminator(table->entry + i); i++) {
+    struct cert_table_entry *entry = table->entry + i;
+
+    if (!entry_is_empty(entry)) {
+      offset += entry->length;
+      if (offset < entry->length) {
+        rc = EOVERFLOW;
+        goto out;
+      }
+      continue;
+    }
+
+    /* Found an empty table entry, so fill it */
+    rc = uuid_parse(guid, entry->guid);
+    if (rc != 0) {
+      rc = EINVAL;
+      goto out;
+    }
+
+    entry->offset = offset;
+    entry->length = cert_size;
+    rc = EXIT_SUCCESS;
+    goto out;
+  }
+
+  /* All cert table entries searched */
+  fprintf(stderr, "%s: cert table is full.\n", __func__);
+  rc = ENOBUFS;
+out:
+  return rc;
+}
+
+int cert_table_get_certs_size(const struct cert_table *table, size_t *size) {
+  int    rc = EXIT_FAILURE;
+  size_t certs_size = 0;
+
+  if (!table || !size) {
+    rc = EINVAL;
+    goto out;
+  }
+
+  for (size_t i = 0; !entry_is_terminator(table->entry + i); i++) {
+    struct cert_table_entry *entry = table->entry + i;
+
+    certs_size += entry->length;
+    if (certs_size < entry->length) {
+      rc = EOVERFLOW;
+      goto out;
+    }
+  }
+
+  *size = certs_size;
+  rc = EXIT_SUCCESS;
+out:
+  return rc;
+}
+
+int cert_table_copy(const struct cert_table *table,
+                    uint8_t *                buffer,
+                    size_t                   size) {
+  int    rc = EXIT_FAILURE;
+  size_t table_size = 0, offset = 0;
+
+  if (!table || !buffer) {
+    rc = EINVAL;
+    goto out;
+  }
+
+  table_size = cert_table_get_size(table);
+  if (table_size == 0) {
+    rc = EINVAL;
+    goto out;
+  }
+
+  if (table_size > size) {
+    rc = ENOBUFS;
+    goto out;
+  }
+
+  for (size_t i = 0; !entry_is_terminator(table->entry + i); i++) {
+    struct cert_table_entry *entry = table->entry + i;
+
+    memcpy(buffer + offset, entry, sizeof(*entry));
+    offset += sizeof(*entry);
+  }
+
+  rc = EXIT_SUCCESS;
+out:
+  return rc;
+}
+
+int cert_table_get_entry(const struct cert_table *table,
+                         struct cert_table_entry *entry,
+                         const char *             guid) {
+  int    rc = EXIT_FAILURE;
+  uuid_t id = {0};
+
+  if (!table || !entry || !guid) {
+    rc = EINVAL;
+    goto out;
+  }
+
+  rc = uuid_parse(guid, id);
+  if (rc != 0) {
+    rc = EINVAL;
+    goto out;
+  }
+
+  /* Return ENOENT if the GUID is not found in the table */
+  rc = ENOENT;
+  for (size_t i = 0; !entry_is_terminator(table->entry + i); i++) {
+    struct cert_table_entry *current = table->entry + i;
+
+    if (memcmp(current->guid, id, sizeof(id)) == 0) {
+      *entry = *current;
+      rc = EXIT_SUCCESS;
+      break;
+    }
+  }
+out:
+  return rc;
+}
+
+int cert_table_append_cert(const struct cert_table *table,
+                           uint8_t *                buffer,
+                           size_t                   buffer_size,
+                           const char *             guid,
+                           uint8_t *                cert,
+                           size_t                   cert_size) {
+  int    rc = EXIT_FAILURE;
+  size_t table_size = 0, certs_size = 0, total_size = 0;
+  uuid_t id = {0};
+
+  if (!table || !buffer || !cert || cert_size == 0) {
+    rc = EINVAL;
+    goto out;
+  }
+
+  table_size = cert_table_get_size(table);
+  if (table_size == 0) {
+    rc = EINVAL;
+    goto out;
+  }
+
+  rc = cert_table_get_certs_size(table, &certs_size);
+  if (rc != EXIT_SUCCESS) {
+    rc = EINVAL;
+    goto out;
+  }
+
+  total_size = table_size + certs_size;
+  if (total_size < certs_size || buffer_size < total_size) {
+    rc = EOVERFLOW;
+    goto out;
+  }
+
+  rc = uuid_parse(guid, id);
+  if (rc != 0) {
+    rc = EINVAL;
+    goto out;
+  }
+
+  /* Return ENOENT if the GUID is not found in the table */
+  rc = ENOENT;
+  for (size_t i = 0; !entry_is_terminator(table->entry + i); i++) {
+    struct cert_table_entry *entry = table->entry + i;
+
+    if (memcmp(entry->guid, id, sizeof(id)) != 0)
+      continue;
+
+    /* GUID entry found. Confirm that the cert sizes match. */
+    if (entry->length != cert_size) {
+      rc = EINVAL;
+      goto out;
+    }
+
+    memcpy(buffer + entry->offset, cert, cert_size);
+    rc = EXIT_SUCCESS;
+    break;
+  }
+out:
+  return rc;
+}
+
+#ifdef __cplusplus
+}
+#endif /* __cpplusplus */

--- a/src/sev-snp/sev_cert_table.h
+++ b/src/sev-snp/sev_cert_table.h
@@ -1,0 +1,54 @@
+/* Copyright (C) 2021 Advanced Micro Devices, Inc. */
+#ifndef SEV_CERT_TABLE_H
+#define SEV_CERT_TABLE_H
+
+#include <stdint.h>
+#include <uuid/uuid.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cpplusplus */
+
+extern const char vcek_guid[];
+extern const char ask_guid[];
+extern const char ark_guid[];
+
+/*
+ * Per the GHCB spec version 2, this table must be terminated
+ * by an entry containing all zeros.
+ */
+struct cert_table_entry {
+  uuid_t   guid;
+  uint32_t offset;
+  uint32_t length;
+};
+
+struct cert_table {
+  struct cert_table_entry *entry;
+};
+
+int    cert_table_alloc(struct cert_table *table, size_t nr_entries);
+void   cert_table_free(struct cert_table *table);
+size_t cert_table_get_size(const struct cert_table *table);
+int    cert_table_get_certs_size(const struct cert_table *table, size_t *size);
+int    cert_table_add_entry(struct cert_table *table,
+                            const char *       guid,
+                            size_t             cert_size);
+int    cert_table_get_entry(const struct cert_table *table,
+                            struct cert_table_entry *entry,
+                            const char *             guid);
+int    cert_table_copy(const struct cert_table *table,
+                       uint8_t *                buffer,
+                       size_t                   size);
+int    cert_table_append_cert(const struct cert_table *table,
+                              uint8_t *                buffer,
+                              size_t                   buffer_size,
+                              const char *             guid,
+                              uint8_t *                cert,
+                              size_t                   cert_size);
+
+#ifdef __cplusplus
+}
+#endif /* __cpplusplus */
+
+#endif /* SEV_CERT_TABLE_H */

--- a/src/sev-snp/sev_support.h
+++ b/src/sev-snp/sev_support.h
@@ -6,6 +6,7 @@
 #include <stdint.h>
 #include <openssl/evp.h>
 #include <secg_sec1.h>
+#include <string>
 
 #define BITS_PER_BYTE (8)
 
@@ -15,6 +16,8 @@
 #define ECDSA_SIG_RSVD_SIZE    (0x1ff - 0x90 + 1)
 #define ECDSA_PUBKEY_SIZE      (0x404)
 #define ECDSA_SIG_SIZE         (0x200)
+
+using std::string;
 
 enum sev_algo {
   SEV_ALGO_INVALID = 0,
@@ -65,5 +68,6 @@ int sev_validate_vcek_cert_chain(X509 *x509_vcek,
                                  X509 *x509_ask,
                                  X509 *x509_ark);
 EVP_PKEY *sev_get_vcek_pubkey(X509 *x509_vcek);
+int       sev_get_platform_certs(string *vcek, string *ask, string *ark);
 
 #endif /* SEV_ECDSA_H */


### PR DESCRIPTION
Added support for SEV-SNP extended guest request to fetch platform certificates configured by the host. On platforms where this is supported, we do not need to supply additional parameters during enclave initialization.