### PR TITLE
Full authentication channel

### DIFF
--- a/certifier_service/certprotos/certifier.proto
+++ b/certifier_service/certprotos/certifier.proto
@@ -355,3 +355,14 @@ message certifier_entry {
 message certifiers_message {
   repeated certifier_entry my_certifiers    = 1;
 };
+
+// Support for cert chain testing
+message full_cert_chain_entry {
+  optional key_message subject_key           = 1;
+  optional key_message signer_key            = 2;
+  optional bytes der_cert                    = 3;
+};
+message full_cert_chain {
+  repeated full_cert_chain_entry list        = 1;
+};
+

--- a/certifier_service/certprotos/certifier.proto
+++ b/certifier_service/certprotos/certifier.proto
@@ -364,5 +364,6 @@ message full_cert_chain_entry {
 };
 message full_cert_chain {
   repeated full_cert_chain_entry list        = 1;
+  optional key_message final_private_key     = 2;
 };
 

--- a/include/cc_helpers.h
+++ b/include/cc_helpers.h
@@ -48,13 +48,21 @@ void print_cn_name(X509_NAME *name);
 void print_org_name(X509_NAME *name);
 void print_ssl_error(int code);
 
-// The functions below are used by BORING_SSL
-// Eventually they will be deprecated
-#  if 1
 bool load_server_certs_and_key(X509 *        x509_root_cert,
                                key_message & private_key,
                                const string &private_key_cert,
                                SSL_CTX *     ctx);
+bool load_server_certs_and_key(X509 *        peer_root_cert,
+                               X509 *        root_cert,
+                               int           cert_chain_length,
+                               string *      cert_chain,
+                               key_message & private_key,
+                               const string &private_key_cert,
+                               SSL_CTX *     ctx);
+
+// The functions below are used by BORING_SSL
+// Eventually they will be deprecated
+#  if 1
 bool init_client_ssl(X509 *        x509_root_cert,
                      key_message & private_key,
                      const string &private_key_cert,

--- a/include/certifier_framework.h
+++ b/include/certifier_framework.h
@@ -460,6 +460,16 @@ class secure_authenticated_channel {
 bool server_dispatch(const string &host_name,
                      int           port,
                      const string &asn1_root_cert,
+                     const string &asn1_peer_root_cert,
+                     int           num_certs,
+                     string *      cert_chain,
+                     key_message & private_key,
+                     const string &private_key_cert,
+                     void (*func)(secure_authenticated_channel &));
+
+bool server_dispatch(const string &host_name,
+                     int           port,
+                     const string &asn1_root_cert,
                      key_message & private_key,
                      const string &private_key_cert,
                      void (*)(secure_authenticated_channel &));

--- a/include/certifier_framework.h
+++ b/include/certifier_framework.h
@@ -381,15 +381,21 @@ class secure_authenticated_channel {
   X509_STORE_CTX *store_ctx_;
   SSL *           ssl_;
   int             sock_;
-  string          asn1_root_cert_;       // root cert for my certificate
-  string          asn1_peer_root_cert_;  // root cert for peer certificate
-  int             num_cert_chain_;
-  string *        cert_chain_;
-  X509 *          root_cert_;
-  X509 *          my_cert_;
-  string          asn1_my_cert_;
-  X509 *          peer_cert_;
-  string          peer_id_;
+
+  string asn1_root_cert_;  // root cert for my certificate
+  X509 * root_cert_;
+
+  string asn1_peer_root_cert_;  // root cert for peer
+  X509 * peer_root_cert_;
+
+  int     num_cert_chain_;
+  string *cert_chain_;
+
+  string asn1_my_cert_;
+  X509 * my_cert_;
+
+  X509 * peer_cert_;
+  string peer_id_;
 
   secure_authenticated_channel(string &role);  // role is client or server
   ~secure_authenticated_channel();

--- a/include/certifier_framework.h
+++ b/include/certifier_framework.h
@@ -381,7 +381,10 @@ class secure_authenticated_channel {
   X509_STORE_CTX *store_ctx_;
   SSL *           ssl_;
   int             sock_;
-  string          asn1_root_cert_;
+  string          asn1_root_cert_;       // root cert for my certificate
+  string          asn1_peer_root_cert_;  // root cert for peer certificate
+  int             num_cert_chain_;
+  string *        cert_chain_;
   X509 *          root_cert_;
   X509 *          my_cert_;
   string          asn1_my_cert_;
@@ -416,6 +419,27 @@ class secure_authenticated_channel {
   bool init_server_ssl(const string &          host_name,
                        int                     port,
                        const cc_trust_manager &mgr);
+
+
+  // Interface invoked for user supplied keys and cert chain.
+  // This is used, for example, when either endpoint is not a certifier approved
+  // key.
+  bool init_client_ssl(const string &host_name,
+                       int           port,
+                       const string &asn1_root_cert,
+                       const string &peer_asn1_root_cert,
+                       int           cert_chain_length,
+                       string *      der_certs,
+                       key_message & private_key,
+                       const string &auth_cert);
+  bool init_server_ssl(const string &host_name,
+                       int           port,
+                       const string &asn1_root_cert,
+                       const string &peer_asn1_root_cert,
+                       int           cert_chain_length,
+                       string *      der_certs,
+                       key_message & private_key,
+                       const string &auth_cert);
 
   void server_channel_accept_and_auth(
       void (*func)(secure_authenticated_channel &));

--- a/src/Noteontests.md
+++ b/src/Noteontests.md
@@ -29,12 +29,12 @@ Either change the calls below or rename:
 
 In one window, type
 
-  ./test_channel.exe --data_dir=./test_dir/ --operation=server --policy_cert_file=policy_cert_file.bin \
+  ./test_channel.exe --data_dir=./test_data/ --operation=server --policy_cert_file=policy_cert_file.bin \
     --policy_key_file=policy_key_file.bin --auth_key_file=auth_key_file.bin
 
 in another
 
-  ./test_channel.exe --data_dir=./test_dir/ --operation=client --policy_cert_file=policy_cert_file.bin \
+  ./test_channel.exe --data_dir=./test_data/ --operation=client --policy_cert_file=policy_cert_file.bin \
     --policy_key_file=policy_key_file.bin --auth_key_file=auth_key_file.bin
 
 You should see the familiar "Hi from your secret client" and "Hi from your secret server."

--- a/src/Noteontests.md
+++ b/src/Noteontests.md
@@ -43,16 +43,19 @@ enclave involves only a couple of initialization calls.
 
 For independent cert chains, after generating the chains with the generate_cert_chain utility
 
+  ../utilities/generate_cert_chain.exe --operation=generate --output_file="test_data/cert_chain1.bin"
+  ../utilities/generate_cert_chain.exe --operation=generate --output_file="test_data/cert_chain2.bin"
+
 
 In one window, type
 
-  ./test_channel.exe --data_dir=./test_data/ --operation=server --test_case=test2 \\
-    --cert_chain1=cert_chain1.bin --cert_chain2=cert_chain2.bin
+  ./test_channel.exe --data_dir=./test_data/ --operation=server --test_case=test2 \
+    --cert_chain1=test_data/cert_chain1.bin --cert_chain2=test_data/cert_chain2.bin
 
 in another
 
-  ./test_channel.exe --data_dir=./test_data/ --operation=client --test_case=test2 \\
-    --cert_chain1=cert_chain1.bin --cert_chain2=cert_chain2.bin
+  ./test_channel.exe --data_dir=./test_data/ --operation=client --test_case=test2 \
+    --cert_chain1=test_data/cert_chain1.bin --cert_chain2=test_data/cert_chain2.bin
 
 Again, you should see the familiar "Hi from your secret client" and "Hi from your secret server."
 Using the support tested, you no longer need to understand TLS and talking to a "trusted"

--- a/src/Noteontests.md
+++ b/src/Noteontests.md
@@ -30,15 +30,31 @@ Either change the calls below or rename:
 In one window, type
 
   ./test_channel.exe --data_dir=./test_data/ --operation=server --policy_cert_file=policy_cert_file.bin \
-    --policy_key_file=policy_key_file.bin --auth_key_file=auth_key_file.bin
+    --policy_key_file=policy_key_file.bin --auth_key_file=auth_key_file.bin --test_case=test1
 
 in another
 
   ./test_channel.exe --data_dir=./test_data/ --operation=client --policy_cert_file=policy_cert_file.bin \
-    --policy_key_file=policy_key_file.bin --auth_key_file=auth_key_file.bin
+    --policy_key_file=policy_key_file.bin --auth_key_file=auth_key_file.bin --test_case=test1
 
 You should see the familiar "Hi from your secret client" and "Hi from your secret server."
 Using the support tested, you no longer need to understand TLS and talking to a "trusted"
 enclave involves only a couple of initialization calls.
 
+For independent cert chains, after generating the chains with the generate_cert_chain utility
+
+
+In one window, type
+
+  ./test_channel.exe --data_dir=./test_data/ --operation=server --test_case=test2 \\
+    --cert_chain1=cert_chain1.bin --cert_chain2=cert_chain2.bin
+
+in another
+
+  ./test_channel.exe --data_dir=./test_data/ --operation=client --test_case=test2 \\
+    --cert_chain1=cert_chain1.bin --cert_chain2=cert_chain2.bin
+
+Again, you should see the familiar "Hi from your secret client" and "Hi from your secret server."
+Using the support tested, you no longer need to understand TLS and talking to a "trusted"
+enclave involves only a couple of initialization calls.
 

--- a/src/Noteontests.md
+++ b/src/Noteontests.md
@@ -41,10 +41,10 @@ You should see the familiar "Hi from your secret client" and "Hi from your secre
 Using the support tested, you no longer need to understand TLS and talking to a "trusted"
 enclave involves only a couple of initialization calls.
 
-For independent cert chains, after generating the chains with the generate_cert_chain utility
+oor independent cert chains, after generating the chains with the generate_cert_chain utility
 
-  ../utilities/generate_cert_chain.exe --operation=generate --output_file="test_data/cert_chain1.bin"
-  ../utilities/generate_cert_chain.exe --operation=generate --output_file="test_data/cert_chain2.bin"
+  ../utilities/generate_cert_chain.exe --operation=generate --root_key_name=clientRootKey --authority_name=clientRootAuthority --output_file="test_data/cert_chain1.bin"
+  ../utilities/generate_cert_chain.exe --operation=generate --root_key_name=serverRootKey --authority_name=serverRootAuthority --output_file="test_data/cert_chain2.bin"
 
 
 In one window, type

--- a/src/Noteontests.md
+++ b/src/Noteontests.md
@@ -41,7 +41,7 @@ You should see the familiar "Hi from your secret client" and "Hi from your secre
 Using the support tested, you no longer need to understand TLS and talking to a "trusted"
 enclave involves only a couple of initialization calls.
 
-oor independent cert chains, after generating the chains with the generate_cert_chain utility
+For independent cert chains, after generating the chains with the generate_cert_chain utility
 
   ../utilities/generate_cert_chain.exe --operation=generate --root_key_name=clientRootKey --authority_name=clientRootAuthority --output_file="test_data/cert_chain1.bin"
   ../utilities/generate_cert_chain.exe --operation=generate --root_key_name=serverRootKey --authority_name=serverRootAuthority --output_file="test_data/cert_chain2.bin"

--- a/src/cc_helpers.cc
+++ b/src/cc_helpers.cc
@@ -2457,9 +2457,9 @@ bool load_server_certs_and_key(X509 *        root_cert,
     return false;
   }
 
-  bool ret = true;
+  bool      ret = true;
   EVP_PKEY *auth_private_key = nullptr;
-  X509 *x509_auth_key_cert = nullptr;
+  X509 *    x509_auth_key_cert = nullptr;
   STACK_OF(X509) *stack = nullptr;
 
 

--- a/src/cc_helpers.cc
+++ b/src/cc_helpers.cc
@@ -2472,6 +2472,9 @@ bool load_server_certs_and_key(X509 *        root_cert,
     return false;
   }
 
+  SSL_CTX_add_client_CA(ctx, peer_root_cert);
+  SSL_CTX_add1_chain_cert(ctx, peer_root_cert);
+
 #ifdef BORING_SSL
   if (!SSL_CTX_use_certificate(ctx, x509_auth_key_cert)) {
     printf("%s() error, line %d, use cert failed\n", __func__, __LINE__);
@@ -2513,14 +2516,8 @@ bool load_server_certs_and_key(X509 *        root_cert,
            __LINE__);
     return false;
   }
-  SSL_CTX_add_client_CA(ctx, peer_root_cert);
 
-#ifdef BORING_SSL
-  SSL_CTX_add1_chain_cert(ctx, peer_root_cert);
-#else
-  SSL_CTX_add1_to_CA_list(ctx, peer_root_cert);
-
-#  ifdef DEBUG
+#ifdef DEBUG
   const STACK_OF(X509_NAME) *ca_list = SSL_CTX_get0_CA_list(ctx);
   printf("CA names to offer\n");
   if (ca_list != nullptr) {
@@ -2529,7 +2526,7 @@ bool load_server_certs_and_key(X509 *        root_cert,
       print_cn_name(name);
     }
   }
-#  endif
+#endif
 #endif  // BORING_SSL
 
   return true;

--- a/src/cc_helpers.cc
+++ b/src/cc_helpers.cc
@@ -2562,12 +2562,14 @@ bool load_server_certs_and_key(X509 *        root_cert,
   }
 
 #ifdef DEBUG
-  const STACK_OF(X509_NAME) *ca_list = SSL_CTX_get0_CA_list(ctx);
-  printf("CA names to offer\n");
-  if (ca_list != nullptr) {
-    for (int i = 0; i < sk_X509_NAME_num(ca_list); i++) {
-      X509_NAME *name = sk_X509_NAME_value(ca_list, i);
-      print_cn_name(name);
+  {
+    const STACK_OF(X509_NAME) *ca_list = SSL_CTX_get0_CA_list(ctx);
+    printf("CA names to offer\n");
+    if (ca_list != nullptr) {
+      for (int i = 0; i < sk_X509_NAME_num(ca_list); i++) {
+        X509_NAME *name = sk_X509_NAME_value(ca_list, i);
+        print_cn_name(name);
+      }
     }
   }
 #endif

--- a/src/cc_helpers.cc
+++ b/src/cc_helpers.cc
@@ -3321,7 +3321,7 @@ void certifier::framework::secure_authenticated_channel::
            __LINE__,
            res);
     unsigned long code = ERR_get_error();
-    printf("Accept error(%x, %d): %s\n",
+    printf("Accept error(%lx, %ld): %s\n",
            code,
            code & 0xffffff,
            ERR_lib_error_string(code));

--- a/src/cc_helpers.cc
+++ b/src/cc_helpers.cc
@@ -2497,13 +2497,13 @@ bool load_server_certs_and_key(X509 *        peer_root_cert,
            __func__,
            __LINE__);
 //#ifdef DEBUG
-#if 1
+#  if 1
     printf("auth cert:\n");
     X509_print_fp(stdout, x509_auth_key_cert);
     printf("key:\n");
     print_key(private_key);
     printf("\n");
-#endif
+#  endif
     return false;
   }
 #endif
@@ -2871,8 +2871,7 @@ bool certifier::framework::secure_authenticated_channel::init_client_ssl(
 
   private_key_.CopyFrom(private_key);
 
-  asn1_root_cert_.assign((char *)asn1_root_cert.data(),
-                              asn1_root_cert.size());
+  asn1_root_cert_.assign((char *)asn1_root_cert.data(), asn1_root_cert.size());
   asn1_peer_root_cert_.assign((char *)peer_asn1_root_cert.data(),
                               peer_asn1_root_cert.size());
 
@@ -2898,7 +2897,8 @@ bool certifier::framework::secure_authenticated_channel::init_client_ssl(
     if (asn1_peer_root_cert_.size() == 0) {
       printf("root cert empty\n");
     } else {
-      print_bytes(asn1_peer_root_cert_.size(), (byte *)asn1_peer_root_cert_.data());
+      print_bytes(asn1_peer_root_cert_.size(),
+                  (byte *)asn1_peer_root_cert_.data());
       printf("\n");
     }
     return false;

--- a/src/cc_helpers.cc
+++ b/src/cc_helpers.cc
@@ -2477,7 +2477,20 @@ bool load_server_certs_and_key(X509 *        root_cert,
   SSL_CTX_add_client_CA(ctx, peer_root_cert);
   SSL_CTX_add1_chain_cert(ctx, peer_root_cert);
 
-#if 1
+// When intermediate certs exist
+#if 0
+  X509* X509_chain_certs[cert_chain_length];
+  for (int i = 0; i < cert_chain_length; i++) {
+    X509_chain_certs[i] = X509_new();
+    if (!asn1_to_x509(cert_chain[i], X509_chain_certs[i])) {
+      printf("%s() error, line %d, cert chain\n", __func__, __LINE__);
+      return false;
+    }
+    X509_STORE_add_cert(cs, X509_cert_chains[i]);
+  }
+#endif
+
+#ifdef DEBUG
   printf("load_server_certs_and_key, peer_root_cert:\n");
   X509_print_fp(stdout, peer_root_cert);
   printf("load_server_certs_and_key, root_cert:\n");
@@ -2939,6 +2952,19 @@ bool certifier::framework::secure_authenticated_channel::init_client_ssl(
   X509_STORE *cs = SSL_CTX_get_cert_store(ssl_ctx_);
   X509_STORE_add_cert(cs, peer_root_cert_);
 
+// When intermediate certs exist
+#if 0
+  X509* X509_chain_certs[cert_chain_length];
+  for (int i = 0; i < cert_chain_length; i++) {
+    X509_chain_certs[i] = X509_new();
+    if (!asn1_to_x509(cert_chain_[i], X509_cert_chains[i])) {
+      printf("%s() error, line %d, cert chain\n", __func__, __LINE__);
+      return false;
+    }
+    X509_STORE_add_cert(cs, X509_cert_chains[i]);
+  }
+#endif
+
   X509 *x509_auth_cert = X509_new();
   if (asn1_to_x509(auth_cert, x509_auth_cert)) {
     X509_STORE_add_cert(cs, x509_auth_cert);
@@ -2946,7 +2972,7 @@ bool certifier::framework::secure_authenticated_channel::init_client_ssl(
     printf("COULDNT ADD\n");
   }
 
-#if 1
+#ifdef DEBUG
   printf("init_client_ssl, peer root cert:\n");
   X509_print_fp(stdout, peer_root_cert_);
   printf("init_client_ssl, auth cert:\n");

--- a/src/cc_helpers.cc
+++ b/src/cc_helpers.cc
@@ -2439,8 +2439,8 @@ bool load_server_certs_and_key(X509 *        root_cert,
 }
 
 // Loads server side certs and keys.
-bool load_server_certs_and_key(X509 *        peer_root_cert,
-                               X509 *        root_cert,
+bool load_server_certs_and_key(X509 *        root_cert,
+                               X509 *        peer_root_cert,
                                int           cert_chain_length,
                                string *      cert_chain,
                                key_message & private_key,
@@ -2496,8 +2496,7 @@ bool load_server_certs_and_key(X509 *        peer_root_cert,
     printf("%s() error, line %d, SSL_CTX_use_cert_and_key failed\n",
            __func__,
            __LINE__);
-//#ifdef DEBUG
-#  if 1
+#  ifdef DEBUG
     printf("auth cert:\n");
     X509_print_fp(stdout, x509_auth_key_cert);
     printf("key:\n");
@@ -3001,8 +3000,11 @@ bool certifier::framework::secure_authenticated_channel::init_server_ssl(
 
   // set keys and cert
   private_key_.CopyFrom(private_key);
+
+  asn1_root_cert_.assign((char *)asn1_root_cert.data(), asn1_root_cert.size());
   asn1_peer_root_cert_.assign((char *)peer_asn1_root_cert.data(),
                               peer_asn1_root_cert.size());
+
   root_cert_ = X509_new();
   if (!asn1_to_x509(asn1_root_cert, root_cert_)) {
     printf("%s() error, line %d, Can't translate der to X509\n",

--- a/src/cc_helpers.cc
+++ b/src/cc_helpers.cc
@@ -2480,6 +2480,8 @@ bool load_server_certs_and_key(X509 *        root_cert,
 #if 1
   printf("load_server_certs_and_key, peer_root_cert:\n");
   X509_print_fp(stdout, peer_root_cert);
+  printf("load_server_certs_and_key, root_cert:\n");
+  X509_print_fp(stdout, root_cert);
   printf("\nload_server_certs_and_key, auth cert:\n");
   X509_print_fp(stdout, x509_auth_key_cert);
   printf("\n");
@@ -2552,7 +2554,7 @@ bool certifier::framework::server_dispatch(
     const string &private_key_cert,
     void (*func)(secure_authenticated_channel &)) {
 
-#ifdef DEBUG
+#if 1
   printf("\nserver_dispatch\n");
   printf("ans1_root_cert: ");
   print_bytes(asn1_root_cert.size(), (byte *)asn1_root_cert.data());
@@ -2606,6 +2608,8 @@ bool certifier::framework::server_dispatch(
   X509 *x509_auth_cert = X509_new();
   if (asn1_to_x509(private_key_cert, x509_auth_cert)) {
     X509_STORE_add_cert(cs, x509_auth_cert);
+  } else {
+    printf("DIDNT ADD AUTH CERT\n");
   }
 
   if (!load_server_certs_and_key(root_cert,
@@ -3032,6 +3036,14 @@ bool certifier::framework::secure_authenticated_channel::init_server_ssl(
 
   root_cert_ = X509_new();
   if (!asn1_to_x509(asn1_root_cert, root_cert_)) {
+    printf("%s() error, line %d, Can't translate der to X509\n",
+           __func__,
+           __LINE__);
+    return false;
+  }
+
+  peer_root_cert_ = X509_new();
+  if (!asn1_to_x509(peer_asn1_root_cert, peer_root_cert_)) {
     printf("%s() error, line %d, Can't translate der to X509\n",
            __func__,
            __LINE__);

--- a/src/cc_helpers.cc
+++ b/src/cc_helpers.cc
@@ -2567,6 +2567,11 @@ bool certifier::framework::server_dispatch(
     printf("%s() error, line %d, Can't convert cert\n", __func__, __LINE__);
     return false;
   }
+  X509 *peer_root_cert = X509_new();
+  if (!asn1_to_x509(asn1_peer_root_cert, peer_root_cert)) {
+    printf("%s() error, line %d, Can't convert cert\n", __func__, __LINE__);
+    return false;
+  }
 
   // Get a socket.
   int sock = -1;
@@ -2587,7 +2592,7 @@ bool certifier::framework::server_dispatch(
     return false;
   }
   X509_STORE *cs = SSL_CTX_get_cert_store(ctx);
-  X509_STORE_add_cert(cs, root_cert);
+  X509_STORE_add_cert(cs, peer_root_cert);
 
   X509 *x509_auth_cert = X509_new();
   if (asn1_to_x509(private_key_cert, x509_auth_cert)) {
@@ -2595,6 +2600,9 @@ bool certifier::framework::server_dispatch(
   }
 
   if (!load_server_certs_and_key(root_cert,
+                                 peer_root_cert,
+                                 num_certs,
+                                 cert_chain,
                                  private_key,
                                  private_key_cert,
                                  ctx)) {
@@ -2641,6 +2649,9 @@ bool certifier::framework::server_dispatch(
     if (!nc.init_server_ssl(host_name,
                             port,
                             asn1_root_cert,
+                            asn1_peer_root_cert,
+                            num_certs,
+                            cert_chain,
                             private_key,
                             private_key_cert)) {
       continue;

--- a/src/test_channel.cc
+++ b/src/test_channel.cc
@@ -364,7 +364,13 @@ int main(int an, char **av) {
     }
 
     // There should only be two
-    if (chain1.list_size()) {
+    if (chain1.list_size() != 2) {
+      printf("Invalid client chain size\n");
+      return 1;
+    }
+    if (chain2.list_size() != 2) {
+      printf("Invalid server chain size\n");
+      return 1;
     }
 
     // subject_key, signer_key, der_cert
@@ -378,42 +384,17 @@ int main(int an, char **av) {
     string             server_root_cert;
     string             server_auth_cert;
 
-#if 0
-    // make admissions certs: not needed
-    string cl_str("client");
-    string client_auth_cert;
-    if (!make_admissions_cert(cl_str,
-                              client_root_key,
-                              client_auth_key,
-                              &client_auth_cert)) {
-      printf("Can't make admissions cert\n");
-      return 1;
-    }
-    string s_str("server");
-    string server_auth_cert;
-    if (!make_admissions_cert(s_str,
-                              server_root_key,
-                              server_auth_key,
-                              &server_auth_cert)) {
-      printf("Can't make admissions cert\n");
-      return 1;
-    }
-#endif
-
     client_root_cert.assign((char *)chain1.list(0).der_cert().data(),
                             chain1.list(0).der_cert().size());
-    server_root_cert.assign((char *)chain2.list(0).der_cert().data(),
-                            chain2.list(0).der_cert().size());
     client_auth_cert.assign((char *)chain1.list(1).der_cert().data(),
                             chain1.list(1).der_cert().size());
+    server_root_cert.assign((char *)chain2.list(0).der_cert().data(),
+                            chain2.list(0).der_cert().size());
     server_auth_cert.assign((char *)chain2.list(1).der_cert().data(),
                             chain2.list(1).der_cert().size());
     ((key_message &)client_auth_key).set_certificate(client_auth_cert);
     ((key_message &)server_auth_key).set_certificate(server_auth_cert);
 
-#if 1
-    string asn1_root_cert;
-    string asn1_peer_root_cert;
     int    cert_chain_length = 0;
     string der_certs[4];
 
@@ -445,10 +426,6 @@ int main(int an, char **av) {
       printf("Unknown operation\n");
       return 1;
     }
-#else
-    printf("test2 case not implemented yet\n");
-    return 1;
-#endif
   } else {
     printf("Unknown test case\n");
   }

--- a/src/test_channel.cc
+++ b/src/test_channel.cc
@@ -49,6 +49,8 @@ DEFINE_string(policy_key_file, "policy_key_file.bin", "policy key file");
 DEFINE_string(auth_key_file, "auth_key_file.bin", "auth key file");
 
 DEFINE_string(test_case, "test1", "test1");
+DEFINE_string(cert_chain1, "cert_chain1.bin", "First certificate chain");
+DEFINE_string(cert_chain2, "cert_chain2.bin", "Second certificate chain");
 
 
 // ----------------------------------------------------------------------------------
@@ -279,6 +281,8 @@ int main(int an, char **av) {
         return 1;
       }
     } else if (FLAGS_test_case == "test2") {
+      // FLAGS_cert_chain1
+      // FLAGS_cert_chain2
       printf("test2 not implemented\n");
       return 1;
     } else {

--- a/src/test_channel.cc
+++ b/src/test_channel.cc
@@ -232,7 +232,7 @@ int main(int an, char **av) {
       return 1;
     }
     policy_key.set_certificate((byte *)str_policy_cert.data(),
-                             str_policy_cert.size());
+                               str_policy_cert.size());
     if (!auth_key.ParseFromString(str_auth_key)) {
       printf("Can't parse auth key\n");
       return 1;
@@ -278,6 +278,9 @@ int main(int an, char **av) {
         printf("server failed\n");
         return 1;
       }
+    } else if (FLAGS_test_case == "test2") {
+      printf("test2 not implemented\n");
+      return 1;
     } else {
       printf("Unknown operation\n");
     }

--- a/src/test_channel.cc
+++ b/src/test_channel.cc
@@ -370,13 +370,13 @@ int main(int an, char **av) {
     // subject_key, signer_key, der_cert
     const key_message &client_root_key = chain1.list(0).signer_key();
     const key_message &client_auth_key = chain1.list(1).subject_key();
-    string client_root_cert;
-    string client_auth_cert;
+    string             client_root_cert;
+    string             client_auth_cert;
 
     const key_message &server_root_key = chain2.list(0).signer_key();
     const key_message &server_auth_key = chain2.list(1).subject_key();
-    string server_root_cert;
-    string server_auth_cert;
+    string             server_root_cert;
+    string             server_auth_cert;
 
 #if 0
     // make admissions certs: not needed
@@ -400,47 +400,51 @@ int main(int an, char **av) {
     }
 #endif
 
-    client_root_cert.assign((char*)chain1.list(0).der_cert().data(), chain1.list(0).der_cert().size());
-    server_root_cert.assign((char*)chain2.list(0).der_cert().data(), chain2.list(0).der_cert().size());
-    client_auth_cert.assign((char*)chain1.list(1).der_cert().data(), chain1.list(1).der_cert().size());
-    server_auth_cert.assign((char*)chain2.list(1).der_cert().data(), chain2.list(1).der_cert().size());
+    client_root_cert.assign((char *)chain1.list(0).der_cert().data(),
+                            chain1.list(0).der_cert().size());
+    server_root_cert.assign((char *)chain2.list(0).der_cert().data(),
+                            chain2.list(0).der_cert().size());
+    client_auth_cert.assign((char *)chain1.list(1).der_cert().data(),
+                            chain1.list(1).der_cert().size());
+    server_auth_cert.assign((char *)chain2.list(1).der_cert().data(),
+                            chain2.list(1).der_cert().size());
     ((key_message &)client_auth_key).set_certificate(client_auth_cert);
     ((key_message &)server_auth_key).set_certificate(server_auth_cert);
 
 #if 1
-      string asn1_root_cert;
-      string asn1_peer_root_cert;
-      int cert_chain_length = 0;
-      string der_certs[4];
+    string asn1_root_cert;
+    string asn1_peer_root_cert;
+    int    cert_chain_length = 0;
+    string der_certs[4];
 
-      if (FLAGS_operation == "client") {
-        if (!run_me_as_client(FLAGS_app_host.c_str(),
-                              FLAGS_app_port,
-                              client_root_cert,
-                              server_root_cert,
-                              cert_chain_length,
-                              der_certs,
-                              (key_message&)client_auth_key,
-                              client_auth_cert)) {
-          printf("run-me-as-client failed\n");
-          return 1;
-        }
-      } else if (FLAGS_operation == "server") {
-        if (!run_me_as_server(FLAGS_app_host.c_str(),
-                              FLAGS_app_port,
-                              server_root_cert,
-                              client_root_cert,
-                              cert_chain_length,
-                              der_certs,
-                              (key_message&)server_auth_key,
-                              server_auth_cert)) {
-          printf("server failed\n");
-          return 1;
-        }
-      } else {
-        printf("Unknown operation\n");
+    if (FLAGS_operation == "client") {
+      if (!run_me_as_client(FLAGS_app_host.c_str(),
+                            FLAGS_app_port,
+                            client_root_cert,
+                            server_root_cert,
+                            cert_chain_length,
+                            der_certs,
+                            (key_message &)client_auth_key,
+                            client_auth_cert)) {
+        printf("run-me-as-client failed\n");
         return 1;
       }
+    } else if (FLAGS_operation == "server") {
+      if (!run_me_as_server(FLAGS_app_host.c_str(),
+                            FLAGS_app_port,
+                            server_root_cert,
+                            client_root_cert,
+                            cert_chain_length,
+                            der_certs,
+                            (key_message &)server_auth_key,
+                            server_auth_cert)) {
+        printf("server failed\n");
+        return 1;
+      }
+    } else {
+      printf("Unknown operation\n");
+      return 1;
+    }
 #else
     printf("test2 case not implemented yet\n");
     return 1;

--- a/utilities/generate_cert_chain.cc
+++ b/utilities/generate_cert_chain.cc
@@ -240,7 +240,6 @@ bool generate_chain(const string &   root_key_name,
     }
     ent->mutable_subject_key()->CopyFrom(public_intermediates[i]);
     ent->mutable_signer_key()->CopyFrom(public_intermediates[i - 1]);
-    ent->mutable_subject_key()->set_certificate(int_der);
     ent->set_der_cert(int_der);
 
     sn++;
@@ -270,6 +269,7 @@ bool generate_chain(const string &   root_key_name,
     return false;
   }
 
+  chain->mutable_final_private_key()->CopyFrom(private_final_key);
   X509 *x509_final_cert = X509_new();
   if (!produce_artifact(private_intermediates[num_intermediate],
                         prev_key_name,
@@ -372,7 +372,12 @@ int main(int an, char **av) {
       printf("Signer Key:\n");
       print_key(ent.signer_key());
       printf("\n");
+      print_key(ent.signer_key());
+      printf("\n");
     }
+    printf("Final signer:\n");
+    print_key(chain.final_private_key());
+    printf("\n");
 
     return 0;
   } else if (FLAGS_operation == "generate") {

--- a/utilities/generate_cert_chain.cc
+++ b/utilities/generate_cert_chain.cc
@@ -114,8 +114,19 @@ bool generate_chain(const string& root_key_name,
   key_message signer_key
   bytes der_cert
 
+  bool generate_key(const string &type, const string &name, key_message *k)
+  // produce_artifact
+
  */
-  return false;
+
+  // generate root
+
+  // generate intermediates
+
+  // generate final
+
+  
+  return true;
 }
 
 
@@ -135,8 +146,37 @@ int main(int an, char **av) {
 
     return 0;
   } else if (FLAGS_operation == "print") {
-    // FLAGS_input
+
+    string str;
     full_cert_chain chain; // list
+
+    // read file
+    if (!read_file_into_string(FLAGS_input_file, &str)) {
+      printf("%s:%d: %s() read_file_into_string failed\n", __FILE__, __LINE__, __func__);
+      return 1;
+    }
+
+    // deserialize
+    if (!chain.ParseFromString(str)) {
+      printf("%s:%d: %s() chain.ParseFromString failed\n", __FILE__, __LINE__, __func__);
+      return 1;
+    }
+
+    // print them
+    for (int i = 0; i < chain.list_size(); i++) {
+      printf("\n Cert %d:\n", i);
+      const full_cert_chain_entry ent = chain.list(i);
+      const string & ser_cert = ent.der_cert();
+      X509* cert = X509_new();
+      if (!asn1_to_x509(ser_cert, cert)) {
+        printf("%s:%d: %s() asn1_to_x509 failed\n", __FILE__, __LINE__, __func__);
+        continue;
+      }
+      X509_print_fp(stdout, cert);
+      X509_free(cert);
+      printf("\n");
+    }
+
     return 0;
   } else if (FLAGS_operation == "generate") {
     full_cert_chain chain; // list

--- a/utilities/generate_cert_chain.cc
+++ b/utilities/generate_cert_chain.cc
@@ -145,8 +145,11 @@ bool generate_chain(const string& root_key_name,
   printf("\n");
 
   full_cert_chain_entry* ent = chain->add_list();
+
   string key_name;
   string org_name;
+  string prev_key_name = root_key_name;;
+  string prev_org_name = authority_name;
 
   // add root to first entry
   string root_der;
@@ -185,8 +188,8 @@ bool generate_chain(const string& root_key_name,
 
     X509* x509_int_cert = X509_new();
     if (!produce_artifact(private_intermediates[i-1],
-			  (string&)private_intermediates[i-1].key_name(),
-			  (string&)authority_name,
+			  prev_key_name,
+			  prev_org_name,
 			  public_intermediates[i],
 			  (string&)key_name,
 			  (string&)org_name,
@@ -216,6 +219,8 @@ bool generate_chain(const string& root_key_name,
     ent->set_der_cert(int_der);
 
     sn++;
+    prev_key_name = key_name;
+    prev_org_name = org_name;
   }
 
   // generate final
@@ -236,8 +241,8 @@ bool generate_chain(const string& root_key_name,
 
   X509* x509_final_cert = X509_new();
   if (!produce_artifact(private_intermediates[num_intermediate],
-                        (string&)private_intermediates[num_intermediate].key_name(),
-                        (string&)authority_name,
+                        prev_key_name,
+                        prev_org_name,
                         public_final_key,
                         (string&)key_name,
                         (string&)org_name,

--- a/utilities/generate_cert_chain.cc
+++ b/utilities/generate_cert_chain.cc
@@ -23,22 +23,22 @@ DEFINE_bool(print_all, false, "verbose");
 // "generate" or "print" are the other option
 DEFINE_string(operation, "", "generate or print cert chain ");
 
-DEFINE_string(root_key_name, "policyKey", "key name");
-DEFINE_string(key_type, Enc_method_rsa_2048_private, "key type");
+DEFINE_string(root_key_name, "rootKey", "key name");
+DEFINE_string(key_type, "rsa-2048-private", "key type");
 DEFINE_string(authority_name,
               "rootAuthority",
               "root authority name");
 DEFINE_string(output_file,
-              "output.bin",
+              "cert_chain_output.bin",
               "output file");
 DEFINE_int32(num_intermediate, 0, "number of intermediate certs");
 DEFINE_string(input_file,
-              "input.bin",
+              "cert_chain_output.bin",
               "input file");
 
 bool generate_key(const string &type, const string &name, key_message *k) {
 
-  if (type == Enc_method_rsa_1024) {
+  if (type == Enc_method_rsa_1024_private) {
     RSA *r = RSA_new();
     if (!generate_new_rsa_key(1024, r)) {
       printf("Can't generate rsa key\n");
@@ -49,7 +49,7 @@ bool generate_key(const string &type, const string &name, key_message *k) {
       return false;
     }
     k->set_key_type(Enc_method_rsa_1024_private);
-  } else if (type == Enc_method_rsa_2048) {
+  } else if (type == Enc_method_rsa_2048_private) {
     RSA *r = RSA_new();
     if (!generate_new_rsa_key(2048, r)) {
       printf("Can't generate rsa key\n");
@@ -60,7 +60,7 @@ bool generate_key(const string &type, const string &name, key_message *k) {
       return false;
     }
     k->set_key_type(Enc_method_rsa_2048_private);
-  } else if (type == Enc_method_rsa_3072) {
+  } else if (type == Enc_method_rsa_3072_private) {
     RSA *r = RSA_new();
     if (!generate_new_rsa_key(3072, r)) {
       printf("Can't generate rsa key\n");
@@ -82,7 +82,7 @@ bool generate_key(const string &type, const string &name, key_message *k) {
       return false;
     }
     k->set_key_type(Enc_method_rsa_4096_private);
-  } else if (type == Enc_method_ecc_384) {
+  } else if (type == Enc_method_ecc_384_private) {
     EC_KEY *ec = generate_new_ecc_key(384);
     if (ec == nullptr) {
       printf("Can't generate ecc key\n");
@@ -225,13 +225,23 @@ int main(int an, char **av) {
                         FLAGS_authority_name,
                         FLAGS_num_intermediate,
                         &chain)) {
-      printf("%s:%d: %s() failed\n", __FILE__, __LINE__, __func__);
+      printf("%s:%d: %s() generate chain failed\n", __FILE__, __LINE__, __func__);
       return 1;
     }
+
     // serialize and save
+    string serialized_chain;
+    if (!chain.SerializeToString(&serialized_chain)) {
+      printf("%s:%d: %s() chain.SerializeToString failed\n", __FILE__, __LINE__, __func__);
+      return 1;
+    }
+    if (!write_file_from_string(FLAGS_output_file, serialized_chain)) {
+      printf("%s:%d: %s() write_file_from_string failed\n", __FILE__, __LINE__, __func__);
+      return 1;
+    }
     return 0;
   } else {
-    printf("Unknown operation\n");
+    printf("%s:%d: %s() Unknown operation\n", __FILE__, __LINE__, __func__);
     return 1;
   }
 

--- a/utilities/generate_cert_chain.cc
+++ b/utilities/generate_cert_chain.cc
@@ -153,7 +153,6 @@ bool generate_chain(const string &   root_key_name,
   string key_name;
   string org_name;
   string prev_key_name = root_key_name;
-  ;
   string prev_org_name = authority_name;
 
   // add root to first entry
@@ -165,6 +164,7 @@ bool generate_chain(const string &   root_key_name,
            __func__);
     return false;
   }
+  private_root_key.set_certificate(root_der);  // NEW
   ent->mutable_subject_key()->CopyFrom(public_root_key);
   ent->mutable_signer_key()->CopyFrom(private_root_key);
   ent->set_der_cert(root_der);
@@ -240,6 +240,7 @@ bool generate_chain(const string &   root_key_name,
     }
     ent->mutable_subject_key()->CopyFrom(public_intermediates[i]);
     ent->mutable_signer_key()->CopyFrom(public_intermediates[i - 1]);
+    ent->mutable_subject_key()->set_certificate(int_der);
     ent->set_der_cert(int_der);
 
     sn++;
@@ -306,6 +307,7 @@ bool generate_chain(const string &   root_key_name,
   ent->mutable_subject_key()->CopyFrom(public_final_key);
   ent->mutable_signer_key()->CopyFrom(private_intermediates[num_intermediate]);
   ent->set_der_cert(final_der);
+  ent->mutable_subject_key()->set_certificate(final_der);
 
   return true;
 }

--- a/utilities/generate_cert_chain.cc
+++ b/utilities/generate_cert_chain.cc
@@ -29,6 +29,7 @@ DEFINE_string(authority_name, "rootAuthority", "root authority name");
 DEFINE_string(output_file, "cert_chain_output.bin", "output file");
 DEFINE_int32(num_intermediate, 0, "number of intermediate certs");
 DEFINE_string(input_file, "cert_chain_output.bin", "input file");
+DEFINE_string(role, "client", "client/server");
 
 bool generate_key(const string &type, const string &name, key_message *k) {
 

--- a/utilities/generate_cert_chain.cc
+++ b/utilities/generate_cert_chain.cc
@@ -1,0 +1,239 @@
+//  Copyright (c) 2021-22, VMware Inc, and the Certifier Authors.  All rights
+//  reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gflags/gflags.h>
+#include "support.h"
+
+using namespace certifier::utilities;
+
+DEFINE_bool(print_all, false, "verbose");
+// "generate-policy-key-and-test-keys" is the other option
+DEFINE_string(operation, "", "generate policy key and self-signed cert");
+
+DEFINE_string(policy_key_name, "policyKey", "key name");
+DEFINE_string(policy_key_type, Enc_method_rsa_2048_private, "policy key type");
+DEFINE_string(policy_authority_name,
+              "policyAuthority",
+              "policy authority name");
+DEFINE_string(policy_key_output_file, "policy_key_file.bin", "policy key file");
+DEFINE_string(policy_cert_output_file,
+              "policy_cert_file.bin",
+              "policy cert file");
+
+bool generate_test_keys() {
+  key_message platform_key;
+  key_message attest_key;
+
+  int n = 2048;
+  if (FLAGS_platform_key_type == Enc_method_rsa_2048_private)
+    n = 2048;
+  else if (FLAGS_platform_key_type == Enc_method_rsa_1024_private)
+    n = 1024;
+  if (!make_certifier_rsa_key(n, &platform_key)) {
+    return false;
+  }
+  platform_key.set_key_name(FLAGS_platform_key_name);
+  platform_key.set_key_type(FLAGS_platform_key_type);
+  string serialized_platform_key;
+  if (!platform_key.SerializeToString(&serialized_platform_key))
+    return false;
+  if (!write_file(FLAGS_platform_key_output_file,
+                  serialized_platform_key.size(),
+                  (byte *)serialized_platform_key.data()))
+    return false;
+
+  n = 2048;
+  if (FLAGS_attest_key_type == Enc_method_rsa_2048_private)
+    n = 2048;
+  else if (FLAGS_attest_key_type == Enc_method_rsa_1024_private)
+    n = 1024;
+  if (!make_certifier_rsa_key(n, &attest_key)) {
+    return false;
+  }
+  attest_key.set_key_name(FLAGS_attest_key_name);
+  attest_key.set_key_type(FLAGS_attest_key_type);
+  string serialized_attest_key;
+  if (!attest_key.SerializeToString(&serialized_attest_key))
+    return false;
+  if (!write_file(FLAGS_attest_key_output_file,
+                  serialized_attest_key.size(),
+                  (byte *)serialized_attest_key.data()))
+    return false;
+
+  printf("\nGenerated platform key:\n");
+  print_key(platform_key);
+  printf("\n");
+
+  printf("\nGenerated attest key:\n");
+  print_key(attest_key);
+  printf("\n");
+
+  return true;
+}
+
+bool generate_policy_key() {
+  key_message policy_key;
+  key_message policy_pk;  // public policy key
+
+  if (!make_root_key_with_cert(FLAGS_policy_key_type,
+                               FLAGS_policy_key_name,
+                               FLAGS_policy_authority_name,
+                               &policy_key))
+    return false;
+  if (!private_key_to_public_key(policy_key, &policy_pk))
+    return false;
+
+  string serialized_key;
+  if (!policy_key.SerializeToString(&serialized_key))
+    return false;
+  if (!write_file(FLAGS_policy_key_output_file,
+                  serialized_key.size(),
+                  (byte *)serialized_key.data()))
+    return false;
+  if (!write_file(FLAGS_policy_cert_output_file,
+                  policy_key.certificate().size(),
+                  (byte *)policy_key.certificate().data()))
+    return false;
+
+  printf("\nGenerated policy key:\n");
+  print_key(policy_key);
+  printf("\n");
+  return true;
+}
+
+bool generate_key(const string &type, const string &name, key_message *k) {
+
+  if (type == Enc_method_rsa_1024) {
+    RSA *r = RSA_new();
+    if (!generate_new_rsa_key(1024, r)) {
+      printf("Can't generate rsa key\n");
+      return false;
+    }
+    if (!RSA_to_key(r, k)) {
+      printf("Can't convert rsa key to key\n");
+      return false;
+    }
+    k->set_key_type(Enc_method_rsa_1024_private);
+  } else if (type == Enc_method_rsa_2048) {
+    RSA *r = RSA_new();
+    if (!generate_new_rsa_key(2048, r)) {
+      printf("Can't generate rsa key\n");
+      return false;
+    }
+    if (!RSA_to_key(r, k)) {
+      printf("Can't convert rsa key to key\n");
+      return false;
+    }
+    k->set_key_type(Enc_method_rsa_2048_private);
+  } else if (type == Enc_method_rsa_3072) {
+    RSA *r = RSA_new();
+    if (!generate_new_rsa_key(3072, r)) {
+      printf("Can't generate rsa key\n");
+      return false;
+    }
+    if (!RSA_to_key(r, k)) {
+      printf("Can't convert rsa key to key\n");
+      return false;
+    }
+    k->set_key_type(Enc_method_rsa_3072_private);
+  } else if (type == Enc_method_rsa_4096) {
+    RSA *r = RSA_new();
+    if (!generate_new_rsa_key(4096, r)) {
+      printf("Can't generate rsa key\n");
+      return false;
+    }
+    if (!RSA_to_key(r, k)) {
+      printf("Can't convert rsa key to key\n");
+      return false;
+    }
+    k->set_key_type(Enc_method_rsa_4096_private);
+  } else if (type == Enc_method_ecc_384) {
+    EC_KEY *ec = generate_new_ecc_key(384);
+    if (ec == nullptr) {
+      printf("Can't generate ecc key\n");
+      return false;
+    }
+    if (!ECC_to_key(ec, k)) {
+      printf("Can't convert ecc key to key\n");
+      return false;
+    }
+    k->set_key_type(Enc_method_ecc_384_private);
+  } else {
+    printf("Unknown key type\n");
+    return false;
+  }
+
+  k->set_key_name(name);
+  k->set_key_format("vse-key");
+  string str;
+  if (!k->SerializeToString(&str)) {
+    printf("Can't serialize key\n");
+    return false;
+  }
+  if (!write_file(FLAGS_key_output_file, str.size(), (byte *)str.data())) {
+    printf("Can't write file\n");
+    return false;
+  }
+  print_key(*k);
+  printf("\n");
+
+  return true;
+}
+
+
+int main(int an, char **av) {
+  string usage("Utility to generate cert chains");
+  gflags::SetUsageMessage(usage);
+  gflags::ParseCommandLineFlags(&an, &av, true);
+
+  if (FLAGS_operation == "") {
+    printf("%s: %s\n", av[0], usage.c_str());
+    printf("\n%s --operation=<generate print> "
+           "--num_intermediate=nn "
+           "--output_file=<file.bin> "
+           "--key_type=<rsa-4096 rsa-2048 ecc-256 ecc-384\n",
+           av[0]);
+
+    return 0;
+  } else if (FLAGS_operation == "test-sig") {
+    test_sig();
+  } else if (FLAGS_operation == "generate-policy-key"
+             || FLAGS_operation == "generate-policy-key-and-test-keys") {
+    printf("Generating policy key and cert\n");
+    if (!generate_policy_key()) {
+      printf("Generate keys failed\n");
+      return 1;
+    }
+
+    if (FLAGS_operation == "generate-policy-key-and-test-keys") {
+      printf("Generating test keys\n");
+      if (!generate_test_keys()) {
+        printf("Generate test keys failed\n");
+        return 1;
+      }
+    }
+  } else if ("generate-key") {
+    key_message k;
+    if (!generate_key(FLAGS_key_type, FLAGS_key_name, &k)) {
+      printf("generate key failed\n");
+      return 1;
+    }
+  } else {
+    printf("Unknown operation\n");
+    return 1;
+  }
+
+  return 0;
+}

--- a/utilities/generate_cert_chain.mak
+++ b/utilities/generate_cert_chain.mak
@@ -67,7 +67,7 @@ clean:
 	@echo "removing executable file"
 	rm -rf $(EXE_DIR)/generate_cert_chain.exe
 
-generate_cert_chain.exe: $(dobj) 
+generate_cert_chain.exe: $(dobj)
 	@echo "\nlinking executable $@"
 	$(LINK) $(dobj) $(LDFLAGS) -o $(EXE_DIR)/$@
 

--- a/utilities/generate_cert_chain.mak
+++ b/utilities/generate_cert_chain.mak
@@ -1,0 +1,105 @@
+#    
+#    File: generate_cert_chain.mak
+
+# CERTIFIER_ROOT will be certifier-framework-for-confidential-computing/ dir
+CERTIFIER_ROOT = ..
+
+ifndef SRC_DIR
+SRC_DIR=$(CERTIFIER_ROOT)/src
+endif
+ifndef OBJ_DIR
+OBJ_DIR=.
+endif
+ifndef EXE_DIR
+EXE_DIR=.
+endif
+ifndef INC_DIR
+INC_DIR=../include
+endif
+
+#ifndef GOOGLE_INCLUDE
+#GOOGLE_INCLUDE=/usr/local/include/g
+#endif
+
+# Allows user to over-ride libs path externally depending on machine's install
+ifndef LOCAL_LIB
+LOCAL_LIB=/usr/local/lib
+endif
+
+ifndef TARGET_MACHINE_TYPE
+TARGET_MACHINE_TYPE= x64
+endif
+
+CP = $(CERTIFIER_ROOT)/certifier_service/certprotos
+
+S= $(SRC_DIR)
+O= $(OBJ_DIR)
+I= $(INC_DIR)
+US= .
+INCLUDE= -I$(I) -I/usr/local/opt/openssl@1.1/include/ -I$(S)/sev-snp/
+
+# Compilation of protobuf files could run into some errors, so avoid using
+# -Werror for those targets
+CFLAGS_NOERROR = $(INCLUDE) -O3 -g -Wall -std=c++11 -Wno-unused-variable -D X64 -Wno-deprecated -Wno-deprecated-declarations
+CFLAGS = $(CFLAGS_NOERROR) -Werror
+
+#For MAC, -D MACOS should be included
+CFLAGS1= $(INCLUDE) -O1 -g -Wall -std=c++11 -Wno-unused-variable -D X64 -Wno-deprecated -Wno-deprecated-declarations
+CC=g++
+LINK=g++
+# PROTO=/usr/local/bin/protoc
+# Point this to the right place, if you have to. I had to do the above on my machine.
+PROTO=protoc
+AR=ar
+#export LD_LIBRARY_PATH=/usr/local/lib
+LDFLAGS= -L $(LOCAL_LIB) -lprotobuf -lgtest -lgflags -lpthread -L/usr/local/opt/openssl@1.1/lib/ -lcrypto -lssl
+
+common_objs = $(O)/certifier.pb.o $(O)/support.o $(O)/certifier.o \
+              $(O)/certifier_proofs.o $(O)/simulated_enclave.o \
+              $(O)/application_enclave.o
+
+dobj =	$(O)/generate_cert_chain.o $(common_objs)
+
+all:	generate_cert_chain.exe
+clean:
+	@echo "removing object and generated files"
+	rm -rf $(O)/*.o $(US)/certifier.pb.cc $(US)/certifier.pb.h $(I)/certifier.pb.h
+	@echo "removing executable file"
+	rm -rf $(EXE_DIR)/generate_cert_chain.exe
+
+generate_cert_chain.exe: $(dobj) 
+	@echo "\nlinking executable $@"
+	$(LINK) $(dobj) $(LDFLAGS) -o $(EXE_DIR)/$@
+
+$(O)/generate_cert_chain.o: $(US)/generate_cert_chain.cc $(I)/support.h $(I)/certifier.pb.h
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
+
+$(I)/certifier.pb.h: $(US)/certifier.pb.cc
+$(US)/certifier.pb.cc: $(CP)/certifier.proto
+	$(PROTO) --cpp_out=$(US) --proto_path $(<D) $<
+	mv $(@D)/certifier.pb.h $(I)
+
+$(O)/certifier.pb.o: $(US)/certifier.pb.cc $(I)/certifier.pb.h
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS_NOERROR) -Wno-array-bounds -o $(@D)/$@ -c $<
+
+$(O)/support.o: $(S)/support.cc $(I)/support.h $(I)/certifier.pb.h
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
+
+$(O)/certifier.o: $(S)/certifier.cc $(I)/certifier.pb.h $(I)/certifier.h
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
+
+$(O)/certifier_proofs.o: $(S)/certifier_proofs.cc $(I)/certifier.pb.h $(I)/certifier.h
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
+
+$(O)/simulated_enclave.o: $(S)/simulated_enclave.cc $(I)/simulated_enclave.h
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
+
+$(O)/application_enclave.o: $(S)/application_enclave.cc $(I)/application_enclave.h
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<


### PR DESCRIPTION
This checkin implements a request from data village to have different roots for client and server elements in secure_authenticated_channel.

There is also a new utility to generate test cases