### PR TITLE
(#214) Persist private-key data to named temp files. Rework warm_restart() execution.

### DIFF
--- a/sample_apps/simple_app_python/example_app.py
+++ b/sample_apps/simple_app_python/example_app.py
@@ -299,9 +299,8 @@ def setup_server_ssl_context(cctm, data_dir:str, print_all:bool):
     cert_outfilename = os.path.join(data_dir, APPLN_CERT_SIGNED_BY_ROOT_CA)
 
     with TemporaryDirectory() as tempdir:
-        with NamedTemporaryFile('wt', dir=tempdir, delete=False) as temp_keyf:
-            temp_keyf.close()
-
+        # With Python v3.10, can also add: delete_on_close=True (default)
+        with NamedTemporaryFile('wt', dir=tempdir, delete=True) as temp_keyf:
             dump_private_key_to_file(cctm, temp_keyf.name, 'server', print_all)
 
             context.load_cert_chain(certfile = cert_outfilename,
@@ -385,9 +384,8 @@ def setup_client_ssl_context(cctm, data_dir:str, print_all:bool):
     cert_outfilename = os.path.join(data_dir, APPLN_CERT_SIGNED_BY_ROOT_CA)
 
     with TemporaryDirectory() as tempdir:
-        with NamedTemporaryFile('wt', dir=tempdir, delete=False) as temp_keyf:
-            temp_keyf.close()
-
+        # With Python v3.10, can also add: delete_on_close=True (default)
+        with NamedTemporaryFile('wt', dir=tempdir, delete=True) as temp_keyf:
             dump_private_key_to_file(cctm, temp_keyf.name, 'client', print_all)
 
             context.load_cert_chain(certfile = cert_outfilename,

--- a/sample_apps/simple_app_python/example_app.py
+++ b/sample_apps/simple_app_python/example_app.py
@@ -13,8 +13,8 @@ import argparse
 from tempfile import TemporaryDirectory, NamedTemporaryFile
 from inspect import currentframe
 
-import policy_key
 import certifier_framework as cfm
+import policy_key
 
 ###############################################################################
 # Global Variables: Used in multiple places. List here for documentation
@@ -26,7 +26,6 @@ THIS_SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 # Script defaults
 ATTEST_KEY_FILE                 = 'attest_key_file.bin'
 APP_DATA_DIR                    = './app1_data/'
-PROVISIONING_DIR                = './provisioning'
 EXAMPLE_MEASUREMENT             = 'example_app.measurement'
 APP_OP_TYPES                    = 'cold-init, get-certified, run-app-as-client, run-app-as-server'
 PLATFORM_ATTEST_ENDORSEMENT     = 'platform_attest_endorsement.bin'
@@ -36,12 +35,6 @@ POLICY_HOST                     = 'localhost'
 POLICY_HOST_PORT                = 8123
 SERVER_APP_HOST                 = '127.0.0.1'
 SERVER_APP_PORT                 = 8124
-
-# ------------------------------------------------------------------------------
-# Script global symbols to app-data dirs.
-CLIENT_APP_DATA='app1_data'
-SERVER_APP_DATA='app2_data'
-PROVISIONING_DIR='./provisioning'
 
 # Basenames for output files created to persist certificates and keys
 APPLN_CERT_SIGNED_BY_ROOT_CA = 'appln.PEM.cert'
@@ -173,8 +166,8 @@ def do_main(args) -> bool:
             print(fnl(), 'warm_restart() failed\n')
             sys.exit(1)
 
-        write_certficates_to_file(cctm, 'server', PROVISIONING_DIR, print_all)
-        result = server_dispatch(cctm, PROVISIONING_DIR,
+        write_certificates_to_file(cctm, 'server', appln_data_dir, print_all)
+        result = server_dispatch(cctm, appln_data_dir,
                                  server_app_host, server_app_port, print_all)
         if result is False:
             print(fnl(), 'server_dispatch() failed\n')
@@ -198,8 +191,8 @@ def do_main(args) -> bool:
             print(fnl(), 'Primary admisison cert is not valid\n')
             sys.exit(1)
 
-        write_certficates_to_file(cctm, 'client', PROVISIONING_DIR, print_all)
-        result = client_dispatch(cctm, PROVISIONING_DIR,
+        write_certificates_to_file(cctm, 'client', appln_data_dir, print_all)
+        result = client_dispatch(cctm, appln_data_dir,
                                  server_app_host, server_app_port, print_all)
         if result is False:
             print(fnl(), 'client_dispatch() failed\n')
@@ -208,7 +201,7 @@ def do_main(args) -> bool:
     return result
 
 ###############################################################################
-def write_certficates_to_file(cctm, whoami, data_dir, print_all):
+def write_certificates_to_file(cctm, whoami, data_dir, print_all):
     """
     Persist app's and root-certificate(s) that have been established as
     part of certification. Data from cc_trust_manager{} is written to disk,
@@ -439,6 +432,10 @@ def parseargs(args):
     """
     Command-line argument parser. Use './example_app.py --help' to get usage info.
     """
+    # Symbols used in --help info messages
+    client_app_data='app1_data'
+    server_app_data='app2_data'
+
     # ======================================================
     # Start of argument parser, with inline examples text
     # Create 'parser' as object of type ArgumentParser
@@ -449,13 +446,13 @@ def parseargs(args):
 
 - Run App-as-Server talk to Certifier Service:
 
-  simple_app_python/example_app.py --data-dir=./{SERVER_APP_DATA} \\
+  simple_app_python/example_app.py --data-dir=./{server_app_data} \\
                                    --operation=cold-init \\
                                    --measurement_file=example_app.measurement \\
                                    --policy_store_file=policy_store \\
                                    [ --print_all ]
 
-  simple_app_python/example_app.py --data-dir=./{SERVER_APP_DATA} \\
+  simple_app_python/example_app.py --data-dir=./{server_app_data} \\
                                    --operation=get-certified \\
                                    --measurement_file=example_app.measurement \\
                                    --policy_store_file=policy_store \\
@@ -463,13 +460,13 @@ def parseargs(args):
 
 - Run App-as-Client talk to Certifier Service:
 
-  simple_app_python/example_app.py --data-dir=./{CLIENT_APP_DATA} \\
+  simple_app_python/example_app.py --data-dir=./{client_app_data} \\
                                    --operation=cold-init \\
                                    --measurement_file=example_app.measurement \\
                                    --policy_store_file=policy_store \\
                                    [ --print_all ]
 
-  simple_app_python/example_app.py --data-dir=./{CLIENT_APP_DATA} \\
+  simple_app_python/example_app.py --data-dir=./{client_app_data} \\
                                    --operation=get-certified \\
                                    --measurement_file=example_app.measurement \\
                                    --policy_store_file=policy_store \\
@@ -477,14 +474,14 @@ def parseargs(args):
 
 - Run App-as-Server offers Trusted Service:
 
-  simple_app_python/example_app.py --data-dir=./{SERVER_APP_DATA} \\
+  simple_app_python/example_app.py --data-dir=./{server_app_data} \\
                                    --operation=run-app-as-server \\
                                    --policy_store_file=policy_store \\
                                    [ --print_all ]
 
 - Run App-as-Client makes Trusted Request:
 
-  simple_app_python/example_app.py --data-dir=./{CLIENT_APP_DATA} \\
+  simple_app_python/example_app.py --data-dir=./{client_app_data} \\
                                    --operation=run-app-as-client \\
                                    --policy_store_file=policy_store \\
                                    [ --print_all ]

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,14 +1,14 @@
 # Tests README
 
 This directory contains a collection of setup-type scripts required by tests
-run as part of CI. 
+that are run as part of CI.
 
 A collection of Python pytests live in the [./pytests](.pytests/) directory.
 
-The tests executed as part of CI can be executed in your development
-environmnet stand-alone using the [./test.sh](../CI/scripts/test.sh) script.
+The tests executed as part of CI can be executed stand-alone in your
+development environment using the [./test.sh](../CI/scripts/test.sh) script.
 
-### Usage
+## Usage
 
 ```
 Usage: test.sh [--help | --list] [ --from-test <test-function-name> ] [test_all]
@@ -16,8 +16,8 @@ Usage: test.sh [--help | --list] [ --from-test <test-function-name> ] [test_all]
 
 - List the tests that can be run: `$ test.sh --list`
 
-  This option will list the names of functions, i.e., test targets, driving a
-  specific test execution. 
+  This option will list the names of functions, i.e., test targets, driving
+  the execution of a specific test scenario.
 
 - Run all the tests: `$ test.sh`
 - Run a specific test: `$ test.sh <test-name>`
@@ -34,6 +34,15 @@ Usage: test.sh [--help | --list] [ --from-test <test-function-name> ] [test_all]
     This will resume test execution from the `test-build-and-install-sev-snp-simulator`
     test to run the remaining tests in the order reported by the `--list` argument.
 
+## Executing test targets: `--list` output
+
+Execution of some tests / test-cases needs multiple steps that need to be
+executed in a sequence. One of the goals of `test.sh` is to encapsulate this
+workflow [of steps] in a single test-execution target, found in the output
+of the `--list` command.
+
+Here are some examples:
+
 - The execution of Python pytests is distributed across these test targets:
 
     - test-cert_framework-pytests
@@ -41,3 +50,21 @@ Usage: test.sh [--help | --list] [ --from-test <test-function-name> ] [test_all]
     - test-mtls-ssl-client-server-comm-pytest
 
     - test-run_example-simple_app
+
+  Each of these can be run using a named test-target. For example:
+
+    ```
+    $ ./test.sh test-cert_framework-pytests
+
+    $ ./test.sh test-mtls-ssl-client-server-comm-pytest
+
+    $ ./test.sh test-run_example-simple_app
+    ```
+
+- Executing simple_app under Application Service needs a multi-step
+  workflow. These are enacpsulated under a single test-target,
+  executed as:
+
+  ```
+  $ ./test.sh test-build-and-setup-App-Service-and-simple_app_under_app_service
+  ```


### PR DESCRIPTION
This commit re-works the way private-key data is managed to be able to call Python SSL interfaces that require certificate and private-key data to be read from files. 

In Python `example_app.py`, private-key data that is instantiated in the `cc_trust_manager{}` object by reading it from the policy-store, will be written to named temp files, in anonymous but-named temp dirs. 

The private-key data will exist **very briefly in the tmp-files** while the SSL certificate-related method is invoked to load-certs.

With this change, `example_app.py` also now handles the case when trust-data is re-loaded from the policy-store by a warm-restart operation. 

Existing pytests have been refactored and extended to add a new pair of client/server tests going thru secure-SSL communication exchange, working off private-key data that is [now] persisted to tmp-files.

`test.sh` is extended to invoke this new pair of secure-channel test-cases. Existing `simple_app_python` test-execution  target is extended to exercise a variation where client-and-server can be restarted, without the Certifier Service, to verify the re-establishment of secure data thru `warm_restart()`.

----
**NOTE**: 

See the internal engineering analysis doc, here: [2023-11-CF-In-Memory-Private-Key-Support](https://onevmw.sharepoint.com/:w:/r/teams/VSE/Shared%20Documents/General/Internal/Engineering/2023-11-CF-In-Memory-Private-Key-Support.docx?d=w90ea145aed7e47938352896953be4fa7&csf=1&web=1&e=l6WFY6)
  where the gory details of Python SSL support efforts done in the public domain have been traced & documented.
  
  This doc gives the reasons why the only solution available to us now is the use of named temporary files.

As of this writing (Nov 2023), there is no support in Python OpenSSL interfaces to load certificates or private-keys
directly from in-memory data. We have to invoke SSL interfaces using files containing such data. Based on
the feedback on one of the threads listed in the above doc, the solution implemented for issue #214 is the use of very short-lived named temp-files created in anonymous but-named temp-dirs.
