### PR TITLE
(#167) Extend run_example.sh to build-and-test multidomain simple_app workflow.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,6 +106,11 @@ jobs:
         ./CI/scripts/test.sh test-build-and-setup-App-Service-and-simple_app_under_app_service
 
     #! -------------------------------------------------------------------------
+    - name: test-run_example-multidomain_simple_app
+      run: |
+        ./CI/scripts/test.sh test-run_example-multidomain_simple_app
+
+    #! -------------------------------------------------------------------------
     - name: test-build-and-install-sev-snp-simulator
       run: |
         ./CI/scripts/test.sh test-build-and-install-sev-snp-simulator

--- a/CI/scripts/test.sh
+++ b/CI/scripts/test.sh
@@ -61,6 +61,7 @@ TestList=( "test-core-certifier-programs"
            "test-run_example-simple_app"
            "test-run_example-simple_app_python"
            "test-build-and-setup-App-Service-and-simple_app_under_app_service"
+           "test-run_example-multidomain_simple_app"
            "test-build-and-install-sev-snp-simulator"
            "test-sev-snp-simulator-sev-test"
            "test-certifier-build-and-test-simulated-SEV-mode"
@@ -355,6 +356,8 @@ function test-run_example-help-list-args() {
 
     ./run_example.sh --list simple_app_python
 
+    ./run_example.sh --list multidomain_simple_app
+
     popd > /dev/null 2>&1
 }
 
@@ -403,6 +406,10 @@ function test-run_example-dry-run() {
     ./run_example.sh --dry-run simple_app_under_islet run_test
 
     ./run_example.sh --dry-run simple_app_python
+
+    ./run_example.sh --dry-run multidomain_simple_app
+    ./run_example.sh --dry-run multidomain_simple_app setup
+    ./run_example.sh --dry-run multidomain_simple_app run_test
 
     popd > /dev/null 2>&1
 }
@@ -590,6 +597,28 @@ function test-build-and-setup-App-Service-and-simple_app_under_app_service() {
     # shellcheck disable=SC2009
     ps -ef | grep -v -E 'root|^sys'
     echo " "
+}
+
+# #############################################################################
+function test-run_example-multidomain_simple_app() {
+    echo "************************************************************************"
+    echo "* Test: Execute script to compile, build and run multidomain_simple_app."
+    echo "************************************************************************"
+    echo " "
+    pushd ./sample_apps > /dev/null 2>&1
+
+    ./cleanup.sh
+
+    set -x
+    # shellcheck disable=SC2009
+    ps -ef | grep -E 'simpleserver|example_app.exe|run_example.sh|app_service.exe'
+    set +x
+
+    ./run_example.sh multidomain_simple_app
+
+    ./cleanup.sh
+
+    popd > /dev/null 2>&1
 }
 
 # #############################################################################

--- a/sample_apps/multidomain_simple_app/script
+++ b/sample_apps/multidomain_simple_app/script
@@ -1,236 +1,397 @@
+#!/bin/bash
+# #############################################################################
+# Helpful stand-alone script to run multi-domain example simple_app
+# #############################################################################
 #
-# Helpful script to run example
-#
+set -Eeuo pipefail
 
-#export GOROOT=/usr/local/go
-#export PATH=$PATH:$GOROOT/bin
-#export GO111MODULE=off
 export GOPATH=$HOME
-export CERTIFIER_PROTOTYPE=~/src/github.com/jlmucb/crypto/v2/certifier-framework-for-confidential-computing
+
+pushd "$(dirname "$0")" > /dev/null 2>&1
+
+cd ../..
+CERTIFIER_PROTOTYPE="$(pwd)"; export CERTIFIER_PROTOTYPE
+
+popd
+
 export MULTIDOMAIN_EXAMPLE_DIR=$CERTIFIER_PROTOTYPE/sample_apps/multidomain_simple_app
+
+NumCPUs=1
+if [ "$(uname -s)" = "Linux" ]; then
+    NumCPUs=$(grep -c "^processor" /proc/cpuinfo)
+fi
+# Cap # of -j threads for make to 8
+NumMakeThreads=${NumCPUs}
+if [ "${NumMakeThreads}" -gt 8 ]; then NumMakeThreads=8; fi
 
 # Compile utilities
 cd $CERTIFIER_PROTOTYPE/utilities
-make -f cert_utility.mak
-make -f policy_utilities.mak
+make -j "${NumMakeThreads}" -f cert_utility.mak
+make -j "${NumMakeThreads}" -f policy_utilities.mak
 
 # Create keys
 mkdir -p $MULTIDOMAIN_EXAMPLE_DIR/provisioning
 
+set -x
+
+# ---------------------------------------------------------------------------
+# Implemented in gen_policy_and_self_signed_cert()
+# ---------------------------------------------------------------------------
 cd $MULTIDOMAIN_EXAMPLE_DIR/provisioning
 
-$CERTIFIER_PROTOTYPE/utilities/cert_utility.exe --operation=generate-policy-key-and-test-keys \
+$CERTIFIER_PROTOTYPE/utilities/cert_utility.exe \
+    --operation=generate-policy-key-and-test-keys \
 	--policy_key_name=client-policy-key \
 	--policy_key_output_file=client_policy_key_file.bin \
 	--policy_cert_output_file=client_policy_cert_file.bin \
 	--platform_key_output_file=platform_key_file.bin \
 	--attest_key_output_file=attest_key_file.bin
 
-$CERTIFIER_PROTOTYPE/utilities/cert_utility.exe --operation=generate-policy-key-and-test-keys \
+$CERTIFIER_PROTOTYPE/utilities/cert_utility.exe \
+    --operation=generate-policy-key-and-test-keys \
 	--policy_key_name=server-policy-key \
 	--policy_key_output_file=server_policy_key_file.bin \
 	--policy_cert_output_file=server_policy_cert_file.bin \
 	--platform_key_output_file=platform_key_file.bin \
 	--attest_key_output_file=attest_key_file.bin
 
-
+# ---------------------------------------------------------------------------
+# Implemented in gen_policy_key_for_example_app()
+# ---------------------------------------------------------------------------
 # embed policy key and compile app
 cd $MULTIDOMAIN_EXAMPLE_DIR/provisioning
 $CERTIFIER_PROTOTYPE/utilities/embed_policy_key.exe \
 	--input=client_policy_cert_file.bin \
 	--output=../client_policy_key.cc
+
 $CERTIFIER_PROTOTYPE/utilities/embed_policy_key.exe \
 	--input=server_policy_cert_file.bin \
 	--output=../server_policy_key.cc
 
 # make app and compute app measurement
 cd $MULTIDOMAIN_EXAMPLE_DIR
-make -f multidomain_app.mak
+make -j "${NumMakeThreads}" -f multidomain_app.mak
 
 # build policy
 cd $MULTIDOMAIN_EXAMPLE_DIR/provisioning
 
-#policyKey says platformKey is-trused-for-attestation
+# ---------------------------------------------------------------------------
+# policyKey says platformKey is-trusted-for-attestation
 
 $CERTIFIER_PROTOTYPE/utilities/make_unary_vse_clause.exe \
 	--key_subject=platform_key_file.bin \
-	--verb="is-trusted-for-attestation" --output=ts1.bin
+	--verb="is-trusted-for-attestation" \
+    --output=ts1.bin
 
-# vse_policy1a.bin is server-policy-key says platform-key is-trusted-for-attestation
+# server_vse_policy1a.bin is server-policy-key says platform-key is-trusted-for-attestation
 $CERTIFIER_PROTOTYPE/utilities/make_indirect_vse_clause.exe \
 	--key_subject=server_policy_key_file.bin \
-	--verb="says" --clause=ts1.bin --output=vse_policy1a.bin
-# vse_policy1b.bin is client-policy-key says platform-key is-trusted-for-attestation
+	--verb="says" \
+    --clause=ts1.bin \
+    --output=server_vse_policy1a.bin
+
+# client_vse_policy1b.bin is client-policy-key says platform-key is-trusted-for-attestation
 $CERTIFIER_PROTOTYPE/utilities/make_indirect_vse_clause.exe \
 	--key_subject=client_policy_key_file.bin \
-	--verb="says" --clause=ts1.bin --output=vse_policy1b.bin
+	--verb="says" \
+    --clause=ts1.bin \
+    --output=client_vse_policy1b.bin
+
+# Up to here done in construct_policyKey_platform_is_trusted_multidomain_simple_app()
+
+# ---------------------------------------------------------------------------
+# Implemented in produce_signed_claims_for_vse_policy_statement_multidomain_simple_app()
+# ---------------------------------------------------------------------------
+#
+$CERTIFIER_PROTOTYPE/utilities/make_signed_claim_from_vse_clause.exe \
+	--vse_file=server_vse_policy1a.bin \
+	--duration=9000 \
+    --private_key_file=server_policy_key_file.bin \
+	--output=server_signed_claim_1a.bin
 
 $CERTIFIER_PROTOTYPE/utilities/make_signed_claim_from_vse_clause.exe \
-	--vse_file=vse_policy1a.bin \
-	--duration=9000 --private_key_file=server_policy_key_file.bin \
-	--output=signed_claim_1a.bin
-$CERTIFIER_PROTOTYPE/utilities/make_signed_claim_from_vse_clause.exe \
-	--vse_file=vse_policy1b.bin --duration=9000 \
+	--vse_file=client_vse_policy1b.bin \
+    --duration=9000 \
 	--private_key_file=client_policy_key_file.bin \
-	--output=signed_claim_1b.bin
+	--output=client_signed_claim_1b.bin
 
+# ---------------------------------------------------------------------------
+# Implemented in get_measurement_of_app_by_name()
+# ---------------------------------------------------------------------------
 # policy key says measurement is-trusted
 $CERTIFIER_PROTOTYPE/utilities/measurement_utility.exe --type=hash \
 	--input=../multidomain_client_app.exe \
 	--output=multidomain_client_app.measurement
+
 $CERTIFIER_PROTOTYPE/utilities/measurement_utility.exe --type=hash \
 	--input=../multidomain_server_app.exe \
 	--output=multidomain_server_app.measurement
 
-#ts2a is server-measurement is-trusted
-$CERTIFIER_PROTOTYPE/utilities/make_unary_vse_clause.exe --key_subject="" \
+# ---------------------------------------------------------------------------
+# Implemented in construct_policyKey_measurement_is_trusted_multidomain_simple_app()
+# ---------------------------------------------------------------------------
+
+# Above two measurements generated in get_measurement_of_app_by_name()
+
+# ts2a is server-measurement is-trusted
+$CERTIFIER_PROTOTYPE/utilities/make_unary_vse_clause.exe \
+    --key_subject="" \
 	--measurement_subject=multidomain_server_app.measurement \
-	--verb="is-trusted" --output=ts2a.bin
-#ts2b is client-measurement is-trusted
-$CERTIFIER_PROTOTYPE/utilities/make_unary_vse_clause.exe --key_subject="" \
-	--measurement_subject=multidomain_client_app.measurement \
-	--verb="is-trusted" --output=ts2b.bin
+	--verb="is-trusted" \
+    --output=ts2a-md-server.bin
 
 # vse_policy2a is server-policy-key says server_measurement is-trusted
 $CERTIFIER_PROTOTYPE/utilities/make_indirect_vse_clause.exe \
 	--key_subject=server_policy_key_file.bin \
-	--verb="says" --clause=ts2a.bin --output=vse_policy2a.bin
+	--verb="says" \
+    --clause=ts2a-md-server.bin \
+    --output=server_vse_policy2a.bin
+
+# ts2b is client-measurement is-trusted
+$CERTIFIER_PROTOTYPE/utilities/make_unary_vse_clause.exe \
+    --key_subject="" \
+	--measurement_subject=multidomain_client_app.measurement \
+	--verb="is-trusted" \
+    --output=ts2b-md-client.bin
+
 # vse_policy2b is server-policy-key says client_measurement is-trusted
 $CERTIFIER_PROTOTYPE/utilities/make_indirect_vse_clause.exe \
 	--key_subject=server_policy_key_file.bin \
-	--verb="says" --clause=ts2b.bin --output=vse_policy2b.bin
+	--verb="says" \
+    --clause=ts2b-md-client.bin \
+    --output=server_vse_policy2b.bin
+
 # vse_policy2c is client-policy-key says server_measurement is-trusted
 $CERTIFIER_PROTOTYPE/utilities/make_indirect_vse_clause.exe \
 	--key_subject=client_policy_key_file.bin \
-	--verb="says" --clause=ts2a.bin --output=vse_policy2c.bin
+	--verb="says" \
+    --clause=ts2a-md-server.bin \
+    --output=client_vse_policy2c.bin
+
 # vse_policy2d is client-policy-key says client_measurement is-trusted
 $CERTIFIER_PROTOTYPE/utilities/make_indirect_vse_clause.exe \
 	--key_subject=client_policy_key_file.bin \
-	--verb="says" --clause=ts2b.bin --output=vse_policy2d.bin
+	--verb="says" \
+    --clause=ts2b-md-client.bin \
+    --output=client_vse_policy2d.bin
 
-#Both measurements are trusted in both domains
+#-- End of construct_policyKey_measurement_is_trusted_multidomain_simple_app()
 
-#server-policy-key signs vse_policy2a and policy2b
+# ---------------------------------------------------------------------------
+# Implemented in produce_signed_claims_for_vse_policy_statement_multidomain_simple_app()
+# ---------------------------------------------------------------------------
+
+# Both measurements are trusted in both domains
+
+# server-policy-key signs vse_policy2a and policy2b
 $CERTIFIER_PROTOTYPE/utilities/make_signed_claim_from_vse_clause.exe \
-	--vse_file=vse_policy2a.bin --duration=9000 \
+	--vse_file=server_vse_policy2a.bin \
+    --duration=9000 \
 	--private_key_file=server_policy_key_file.bin \
 	--output=server_signed_claim_2a.bin
+
 $CERTIFIER_PROTOTYPE/utilities/make_signed_claim_from_vse_clause.exe \
-	--vse_file=vse_policy2b.bin --duration=9000 \
+	--vse_file=server_vse_policy2b.bin \
+    --duration=9000 \
 	--private_key_file=server_policy_key_file.bin \
 	--output=server_signed_claim_2b.bin
 
-#client-policy-key signs vse_policy2c and policy2d
+# client-policy-key signs vse_policy2c and policy2d
 $CERTIFIER_PROTOTYPE/utilities/make_signed_claim_from_vse_clause.exe \
-	--vse_file=vse_policy2c.bin --duration=9000 \
+	--vse_file=client_vse_policy2c.bin \
+    --duration=9000 \
 	--private_key_file=client_policy_key_file.bin \
 	--output=client_signed_claim_2c.bin
+
 $CERTIFIER_PROTOTYPE/utilities/make_signed_claim_from_vse_clause.exe \
-	--vse_file=vse_policy2d.bin --duration=9000 \
+	--vse_file=client_vse_policy2d.bin \
+    --duration=9000 \
 	--private_key_file=client_policy_key_file.bin \
 	--output=client_signed_claim_2d.bin
 
+# ---------------------------------------------------------------------------
+# Implemented in combine_policy_stmts_multidomain_simple_app()
+# ---------------------------------------------------------------------------
+
 $CERTIFIER_PROTOTYPE/utilities/package_claims.exe \
-	--input=signed_claim_1a.bin,server_signed_claim_2a.bin,server_signed_claim_2b.bin \
+	--input=server_signed_claim_1a.bin,server_signed_claim_2a.bin,server_signed_claim_2b.bin \
 	--output=server_policy.bin
+
 $CERTIFIER_PROTOTYPE/utilities/package_claims.exe \
-	--input=signed_claim_1b.bin,client_signed_claim_2c.bin,client_signed_claim_2d.bin \
+	--input=client_signed_claim_1b.bin,client_signed_claim_2c.bin,client_signed_claim_2d.bin \
 	--output=client_policy.bin
 
+# ---------------------------------------------------------------------------
+# Implemented in print_policy()
+# ---------------------------------------------------------------------------
 $CERTIFIER_PROTOTYPE/utilities/print_packaged_claims.exe --input=server_policy.bin
 $CERTIFIER_PROTOTYPE/utilities/print_packaged_claims.exe --input=client_policy.bin
 
+# ---------------------------------------------------------------------------
+# Implemented in construct_platform_key_attestation_stmt_sign_it()
+# ---------------------------------------------------------------------------
 # This gets included from the app
 $CERTIFIER_PROTOTYPE/utilities/make_unary_vse_clause.exe \
 	--key_subject=attest_key_file.bin \
-	--verb="is-trusted-for-attestation" --output=tsc1.bin
+	--verb="is-trusted-for-attestation" \
+    --output=tsc1.bin
+
 $CERTIFIER_PROTOTYPE/utilities/make_indirect_vse_clause.exe \
 	--key_subject=platform_key_file.bin \
-	--verb="says" --clause=tsc1.bin --output=vse_policy3.bin
+	--verb="says" \
+    --clause=tsc1.bin \
+    --output=vse_policy3.bin
+
 $CERTIFIER_PROTOTYPE/utilities/make_signed_claim_from_vse_clause.exe \
 	--vse_file=vse_policy3.bin --duration=9000 \
 	--private_key_file=platform_key_file.bin \
 	--output=platform_attest_endorsement.bin
+
+# Implemented in print_signed_claim()
 $CERTIFIER_PROTOTYPE/utilities/print_signed_claim.exe \
 	--input=platform_attest_endorsement.bin
 
+# Implemented in mkdirs_for_test()
 # provision service and apps
 cd $MULTIDOMAIN_EXAMPLE_DIR
+
 mkdir -p app1_data app2_data
 mkdir -p client_service
 mkdir -p server_service
 
+# ---------------------------------------------------------------------------
+# Implemented in provision_app_service_files()
+# ---------------------------------------------------------------------------
 # provision service and apps
 cd $MULTIDOMAIN_EXAMPLE_DIR/provisioning
 
-cp ./* $MULTIDOMAIN_EXAMPLE_DIR/client_service
-cp ./* $MULTIDOMAIN_EXAMPLE_DIR/server_service
-cp ./* $MULTIDOMAIN_EXAMPLE_DIR/app1_data
-cp ./* $MULTIDOMAIN_EXAMPLE_DIR/app2_data
+cp -p ./* $MULTIDOMAIN_EXAMPLE_DIR/client_service
+cp -p ./* $MULTIDOMAIN_EXAMPLE_DIR/server_service
+cp -p ./* $MULTIDOMAIN_EXAMPLE_DIR/app1_data
+cp -p ./* $MULTIDOMAIN_EXAMPLE_DIR/app2_data
 
-#compile the server
-cd $CERTIFIER_PROTOTYPE/certifier_service/graminelib
-make dummy
+# ---------------------------------------------------------------------------
+# Implemented in build_simple_server()
+# ---------------------------------------------------------------------------
+# compile the server
 cd $CERTIFIER_PROTOTYPE/certifier_service/oelib
 make dummy
+
+cd $CERTIFIER_PROTOTYPE/certifier_service/graminelib
+make dummy
+
 cd $CERTIFIER_PROTOTYPE/certifier_service/isletlib
 make dummy
+
 cd $CERTIFIER_PROTOTYPE/certifier_service/teelib
 make
+
 cd $CERTIFIER_PROTOTYPE/certifier_service
 go build simpleserver.go
 
-#run certifier server for server policy in one window
+# ---------------------------------------------------------------------------
+# Implemented in start_certifier_service_multidomain_simple_app()
+# ---------------------------------------------------------------------------
+# run certifier server for server policy in one window
 cd $MULTIDOMAIN_EXAMPLE_DIR/server_service
-$CERTIFIER_PROTOTYPE/certifier_service/simpleserver --port=8121 \
-	--policyFile=server_policy.bin --policy_key_file=server_policy_key_file.bin \
-	--policy_cert_file=server_policy_cert_file.bin --readPolicy=true
-#run certifier server for client policy in another window
-cd $MULTIDOMAIN_EXAMPLE_DIR/client_service
-$CERTIFIER_PROTOTYPE/certifier_service/simpleserver --port=8122 \
-	--policyFile=client_policy.bin --policy_key_file=client_policy_key_file.bin \
-	--policy_cert_file=client_policy_cert_file.bin --readPolicy=true
 
+$CERTIFIER_PROTOTYPE/certifier_service/simpleserver \
+    --port=8121 \
+	--policyFile=server_policy.bin \
+    --policy_key_file=server_policy_key_file.bin \
+	--policy_cert_file=server_policy_cert_file.bin \
+    --readPolicy=true &
+
+sleep 5
+
+# run certifier server for client policy in another window
+cd $MULTIDOMAIN_EXAMPLE_DIR/client_service
+
+$CERTIFIER_PROTOTYPE/certifier_service/simpleserver \
+    --port=8122 \
+	--policyFile=client_policy.bin \
+    --policy_key_file=client_policy_key_file.bin \
+	--policy_cert_file=client_policy_cert_file.bin \
+    --readPolicy=true &
+
+sleep 5
+
+# ---------------------------------------------------------------------------
+# Implemented in run_multidomain_simple_app_as_server_talk_to_Cert_Service()
+# ---------------------------------------------------------------------------
 # initialize server app
 cd $MULTIDOMAIN_EXAMPLE_DIR
-$MULTIDOMAIN_EXAMPLE_DIR/multidomain_server_app.exe --print_all=true \
-	--operation=cold-init --data_dir=./app2_data/ \
+
+$MULTIDOMAIN_EXAMPLE_DIR/multidomain_server_app.exe \
+	--operation=cold-init \
+    --data_dir=./app2_data/ \
 	--measurement_file="multidomain_server_app.measurement" \
-	--policy_store_file=policy_store --policy_port=8121
+	--policy_store_file=policy_store \
+    --policy_port=8121 \
+    --print_all=true
+
 # get server app certified
 cd $MULTIDOMAIN_EXAMPLE_DIR
-$MULTIDOMAIN_EXAMPLE_DIR/multidomain_server_app.exe --print_all=true \
-	--operation=get-certified --data_dir=./app2_data/ \
-	--measurement_file="multidomain_server_app.measurement" \
-	--policy_store_file=policy_store --policy_port=8121
 
+$MULTIDOMAIN_EXAMPLE_DIR/multidomain_server_app.exe \
+	--operation=get-certified \
+    --data_dir=./app2_data/ \
+	--measurement_file="multidomain_server_app.measurement" \
+	--policy_store_file=policy_store \
+    --policy_port=8121 \
+    --print_all=true
+
+# ---------------------------------------------------------------------------
+# Implemented in run_multidomain_simple_app_as_client_talk_to_Cert_Service()
+# ---------------------------------------------------------------------------
 # initialize client app
 cd $MULTIDOMAIN_EXAMPLE_DIR
-$MULTIDOMAIN_EXAMPLE_DIR/multidomain_client_app.exe --print_all=true \
-	--operation=cold-init --data_dir=./app1_data/ \
+
+$MULTIDOMAIN_EXAMPLE_DIR/multidomain_client_app.exe \
+	--operation=cold-init \
+    --data_dir=./app1_data/ \
 	--measurement_file="multidomain_client_app.measurement" \
 	--policy_store_file=policy_store \
-	--primary_policy_port=8122 --secondary_policy_port=8121
+	--primary_policy_port=8122 \
+    --secondary_policy_port=8121 \
+    --print_all=true
+
 # get client app certified
 cd $MULTIDOMAIN_EXAMPLE_DIR
-$MULTIDOMAIN_EXAMPLE_DIR/multidomain_client_app.exe --print_all=true \
-	--operation=get-certified --data_dir=./app1_data/ \
+
+$MULTIDOMAIN_EXAMPLE_DIR/multidomain_client_app.exe \
+	--operation=get-certified \
+    --data_dir=./app1_data/ \
 	--measurement_file="multidomain_client_app.measurement" \
 	--policy_store_file=policy_store \
-	--primary_policy_port=8122 --secondary_policy_port=8121 \
-        --secondary_cert_file=server_policy_cert_file.bin
+	--primary_policy_port=8122 \
+    --secondary_policy_port=8121 \
+    --secondary_cert_file=server_policy_cert_file.bin \
+    --print_all=true
 
-#run the app
+# ---------------------------------------------------------------------------
+# Implemented in run_app_by_name_as_server_offers_trusted_service()
+# ---------------------------------------------------------------------------
+# run the app
 cd $MULTIDOMAIN_EXAMPLE_DIR
-$MULTIDOMAIN_EXAMPLE_DIR/multidomain_server_app.exe --print_all=true \
+
+$MULTIDOMAIN_EXAMPLE_DIR/multidomain_server_app.exe \
 	--operation=run-app-as-server \
 	--data_dir=./app2_data/ \
 	--policy_store_file=policy_store \
-	--measurement_file="multidomain_server_app.measurement"
+	--measurement_file="multidomain_server_app.measurement" \
+    --print_all=true &
+
+sleep 10
+
+# ---------------------------------------------------------------------------
+# Implemented in run_app_by_name_as_client_offers_trusted_service()
+# ---------------------------------------------------------------------------
 cd $MULTIDOMAIN_EXAMPLE_DIR
-$MULTIDOMAIN_EXAMPLE_DIR/multidomain_client_app.exe --print_all=true \
+
+$MULTIDOMAIN_EXAMPLE_DIR/multidomain_client_app.exe \
 	--operation=run-app-as-client \
 	--data_dir=./app1_data/ \
 	--policy_store_file=policy_store \
-	--measurement_file="multidomain_client_app.measurement"
-
+	--measurement_file="multidomain_client_app.measurement" \
+    --print_all=true

--- a/sample_apps/simple_app/script
+++ b/sample_apps/simple_app/script
@@ -36,19 +36,24 @@ cd $EXAMPLE_DIR/provisioning
 #policyKey says platformKey is-trused-for-attestation
 $CERTIFIER_PROTOTYPE/utilities/make_unary_vse_clause.exe --key_subject=platform_key_file.bin \
   --verb="is-trusted-for-attestation" --output=ts1.bin
+
 $CERTIFIER_PROTOTYPE/utilities/make_indirect_vse_clause.exe --key_subject=policy_key_file.bin \
   --verb="says" --clause=ts1.bin --output=vse_policy1.bin
+
 $CERTIFIER_PROTOTYPE/utilities/make_signed_claim_from_vse_clause.exe --vse_file=vse_policy1.bin \
   --duration=9000 --private_key_file=policy_key_file.bin --output=signed_claim_1.bin
 
 # policy key says measurement is-trusted
 $CERTIFIER_PROTOTYPE/utilities/measurement_utility.exe --type=hash --input=../example_app.exe \
       --output=example_app.measurement
+
 $CERTIFIER_PROTOTYPE/utilities/make_unary_vse_clause.exe --key_subject="" \
   --measurement_subject=example_app.measurement --verb="is-trusted" \
   --output=ts2.bin
+
 $CERTIFIER_PROTOTYPE/utilities/make_indirect_vse_clause.exe --key_subject=policy_key_file.bin \
   --verb="says" --clause=ts2.bin --output=vse_policy2.bin
+
 $CERTIFIER_PROTOTYPE/utilities/make_signed_claim_from_vse_clause.exe \
   --vse_file=vse_policy2.bin --duration=9000 \
   --private_key_file=policy_key_file.bin --output=signed_claim_2.bin
@@ -63,9 +68,11 @@ $CERTIFIER_PROTOTYPE/utilities/make_unary_vse_clause.exe --key_subject=attest_ke
   --verb="is-trusted-for-attestation" --output=tsc1.bin
 $CERTIFIER_PROTOTYPE/utilities/make_indirect_vse_clause.exe --key_subject=platform_key_file.bin \
   --verb="says" --clause=tsc1.bin --output=vse_policy3.bin
+
 $CERTIFIER_PROTOTYPE/utilities/make_signed_claim_from_vse_clause.exe --vse_file=vse_policy3.bin \
   --duration=9000 --private_key_file=platform_key_file.bin \
   --output=platform_attest_endorsement.bin
+
 $CERTIFIER_PROTOTYPE/utilities/print_signed_claim.exe --input=platform_attest_endorsement.bin
 
 # provision service and apps
@@ -83,12 +90,16 @@ cp ./* $EXAMPLE_DIR/app2_data
 #compile the server
 cd $CERTIFIER_PROTOTYPE/certifier_service/graminelib
 make dummy
+
 cd $CERTIFIER_PROTOTYPE/certifier_service/oelib
 make dummy
+
 cd $CERTIFIER_PROTOTYPE/certifier_service/isletlib
 make dummy
+
 cd $CERTIFIER_PROTOTYPE/certifier_service/teelib
 make
+
 cd $CERTIFIER_PROTOTYPE/certifier_service
 go build simpleserver.go
 
@@ -102,6 +113,7 @@ cd $EXAMPLE_DIR
 $EXAMPLE_DIR/example_app.exe --print_all=true \
       --operation=cold-init --data_dir=./app1_data/ --measurement_file="example_app.measurement" \
       --policy_store_file=policy_store
+
 # get client app certified
 $EXAMPLE_DIR/example_app.exe --print_all=true \
       --operation=get-certified --data_dir=./app1_data/ --measurement_file="example_app.measurement" \
@@ -111,6 +123,7 @@ $EXAMPLE_DIR/example_app.exe --print_all=true \
 $EXAMPLE_DIR/example_app.exe --print_all=true \
       --operation=cold-init --data_dir=./app2_data/ --measurement_file="example_app.measurement" \
       --policy_store_file=policy_store
+
 # get server app certified
 $EXAMPLE_DIR/example_app.exe --print_all=true \
       --operation=get-certified --data_dir=./app2_data/ --measurement_file="example_app.measurement" \
@@ -120,7 +133,7 @@ $EXAMPLE_DIR/example_app.exe --print_all=true \
 cd $EXAMPLE_DIR
 $EXAMPLE_DIR/example_app.exe --print_all=true --operation=run-app-as-server --data_dir=./app2_data/ \
       --policy_store_file=policy_store --measurement_file="example_app.measurement"
+
 cd $EXAMPLE_DIR
 $EXAMPLE_DIR/example_app.exe --print_all=true --operation=run-app-as-client --data_dir=./app1_data/ \
       --policy_store_file=policy_store --measurement_file="example_app.measurement"
-


### PR DESCRIPTION
This commit extends run_example.sh to build-and-test the multidomain_simple_app sample program.

- Cleaned up `multidomain_simple_app/script` to be usable as a
  stand-alone script to run through the workflow.

- Refactored / changed driver `run_example.sh` script to
  handle the files needed to support multi-domain certification.
  Basically the steps in 'script' are re-implemented in the
  workflow of this shell script, so that this run script
  can be used as the single-driver script for multi-domain
  simple-app testing.

- Add `test-run_example-multidomain_simple_app()` to `test.sh` and
  invoke a new test-case from CI `build.yml`
