### PR TITLE
(#215) Fix scripts, Makefiles to have test.sh run on other Linux dev boxes.

### DIFF
--- a/CI/scripts/test.sh
+++ b/CI/scripts/test.sh
@@ -231,8 +231,8 @@ function unit-test-certlib-utility-programs() {
     pushd utilities > /dev/null 2>&1
 
     # Build utilities
-    make -j2 -f cert_utility.mak
-    make -j2 -f policy_utilities.mak
+    make -j${NumMakeThreads} -f cert_utility.mak
+    make -j${NumMakeThreads} -f policy_utilities.mak
 
     popd > /dev/null 2>&1
 
@@ -424,7 +424,7 @@ function test-run_example-simple_app() {
 
     # Rebuild shared library that pytest needs
     pushd ../src > /dev/null 2>&1
-    make -f certifier.mak --always-make -j2 sharedlib
+    NO_ENABLE_SEV=1 make -f certifier.mak --always-make -j${NumMakeThreads} sharedlib
     popd > /dev/null 2>&1
 
     # Re-start Certifier Service as script, above, would have shut it down
@@ -587,7 +587,7 @@ function test-certifier-build-and-test-simulated-SEV-mode() {
     pushd src > /dev/null 2>&1
 
     make -f certifier_tests.mak clean
-    ENABLE_SEV=1 make -j2 -f certifier_tests.mak
+    ENABLE_SEV=1 make -j${NumMakeThreads} -f certifier_tests.mak
     sudo ./certifier_tests.exe --print_all=true
 
     echo " "
@@ -597,7 +597,7 @@ function test-certifier-build-and-test-simulated-SEV-mode() {
     echo " "
     make -f certifier.mak clean
     make -f certifier_tests.mak clean
-    ENABLE_SEV=1 make -j2 -f certifier.mak
+    ENABLE_SEV=1 make -j${NumMakeThreads} -f certifier.mak
 
     popd > /dev/null 2>&1
 

--- a/src/certifier.mak
+++ b/src/certifier.mak
@@ -1,7 +1,9 @@
 #    
 #    File: certifier.mak
 
-ENABLE_SEV=1
+ifndef NO_ENABLE_SEV
+    ENABLE_SEV=1
+endif
 
 # CERTIFIER_ROOT will be certifier-framework-for-confidential-computing/ dir
 CERTIFIER_ROOT = ..
@@ -23,7 +25,9 @@ endif
 #GOOGLE_INCLUDE=/usr/local/include/google
 #endif
 
-LOCAL_LIB=/usr/local/lib
+ifndef LOCAL_LIB
+    LOCAL_LIB=/usr/local/lib
+endif
 
 ifndef TARGET_MACHINE_TYPE
 TARGET_MACHINE_TYPE= x64

--- a/src/certifier_tests.mak
+++ b/src/certifier_tests.mak
@@ -24,7 +24,9 @@ endif
 #GOOGLE_INCLUDE=/usr/local/include/google
 #endif
 
-LOCAL_LIB=/usr/local/lib
+ifndef LOCAL_LIB
+    LOCAL_LIB=/usr/local/lib
+endif
 
 ifndef TARGET_MACHINE_TYPE
 TARGET_MACHINE_TYPE= x64

--- a/src/keystone/shim_test.mak
+++ b/src/keystone/shim_test.mak
@@ -22,7 +22,9 @@ endif
 #GOOGLE_INCLUDE=/usr/local/include/google
 #endif
 
-LOCAL_LIB=/usr/local/lib
+ifndef LOCAL_LIB
+    LOCAL_LIB=/usr/local/lib
+endif
 
 ifndef TARGET_MACHINE_TYPE
 TARGET_MACHINE_TYPE= x64

--- a/tests/gen_client_server_certs_key_files.sh
+++ b/tests/gen_client_server_certs_key_files.sh
@@ -34,6 +34,12 @@ pushd "${TEST_DATA}" > /dev/null 2>&1
 # In more current OpenSSL v3.0 and later, use -noenc.
 # If your OpenSSL installation is older, change this to -nodes
 pvt_key_encr_arg="-noenc"
+set +e
+open_ssl_ver_is_1x=$(openssl version | grep -c "OpenSSL 1\.")
+set -e
+if [ "${open_ssl_ver_is_1x}" -eq 1 ]; then
+    pvt_key_encr_arg="-nodes"
+fi
 
 echo "${Me}: Generating self-signed server public certificate and private-key ..."
 openssl req -batch -new -x509 -days 365 ${pvt_key_encr_arg} \


### PR DESCRIPTION
This commit does some clean-up of scripts and Makefiles so that the newly-added test.sh can be used by other dev engineers on diff Linux physical machines.

- Fix few Makefiles to allow re-specifying LOCAL_LIB, to point to, say, /usr/local/lib (for SSL libs, e.g.)
- Hacky support to allow use of OpenSSL V1.x versions

- Add NO_ENABLE_SEV=1 flag in certifier.mak, so that we can build
      shared library without #include'ing SEV_SNP-specific code. This
      seems to cause pytests which to "hang" as they end up calling
      SEV_SNP code-paths.

    Use this new flag when building shared-libraries in the  test-run_example-simple_app() test-case, in test.sh .
        This is used to execute pytests that need Certifier Service.

---
**NOTE**:  It’s not a complete fix, i.e., it does not address all the points Rado brought up. I just did enough clean-up to get test.sh running reasonably stably on Ye’s SGX box, w/o destabilizing CI jobs.
