### PR TITLE
simple_app_python: Complete client-server secure communication channel.

### DIFF
--- a/include/certifier_framework.h
+++ b/include/certifier_framework.h
@@ -336,6 +336,7 @@ class cc_trust_manager {
   bool certify_secondary_domain(const string &domain_name);
   bool get_certifiers_from_store();
   bool put_certifiers_in_store();
+  bool write_private_key_to_file(const string &filename);
 };
 
 // Certification Anchors

--- a/sample_apps/run_example.sh
+++ b/sample_apps/run_example.sh
@@ -38,7 +38,7 @@ MeMsg="Build and run example program"
 
 # Script global symbols to app-data dirs
 Client_app_data="app1_data"
-Srvr_app_data="app2_data"
+Server_app_data="app2_data"
 
 SimpleServer_PID=0
 # ApplicationServer_PID=0
@@ -1724,10 +1724,10 @@ function mkdirs_for_test() {
     # to create the other client-/server-test data dirs.
     set -x
 
-    rm -rf ${Client_app_data} ${Srvr_app_data} service
+    rm -rf ${Client_app_data} ${Server_app_data} service
     mkdir service
     if [ "${SampleAppName}" != "application_service" ]; then
-        mkdir  ${Client_app_data} ${Srvr_app_data}
+        mkdir  ${Client_app_data} ${Server_app_data}
     fi
 
     set +x
@@ -1761,7 +1761,7 @@ function provision_app_service_files() {
 
     else
         run_cmd cp -p ./* "${EXAMPLE_DIR}"/${Client_app_data}
-        run_cmd cp -p ./* "${EXAMPLE_DIR}"/${Srvr_app_data}
+        run_cmd cp -p ./* "${EXAMPLE_DIR}"/${Server_app_data}
     fi
 
     if [ "${SampleAppName}" = "simple_app_under_sev" ]; then
@@ -1889,9 +1889,10 @@ function run_app_by_name_as_server_talk_to_Cert_Service() {
 
         # In order to get access to SWIG-generated *.py modules
         PYTHONPATH=../..; export PYTHONPATH
+        PYTHONUNBUFFERED=TRUE; export PYTHONUNBUFFERED
     fi
     run_cmd "${EXAMPLE_DIR}/${app_name_exe}"  \
-                --data_dir="./${Srvr_app_data}/"                \
+                --data_dir="./${Server_app_data}/"                \
                 --operation=cold-init                           \
                 --measurement_file="example_app.measurement"    \
                 --policy_store_file=policy_store                \
@@ -1900,7 +1901,7 @@ function run_app_by_name_as_server_talk_to_Cert_Service() {
     run_cmd sleep 1
 
     run_cmd "${EXAMPLE_DIR}/${app_name_exe}"  \
-                --data_dir="./${Srvr_app_data}/"                \
+                --data_dir="./${Server_app_data}/"                \
                 --operation=get-certified                       \
                 --measurement_file="example_app.measurement"    \
                 --policy_store_file=policy_store                \
@@ -1917,14 +1918,14 @@ function run_simple_app_under_oe_as_server_talk_to_Cert_Service() {
     run_cmd ./host/host                             \
                 enclave/enclave.signed              \
                 cold-init                           \
-                "${EXAMPLE_DIR}"/${Srvr_app_data}
+                "${EXAMPLE_DIR}"/${Server_app_data}
 
     run_cmd sleep 1
 
     run_cmd ./host/host                             \
                 enclave/enclave.signed              \
                 get-certified                       \
-                "${EXAMPLE_DIR}"/${Srvr_app_data}
+                "${EXAMPLE_DIR}"/${Server_app_data}
 
     run_popd
 }
@@ -1940,7 +1941,7 @@ function run_simple_app_under_gramine_as_server_talk_to_Cert_Service() {
     run_pushd "${EXAMPLE_DIR}"
 
     run_cmd gramine-sgx gramine_example_app         \
-                --data_dir="./${Srvr_app_data}/"    \
+                --data_dir="./${Server_app_data}/"    \
                 --operation=cold-init               \
                 --policy_store_file=policy_store    \
                 --print_all=true || 0
@@ -1948,7 +1949,7 @@ function run_simple_app_under_gramine_as_server_talk_to_Cert_Service() {
     run_cmd sleep 1
 
     run_cmd gramine-sgx gramine_example_app         \
-                --data_dir="./${Srvr_app_data}/"    \
+                --data_dir="./${Server_app_data}/"    \
                 --operation=get-certified           \
                 --policy_store_file=policy_store    \
                 --print_all=true || 0
@@ -1962,13 +1963,13 @@ function run_simple_app_under_sev_as_server_talk_to_Cert_Service() {
     run_pushd "${EXAMPLE_DIR}"
 
     run_cmd "${EXAMPLE_DIR}"/sev_example_app.exe    \
-                --data_dir="./${Srvr_app_data}/"    \
+                --data_dir="./${Server_app_data}/"    \
                 --operation=cold-init               \
                 --policy_store_file=policy_store    \
                 --print_all=true
 
     run_cmd "${EXAMPLE_DIR}"/sev_example_app.exe    \
-                --data_dir="./${Srvr_app_data}/"    \
+                --data_dir="./${Server_app_data}/"    \
                 --operation=get-certified           \
                 --policy_store_file=policy_store    \
                 --print_all=true
@@ -2022,6 +2023,7 @@ function run_app_by_name_as_client_talk_to_Cert_Service() {
 
         # In order to get access to SWIG-generated *.py modules
         PYTHONPATH=../..; export PYTHONPATH
+        PYTHONUNBUFFERED=TRUE; export PYTHONUNBUFFERED
     fi
 
     run_cmd "${EXAMPLE_DIR}/${app_name_exe}"                    \
@@ -2150,10 +2152,11 @@ function run_app_by_name_as_server_offers_trusted_service() {
 
         # In order to get access to SWIG-generated *.py modules
         PYTHONPATH=../..; export PYTHONPATH
+        PYTHONUNBUFFERED=TRUE; export PYTHONUNBUFFERED
     fi
     # Run app as a server: In app as a server terminal run the following:
     run_cmd "${EXAMPLE_DIR}/${app_name_exe}"        \
-                --data_dir="./${Srvr_app_data}/"    \
+                --data_dir="./${Server_app_data}/"    \
                 --operation=run-app-as-server       \
                 --policy_store_file=policy_store    \
                 ${print_all_arg} &
@@ -2176,7 +2179,7 @@ function run_simple_app_under_oe_as_server_offers_trusted_service() {
     run_cmd ./host/host                         \
                 enclave/enclave.signed          \
                 run-app-as-server               \
-                "${EXAMPLE_DIR}/${Srvr_app_data}" &
+                "${EXAMPLE_DIR}/${Server_app_data}" &
 
     run_cmd sleep 5
 
@@ -2193,7 +2196,7 @@ function run_simple_app_under_gramine_as_server_offers_trusted_service() {
 
     # Run app as a server: In app as a server terminal run the following:
     run_cmd gramine-sgx gramine_example_app         \
-                --data_dir=./"${Srvr_app_data}"/    \
+                --data_dir=./"${Server_app_data}"/    \
                 --operation=run-app-as-server       \
                 --policy_store_file=policy_store    \
                 --print_all=true || 0 &
@@ -2256,6 +2259,7 @@ function run_app_by_name_as_client_make_trusted_request() {
 
         # In order to get access to SWIG-generated *.py modules
         PYTHONPATH=../..; export PYTHONPATH
+        PYTHONUNBUFFERED=TRUE; export PYTHONUNBUFFERED
     fi
     # Run app as a client: In app as a client terminal run the following:
     run_cmd "${EXAMPLE_DIR}/${app_name_exe}"        \
@@ -2684,13 +2688,13 @@ function run_simple_app_under_app_service_as_server_talk_to_Cert_Service() {
 
     run_cmd "${EXAMPLE_DIR}"/start_program.exe                              \
             --executable="${EXAMPLE_DIR}"/service_example_app.exe   \
-            --args="--print_all=true,--operation=cold-init,--data_dir=${EXAMPLE_DIR}/${Srvr_app_data}/,--measurement_file=example_app.measurement,--policy_store_file=policy_store,--parent_enclave=simulated-enclave"
+            --args="--print_all=true,--operation=cold-init,--data_dir=${EXAMPLE_DIR}/${Server_app_data}/,--measurement_file=example_app.measurement,--policy_store_file=policy_store,--parent_enclave=simulated-enclave"
 
     run_cmd sleep 5
 
     run_cmd "${EXAMPLE_DIR}"/start_program.exe                              \
             --executable="${EXAMPLE_DIR}"/service_example_app.exe   \
-            --args="--print_all=true,--operation=get-certified,--data_dir=${EXAMPLE_DIR}/${Srvr_app_data}/,--measurement_file=example_app.measurement,--policy_store_file=policy_store,--parent_enclave=simulated-enclave"
+            --args="--print_all=true,--operation=get-certified,--data_dir=${EXAMPLE_DIR}/${Server_app_data}/,--measurement_file=example_app.measurement,--policy_store_file=policy_store,--parent_enclave=simulated-enclave"
 
     run_popd
 }
@@ -2728,7 +2732,7 @@ function run_simple_app_under_app_service_as_server_offers_trusted_service() {
 
     run_cmd "${EXAMPLE_DIR}"/start_program.exe                              \
             --executable="${EXAMPLE_DIR}"/service_example_app.exe   \
-            --args="--print_all=true,--operation=run-app-as-server,--data_dir=${EXAMPLE_DIR}/${Srvr_app_data}/,--measurement_file=example_app.measurement,--policy_store_file=policy_store,--parent_enclave=simulated-enclave"
+            --args="--print_all=true,--operation=run-app-as-server,--data_dir=${EXAMPLE_DIR}/${Server_app_data}/,--measurement_file=example_app.measurement,--policy_store_file=policy_store,--parent_enclave=simulated-enclave"
 
     run_popd
 }

--- a/sample_apps/simple_app_python/example_app.py
+++ b/sample_apps/simple_app_python/example_app.py
@@ -7,6 +7,8 @@ Python simple-app to demonstrate use of Certifier Framework APIs.
 """
 import sys
 import os
+import ssl
+import socket
 import argparse
 from inspect import currentframe
 
@@ -23,6 +25,7 @@ THIS_SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 # Script defaults
 ATTEST_KEY_FILE                 = 'attest_key_file.bin'
 APP_DATA_DIR                    = './app1_data/'
+PROVISIONING_DIR                = './provisioning'
 EXAMPLE_MEASUREMENT             = 'example_app.measurement'
 APP_OP_TYPES                    = 'cold-init, get-certified, run-app-as-client, run-app-as-server'
 PLATFORM_ATTEST_ENDORSEMENT     = 'platform_attest_endorsement.bin'
@@ -30,8 +33,18 @@ PLATFORM_CERT_FILE              = 'platform_file.bin'
 POLICY_STORE                    = 'store.bin'
 POLICY_HOST                     = 'localhost'
 POLICY_HOST_PORT                = 8123
-SERVER_APP_HOST                 = 'localhost'
+SERVER_APP_HOST                 = '127.0.0.1'
 SERVER_APP_PORT                 = 8124
+
+# ------------------------------------------------------------------------------
+# Script global symbols to app-data dirs.
+SERVER_APP_DATA='app2_data'
+PROVISIONING_DIR='./provisioning'
+
+# Basenames for output files created to persist certificates and keys
+APPLN_CERT_SIGNED_BY_ROOT_CA = 'appln.PEM.cert'
+APPLN_KEYF_SIGNED_BY_ROOT_CA = 'appln.PEM.key'
+ROOT_CA_POLICY_CERT          = 'ca_root.PEM.cert'
 
 ###############################################################################
 # main() driver
@@ -54,7 +67,8 @@ def do_main(args) -> bool:
     parsed_args = parseargs(args)
 
     attest_key_file         = parsed_args.attest_key_file
-    app1_data_dir           = parsed_args.app1_data_dir.rstrip('/')
+    # Will vary when invoked by client (app1_data) v/s server (app2_data)
+    appln_data_dir          = parsed_args.appln_data_dir.rstrip('/')
     measurement             = parsed_args.measurement
     operation               = parsed_args.operation
     pf_attest_endorsement   = parsed_args.pf_attest_endorsement
@@ -70,10 +84,11 @@ def do_main(args) -> bool:
         print('INITIALIZED_CERT_SIZE = ', policy_key.INITIALIZED_CERT_SIZE)
         print('INITIALIZED_CERT[] size = ', len(policy_key.INITIALIZED_CERT))
         print('pf_file_name = ', pf_file_name)
+        print('appln_data_dir = ', appln_data_dir)
 
     purpose = 'authentication'
     enclave_type = 'simulated-enclave'
-    store_file = app1_data_dir + '/' + policy_store_file
+    store_file = os.path.join(appln_data_dir, policy_store_file)
 
     cctm = cfm.cc_trust_manager(enclave_type, purpose, store_file)
 
@@ -90,15 +105,15 @@ def do_main(args) -> bool:
     # -------------------------------------------------------------------------
     # Open hard-coded key / platform endorsement & app-measurement files
     # and read-in data as a bytestream.
-    attest_key_file_name = app1_data_dir + '/' + attest_key_file
+    attest_key_file_name = os.path.join(appln_data_dir, attest_key_file)
     with open(attest_key_file_name, 'rb') as attest_key_file_fh:
         attest_key_bin = attest_key_file_fh.read()
 
-    measurement_file_name = app1_data_dir + '/' + measurement
+    measurement_file_name = os.path.join(appln_data_dir, measurement)
     with open(measurement_file_name, 'rb') as measurement_fh:
         example_app_measurement = measurement_fh.read()
 
-    attest_endorsement_file_name = app1_data_dir + '/' + pf_attest_endorsement
+    attest_endorsement_file_name = os.path.join(appln_data_dir, pf_attest_endorsement)
     with open(attest_endorsement_file_name, 'rb') as attest_endorsement_fh:
         platform_attest_endorsement_bin = attest_endorsement_fh.read()
 
@@ -123,6 +138,7 @@ def do_main(args) -> bool:
 
     public_key_alg = "rsa-2048"
     symmetric_key_alg = "aes-256-cbc-hmac-sha256"
+    whoami = 'unknown'
 
     # -------------------------------------------------------------------------
     # Should succeed with valid key algorithm names, after policy key has been
@@ -147,6 +163,12 @@ def do_main(args) -> bool:
             print(fnl(), 'certify_me() failed\n')
             sys.exit(1)
 
+        # Server will persist required files upon certification.
+        if appln_data_dir.endswith(SERVER_APP_DATA):
+            whoami = 'server'
+            # Persist cert-and-key files in the provisioning dir.
+            write_cert_pvt_key_to_files(cctm, whoami, PROVISIONING_DIR, print_all)
+
     # -------------------------------------------------------------------------
     elif operation == 'run-app-as-server':
         print(operation)
@@ -156,12 +178,8 @@ def do_main(args) -> bool:
             print(fnl(), 'warm_restart() failed\n')
             sys.exit(1)
 
-        # (fixme): For now we invoke this method with NULL 'server_application'
-        # function ptr, just to get the basic plumbing working. This will be
-        # extended to implement the client-server communication through
-        # secure channel established.
-        result = cfm.server_dispatch(server_app_host, server_app_port,
-                                     cctm, None)
+        result = server_dispatch(PROVISIONING_DIR,
+                                 server_app_host, server_app_port)
         if result is False:
             print(fnl(), 'server_dispatch() failed\n')
             sys.exit(1)
@@ -169,9 +187,6 @@ def do_main(args) -> bool:
     # -------------------------------------------------------------------------
     elif operation == 'run-app-as-client':
         print(operation)
-        my_role = 'client'
-        channel = cfm.secure_authenticated_channel(my_role)
-
         result = cctm.warm_restart()
         if result is False:
             print(fnl(), 'warm_restart() failed\n')
@@ -187,13 +202,157 @@ def do_main(args) -> bool:
             print(fnl(), 'Primary admisison cert is not valid\n')
             sys.exit(1)
 
-        # (fixme): This will currently fail as we have not started the
-        # server process, yet.
-        result = channel.init_client_ssl(server_app_host, server_app_port,
-                                         cctm)
-        assert result is False
+        result = client_dispatch(PROVISIONING_DIR,
+                                 server_app_host, server_app_port)
+        if result is False:
+            print(fnl(), 'client_dispatch() failed\n')
+            sys.exit(1)
 
     return result
+
+###############################################################################
+def write_cert_pvt_key_to_files(cctm, whoami, data_dir, print_all):
+    """
+    Persist certificate(s) and private-keys that have been established as
+    part of certification. Data from cc_trust_manager{} is written to disk,
+    so that, later, Python interfaces requiring certificates can use this
+    data from file(s).
+    """
+    assert whoami == 'server'
+
+    print('cc_auth_key_initialized_ = ', cctm.cc_auth_key_initialized_)
+    print('primary_admissions_cert_valid_ = ', cctm.primary_admissions_cert_valid_)
+
+    cert_outfile = os.path.join(data_dir, APPLN_CERT_SIGNED_BY_ROOT_CA)
+    pkey_outfile = os.path.join(data_dir, APPLN_KEYF_SIGNED_BY_ROOT_CA)
+
+    ca_root_outfile = os.path.join(data_dir, ROOT_CA_POLICY_CERT)
+    dump_cert_to_file(cctm.serialized_primary_admissions_cert_,
+                      cert_outfile, print_all)
+
+    dump_private_key_to_file(cctm, pkey_outfile, print_all)
+
+    dump_cert_to_file(cctm.serialized_policy_cert_, ca_root_outfile, print_all)
+
+###############################################################################
+def server_dispatch(data_dir, server_app_host, server_app_port):
+    """
+    Start a server process listening on a SSL socket waiting for client input.
+    """
+    print(fnl(), 'Start server process ...\n')
+
+    # Server needs to authenticate the client; hence 'Purpose.CLIENT_AUTH'
+    context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+    context.verify_mode = ssl.CERT_REQUIRED
+
+    cert_outfilename = os.path.join(data_dir, APPLN_CERT_SIGNED_BY_ROOT_CA)
+    key_outfilename  = os.path.join(data_dir, APPLN_KEYF_SIGNED_BY_ROOT_CA)
+    context.load_cert_chain(certfile = cert_outfilename, keyfile = key_outfilename)
+
+    ca_root_outfilename = os.path.join(data_dir, ROOT_CA_POLICY_CERT)
+    context.load_verify_locations(cafile = ca_root_outfilename)
+
+    bindsocket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    bindsocket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    bindsocket.bind((server_app_host, server_app_port))
+    bindsocket.listen(10)
+    print('\n', fnl(), 'Waiting for client ...')
+
+    new_socket, fromaddr = bindsocket.accept()
+    print('\n', fnl(), 'Client connected: ', fromaddr[0], ":", fromaddr[1])
+
+    secure_sock = context.wrap_socket(new_socket, server_side=True)
+
+    try:
+        data = secure_sock.recv(1024)
+        print('\n', fnl(), 'Received from client: ', str(data, 'UTF-8'))
+
+        ret_hdr = 'Return back to client: '
+        print('\n', fnl(), 'Return message back to client:', ret_hdr + str(data, 'UTF-8'))
+        secure_sock.write(bytes(ret_hdr, 'UTF-8') +  data)
+    finally:
+        secure_sock.close()
+        bindsocket.close()
+
+    return True
+
+###############################################################################
+def client_dispatch(data_dir, server_app_host, server_app_port):
+    """
+    Start a client app that sends a message via secure SSL connection.
+    """
+    print(fnl(), 'Start client application process ...\n')
+
+    # Client needs to authenticate the server; hence 'Purpose.SERVER_AUTH'
+    context = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
+    context.verify_mode = ssl.CERT_REQUIRED
+
+    cert_outfilename = os.path.join(data_dir, APPLN_CERT_SIGNED_BY_ROOT_CA)
+    key_outfilename  = os.path.join(data_dir, APPLN_KEYF_SIGNED_BY_ROOT_CA)
+    context.load_cert_chain(certfile = cert_outfilename, keyfile = key_outfilename)
+
+    ca_root_outfilename = os.path.join(data_dir, ROOT_CA_POLICY_CERT)
+    context.load_verify_locations(cafile = ca_root_outfilename)
+
+    bindsocket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    bindsocket.setblocking(1)
+    bindsocket.connect((server_app_host, server_app_port))
+
+    secure_sock = context.wrap_socket(bindsocket, server_side=False,
+                                      server_hostname=server_app_host)
+
+    send_msg = 'hello'
+    try:
+        secure_sock.send(bytes(send_msg, 'UTF-8'))
+
+        recv_data = secure_sock.recv(1024)
+        recv_data_str = str(recv_data, 'UTF-8')
+
+        print('\n', fnl(), 'Received message from server:', recv_data_str)
+
+        # Server should have prepended this to our message and returned it
+        assert recv_data_str == 'Return back to client: ' + send_msg
+    finally:
+        secure_sock.close()
+        bindsocket.close()
+    return True
+
+###############################################################################
+def dump_cert_to_file(der_cert, outfile, print_all):
+    """
+    Dump an input certificate 'der_cert' in DER-format to an output file in a
+    known hard-coded provisioning dir. This helper routine exists to exchange
+    in-memory certificate(s) to invoke SSL interfaces that need a file-handle
+    to get a certificate.
+    """
+    pem_cert = ssl.DER_cert_to_PEM_cert(bytes(der_cert, encoding='utf-8',
+                                               errors = 'surrogateescape'))
+
+    with open(outfile, 'wt', encoding = 'UTF-8') as outf:
+        outf.write(pem_cert)
+
+    if print_all:
+        print('\n**** Dumped certificate in PEM-format to:', outfile)
+
+###############################################################################
+def dump_private_key_to_file(cctm, outfile, print_all):
+    """
+    Dump in PEM-format the private key for the certificate.
+    We invoke a trust-manager's method to externalize the private key
+    to disk.
+    NOTE: Here, we are writing out the private-key to a file on the file-system.
+          This is being done just to get the end-to-end flow of this app
+          working and demo'able. Exposing this private key is known to be
+          a potential security hole, and is something that we will have to
+          rework eventually.
+    """
+    result = cctm.write_private_key_to_file(outfile)
+    if result is False:
+        print(fnl(), 'Error writing out private-key to file', outfile)
+        sys.exit(1)
+
+    if print_all:
+        print('\n**** Dumped private key in PEM-format to:', outfile)
 
 ###############################################################################
 # Argument Parsing routine
@@ -220,7 +379,7 @@ def parseargs(args):
                         , help='Attestation key file name, default: '
                                 + ATTEST_KEY_FILE)
 
-    parser.add_argument('--data_dir', dest='app1_data_dir'
+    parser.add_argument('--data_dir', dest='appln_data_dir'
                         , metavar='<app-data-dir>'
                         , default=APP_DATA_DIR
                         , help='Directory for application data, default: '

--- a/src/cc_helpers.cc
+++ b/src/cc_helpers.cc
@@ -1611,6 +1611,43 @@ bool certifier::framework::cc_trust_manager::put_certifiers_in_store() {
                                  serialized_cert_messages);
 }
 
+bool certifier::framework::cc_trust_manager::write_private_key_to_file(
+    const string &filename) {
+  RSA *tmp_rsa = RSA_new();
+  if (!key_to_RSA(private_auth_key_, tmp_rsa)) {
+    printf("%s() error, line %d, Failed to convert private key to "
+           "RSA format.\n",
+           __func__,
+           __LINE__);
+    return false;
+  }
+  FILE *outfh = fopen(filename.c_str(), "wb");
+  if (!outfh) {
+    printf("%s() error, line %d, Failed to open output file: '%s'\n",
+           __func__,
+           __LINE__,
+           filename.c_str());
+    RSA_free(tmp_rsa);
+    return false;
+  }
+  PEM_write_RSAPrivateKey(outfh,
+                          tmp_rsa,
+                          nullptr,
+                          nullptr,
+                          0,
+                          nullptr,
+                          nullptr);
+  fclose(outfh);
+  RSA_free(tmp_rsa);
+
+#ifdef DEBUG
+  printf("%s(): Wrote private key in PEM-format to file '%s'\n",
+         __func__,
+         filename.c_str());
+#endif  // DEBUG
+  return true;
+}
+
 certifier::framework::certifiers::certifiers(cc_trust_manager *owner) {
   owner_ = owner;
 }

--- a/tests/pytests/test_certifier_framework.py
+++ b/tests/pytests/test_certifier_framework.py
@@ -605,6 +605,37 @@ def test_run_app_as_a_server_with_trust_manager():
     print(' ... cfm.server_dispatch() with cc_trust_manager &mgr interface succeeded.')
 
 # ##############################################################################
+@pytest.mark.needs_cert_service()
+@pytest.mark.check_leaks()
+def test_trust_manager_write_private_key_to_file():
+    """
+    Exercise the utility method to write out the private key to a file.
+    """
+    cctd = cfm.cc_trust_manager('simulated-enclave', 'authentication',
+                                CertPyTestsDir + '/data/policy_store')
+    assert cctd.cc_all_initialized() is False
+
+    # Performs cold_init() and also does warm_restart()
+    result = cc_trust_manager_get_certified(cctd)
+    assert result is True
+    print(' cc_trust_manager_get_certified() succeeded. cc_all_initialized() is True.')
+
+    result = cctd.cc_auth_key_initialized_ and cctd.cc_policy_info_initialized_
+    assert result is True
+    print(' ... cctd.trust data is initialized.')
+
+    # Negative test: Writing to a non-existent file should fail cleanly
+    pvt_key_filename = CertPyTestsDir + '/Junk-XXX-data/test_write_private_key_to_file.key'
+    result = cctd.write_private_key_to_file(pvt_key_filename)
+    assert result is False
+
+    pvt_key_filename = CertPyTestsDir + '/data/test_write_private_key_to_file.key'
+    result = cctd.write_private_key_to_file(pvt_key_filename)
+    assert result is True
+
+    print(' ... cctd.write_private_key_to_file succeeded:', pvt_key_filename)
+
+# ##############################################################################
 # Work-horse function: Implements the steps taken with cc_trust_manager() object.
 # ##############################################################################
 # pylint: disable=too-many-locals


### PR DESCRIPTION
This commit completes the remaining work to setup a secure communication
channel between client and server portions of simple_app_python.
This is modelled on the lines of mTLS communication test.

As Python SSL interfaces only deal with certificates / keys from files, we do the following in this work:

- Add external interface to cc_trust_manager{} to write out the private key to a file.

- As part of 'get-certified' operation, the certificate and  private-key for the client & server get written out to files
  in their respective application data-dir. The CA-root policy cert will also get written out.

- Introduce server_dispatch() and client_dispatch() methods, to   run under the "app-as-server" and "app-as-client" targets.  These methods will establish the secure SSL channel communication, using the certificate & private-key files persisted above.

With this work, simple_app in Python is fully functional demonstrating the exchange of a simple 'Hello' message. (Caveat is that we expect for a real-app, any data persisted will be written to secure storage within a TEE.)

-------

The meat of the success of this program can be seen in this output in CI : `test-run_example-simple_app_python`:

```
run_example.sh: simple_app_python: Running run_app_by_name_as_client_make_trusted_request 
+ /home/runner/work/certifier-framework-for-confidential-computing/certifier-framework-for-confidential-computing/sample_apps/simple_app_python/example_app.py --data_dir=./app1_data/ --operation=run-app-as-client --policy_store_file=policy_store --print_all
 
INITIALIZED_CERT_SIZE =  787
INITIALIZED_CERT[] size =  787
pf_file_name =  platform_file.bin
appln_data_dir =  ./app1_data
Size of bytes() array = 787
attest_key_file_name         = ./app1_data/attest_key_file.bin , attest_key_bin len = 1219
measurement_file_name        = ./app1_data/example_app.measurement , measurement len =  32
attest_endorsement_file_name = ./app1_data/platform_attest_endorsement.bin , pf_attest_endorsement_bin = 1358
 
run-app-as-client
client_dispatch:301 Start client application process ...
 server_dispatch:279 Client connected:  127.0.0.1 : 56860
 server_dispatch:285 Received from client:  hello
 server_dispatch:288 Return message back to client: Return back to client: hello
 client_dispatch:328 Received message from server: Return back to client: hello
```

... where the exchange of messages between client and server can be seen.