### PR TITLE
(#174) Initial support to parametrize public-key and symmetric-key algorithms.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,9 +96,26 @@ jobs:
         ./CI/scripts/test.sh test-run_example-simple_app
 
     #! -------------------------------------------------------------------------
+    - name: test-simple_app-with-crypto_algorithms
+      run: |
+        #! ---------------------------------------------------------------------
+        # Set this env-var to indicate that we are running this test-case
+        # from CI, where previous test case has already run 'setup'.
+        # So, in this test case, we will not re-do 'setup'.
+        FROM_CI_BUILD_YML=1 ./CI/scripts/test.sh test-simple_app-with-crypto_algorithms
+
+    #! -------------------------------------------------------------------------
     - name: test-run_example-simple_app_python
       run: |
         ./CI/scripts/test.sh test-run_example-simple_app_python
+
+    #! -------------------------------------------------------------------------
+    - name: test-simple_app_python-with-warm-restart
+      run: |
+        # Set this env-var to indicate that we are running this test-case
+        # from CI, where previous test case has already run 'setup'.
+        # So, in this test case, we will not re-do 'setup'.
+        FROM_CI_BUILD_YML=1 ./CI/scripts/test.sh test-simple_app_python-with-warm-restart
 
     #! -------------------------------------------------------------------------
     - name: test-build-and-setup-App-Service-and-simple_app_under_app_service

--- a/include/cc_useful.h
+++ b/include/cc_useful.h
@@ -40,6 +40,9 @@ typedef struct optlookup {
 #define DCL_OPTLOOKUP_TERM()                                                   \
   { .id = -1, .name = NULL }
 
+// Evaluate the size of an array of constants
+#define ARRAY_LEN(a) ((int)(sizeof(a) / sizeof((*a))))
+
 const char *optbyid(optlookup *opt, int id);
 
 #endif /* __CC_USEFUL_H__ */

--- a/include/certifier_algorithms.h
+++ b/include/certifier_algorithms.h
@@ -17,6 +17,8 @@
 #ifndef __CERTIFIER_ALGORITHMS_H__
 #define __CERTIFIER_ALGORITHMS_H__
 
+#include <vector>
+
 /*
  * Encryption algorithms supported.
  */
@@ -67,5 +69,11 @@ extern const char *Integrity_method_aes_256_cbc_hmac_sha256;
 extern const char *Integrity_method_aes_256_cbc_hmac_sha384;
 extern const char *Integrity_method_aes_256_gcm;
 extern const char *Integrity_method_hmac_sha256;
+
+extern std::vector<const char *> Enc_public_key_algorithms;
+extern std::vector<const char *> Enc_authenticated_symmetric_key_algorithms;
+
+extern const int Num_public_key_algorithms;
+extern const int Num_symmetric_key_algorithms;
 
 #endif  // __CERTIFIER_ALGORITHMS_H__

--- a/sample_apps/common/example_app.cc
+++ b/sample_apps/common/example_app.cc
@@ -30,6 +30,7 @@
 
 #include "certifier_framework.h"
 #include "certifier_utilities.h"
+#include "certifier_algorithms.h"
 
 using namespace certifier::framework;
 using namespace certifier::utilities;
@@ -54,6 +55,11 @@ DEFINE_string(platform_attest_endorsement,
               "platform endorsement of attest key");
 DEFINE_string(attest_key_file, "attest_key_file.bin", "attest key");
 DEFINE_string(measurement_file, "example_app.measurement", "measurement");
+
+DEFINE_string(public_key_alg, Enc_method_rsa_2048, "public key algorithm");
+DEFINE_string(auth_symmetric_key_alg,
+              Enc_method_aes_256_cbc_hmac_sha256,
+              "authenticated symmetric key algorithm");
 
 static string enclave_type("simulated-enclave");
 
@@ -283,28 +289,74 @@ int main(int an, char **av) {
   an = 1;
   ::testing::InitGoogleTest(&an, av);
 
+  // clang-format off
   if (FLAGS_operation == "") {
-    printf("%s --print_all=true|false --operation=op "
-           "--policy_host=policy-host-address "
-           "--policy_port=policy-host-port\n",
-           av[0]);
-    printf("\t --data_dir=-directory-for-app-data "
-           "--server_app_host=my-server-host-address "
-           "--server_app_port=server-host-port\n");
-    printf("\t --policy_cert_file=self-signed-policy-cert-file-name "
-           "--policy_store_file=policy-store-file-name\n");
+    printf("                                                                            (Defaults)\n");
+    printf("%s --operation=<op>                                        ; %s", av[0], "(See below)");
+    printf("\n\
+                  --policy_host=policy-host-address                       ; %s\n\
+                  --policy_port=policy-host-port                          ; %d\n\
+                  --server_app_host=my-server-host-address                ; %s\n\
+                  --server_app_port=my-server-port-number                 ; %d\n\
+                  --data_dir=-directory-for-app-data                      ; %s\n\
+                  --policy_cert_file=self-signed-policy-cert-file-name    ; \n\
+                  --policy_store_file=policy-store-file-name              ; %s\n\
+                  --print_all=true|false",
+                  FLAGS_policy_host.c_str(),
+                  FLAGS_policy_port,
+                  FLAGS_server_app_host.c_str(),
+                  FLAGS_server_app_port,
+                  FLAGS_data_dir.c_str(),
+                  FLAGS_policy_store_file.c_str());
+#ifdef SIMPLE_APP
+    printf("\n\
+                  --platform_file_name=platform-cert-bin-file-name        ; %s\n\
+                  --platform_attest_endorsement=endorsement-bin-file-name ; %s\n\
+                  --measurement_file=measurement-bin-file-name            ; %s\n\
+                  --attest_key_file=attest-key-bin-file-name              ; %s\n",
+                  FLAGS_platform_file_name.c_str(),
+                  FLAGS_platform_attest_endorsement.c_str(),
+                  FLAGS_measurement_file.c_str(),
+                  FLAGS_attest_key_file.c_str());
+#endif  // SIMPLE_APP
+
 #ifdef SEV_SIMPLE_APP
-    printf("\t --ark_cert_file=./service/milan_ark_cert.der "
-           "--ask_cert_file=./service/milan_ask_cert.der "
-           "--vcek_cert_file=./service/milan_vcek_cert.der\n");
+    printf("\n\
+                  --ark_cert_file=./service/milan_ark_cert.der \n\
+                  --ask_cert_file=./service/milan_ask_cert.der \n\
+                  --vcek_cert_file=./service/milan_vcek_cert.der ");
 #endif  // SEV_SIMPLE_APP
 #ifdef GRAMINE_SIMPLE_APP
-    printf("\t --gramine_cert_file=sgx.cert.der\n");
+    printf("\n\
+                  --gramine_cert_file=sgx.cert.der");
 #endif  // GRAMINE_SIMPLE_APP
-    printf("Operations are: cold-init, get-certified, "
+    printf("\n\nOperations are: cold-init, get-certified, "
            "run-app-as-client, run-app-as-server\n");
+
+#ifdef SIMPLE_APP
+
+    // clang-format off
+    printf("\nFor the simple_app, you can additionally drive 'cold-init' with different pairs of:\n");
+    printf("\n\
+    --public_key_alg=public-key-algorigthm-name                          : %s\n\
+    --auth_symmetric_key_alg=authenticated-symmetric-key-algorigthm-name : %s\n",
+            FLAGS_public_key_alg.c_str(),
+            FLAGS_auth_symmetric_key_alg.c_str());
+    // clang-format on
+
+    printf("\nPublic-key algorithms supported:\n");
+    for (int i = 0; i < Num_public_key_algorithms; i++) {
+      printf("  %s\n", Enc_public_key_algorithms[i]);
+    }
+    printf("\nSymmetric-key algorithms supported:\n");
+    for (int i = 0; i < Num_symmetric_key_algorithms; i++) {
+      printf("  %s\n", Enc_authenticated_symmetric_key_algorithms[i]);
+    }
+
+#endif  // SIMPLE_APP
     return 0;
   }
+  // clang-format on
 
   SSL_library_init();
   string purpose("authentication");
@@ -343,15 +395,35 @@ int main(int an, char **av) {
     params = nullptr;
   }
 
-  // Standard algorithms for the enclave
+  // clang-format off
+
+  // Use specified algorithms for the enclave            Defaults:
+#ifdef SIMPLE_APP
+  // We support --public_key_alg and --auth_symmetric_key_alg only for simple_app
+  // (as a way to exercise tests w/ different pairs of algorithms).
+  string public_key_alg(FLAGS_public_key_alg);                  // Enc_method_rsa_2048
+  string auth_symmetric_key_alg(FLAGS_auth_symmetric_key_alg);  // Enc_method_aes_256_cbc_hmac_sha256
+  if (FLAGS_print_all) {
+      printf("measurement file='%s', ", FLAGS_measurement_file.c_str());
+  }
+#else
   string public_key_alg(Enc_method_rsa_2048);
-  string symmetric_key_alg(Enc_method_aes_256_cbc_hmac_sha256);
+  string auth_symmetric_key_alg(Enc_method_aes_256_cbc_hmac_sha256);
+#endif  // SIMPLE_APP
+
+  // clang-format on
+
+  if (FLAGS_print_all && (FLAGS_operation == "cold-init")) {
+    printf("public_key_alg='%s', authenticated_symmetric_key_alg='%s\n",
+           public_key_alg.c_str(),
+           auth_symmetric_key_alg.c_str());
+  }
 
   // Carry out operation
   int ret = 0;
   if (FLAGS_operation == "cold-init") {
     if (!trust_mgr->cold_init(public_key_alg,
-                              symmetric_key_alg,
+                              auth_symmetric_key_alg,
                               "simple-app-home_domain",
                               FLAGS_policy_host,
                               FLAGS_policy_port,

--- a/sample_apps/simple_app/example_app.mak
+++ b/sample_apps/simple_app/example_app.mak
@@ -114,3 +114,7 @@ $(O)/cc_helpers.o: $(S)/cc_helpers.cc $(I)/certifier.h $(US)/certifier.pb.cc
 $(O)/cc_useful.o: $(S)/cc_useful.cc $(I)/cc_useful.h
 	@echo "\ncompiling $<"
 	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<
+
+$(O)/certifier_algorithms.o: $(S)/certifier_algorithms.cc
+	@echo "\ncompiling $<"
+	$(CC) $(CFLAGS) -o $(@D)/$@ -c $<

--- a/src/cc_helpers.cc
+++ b/src/cc_helpers.cc
@@ -1077,7 +1077,7 @@ bool certifier::framework::cc_trust_manager::generate_symmetric_key(
   if (cc_symmetric_key_initialized_ && !regen)
     return true;
 
-  // Make up symmetric keys (e.g.-for sealing)for app
+  // Make up symmetric keys (e.g.-for sealing) for app
   int num_key_bytes;
   if (symmetric_key_algorithm_ == Enc_method_aes_256_cbc_hmac_sha256
       || symmetric_key_algorithm_ == Enc_method_aes_256_cbc_hmac_sha384
@@ -1186,9 +1186,10 @@ bool certifier::framework::cc_trust_manager::generate_auth_key(bool regen) {
       return false;
     }
   } else {
-    printf("%s() error, line %d, Unsupported public key algorithm\n",
+    printf("%s() error, line %d, Unsupported public key algorithm: '%s'\n",
            __func__,
-           __LINE__);
+           __LINE__,
+           public_key_algorithm_.c_str());
     return false;
   }
 

--- a/src/certifier.cc
+++ b/src/certifier.cc
@@ -956,10 +956,11 @@ bool certifier::framework::unprotect_blob(const string &enclave_type,
   }
 
   if (key->key_type() != Enc_method_aes_256_cbc_hmac_sha256) {
-    printf(
-        "%s() error, line %d, unprotect_blob, unsupported encryption scheme\n",
-        __func__,
-        __LINE__);
+    printf("%s() error, line %d, unprotect_blob, unsupported encryption "
+           "scheme: '%s'\n",
+           __func__,
+           __LINE__,
+           key->key_type().c_str());
     return false;
   }
   if (!key->has_secret_key_bits()) {

--- a/src/certifier_algorithms.cc
+++ b/src/certifier_algorithms.cc
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "cc_useful.h"
 
 // clang-format off
 
@@ -20,12 +21,15 @@
  * Encryption algorithms supported.
  */
 const char * Enc_method_aes_128                   = "aes-128";
-const char * Enc_method_aes_128_cbc_hmac_sha256   = "aes-128-cbc-hmac-sha256";
 const char * Enc_method_aes_256                   = "aes-256";
 const char * Enc_method_aes_256_cbc               = "aes-256-cbc";
+
+// Authenticated symmetric-key algorithms
+const char * Enc_method_aes_128_cbc_hmac_sha256   = "aes-128-cbc-hmac-sha256";
 const char * Enc_method_aes_256_cbc_hmac_sha256   = "aes-256-cbc-hmac-sha256";
 const char * Enc_method_aes_256_cbc_hmac_sha384   = "aes-256-cbc-hmac-sha384";
 const char * Enc_method_aes_256_gcm               = "aes-256-gcm";
+
 const char * Enc_method_ecc_256_private           = "ecc-256-private";
 const char * Enc_method_ecc_256_public            = "ecc-256-public";
 const char * Enc_method_ecc_256_sha256_pkcs_sign  = "ecc-256-sha256-pkcs-sign";
@@ -49,7 +53,26 @@ const char * Enc_method_rsa_4096                  = "rsa-4096";
 const char * Enc_method_rsa_4096_private          = "rsa-4096-private";
 const char * Enc_method_rsa_4096_public           = "rsa-4096-public";
 const char * Enc_method_rsa_4096_sha384_pkcs_sign = "rsa-4096-sha384-pkcs-sign";
- 
+
+std::vector<const char *> Enc_public_key_algorithms =
+                    {   Enc_method_rsa_2048
+                      , Enc_method_rsa_3072
+                      , Enc_method_rsa_4096
+                      , Enc_method_ecc_384
+                    };
+
+const int Num_public_key_algorithms = Enc_public_key_algorithms.size();
+
+// Names of Authenticated symmetric-key algorithms
+std::vector<const char *> Enc_authenticated_symmetric_key_algorithms =
+                    {   Enc_method_aes_128_cbc_hmac_sha256
+                      , Enc_method_aes_256_cbc_hmac_sha256
+                      , Enc_method_aes_256_cbc_hmac_sha384
+                      , Enc_method_aes_256_gcm
+                    };
+
+const int Num_symmetric_key_algorithms = Enc_authenticated_symmetric_key_algorithms.size();
+
 /*
  * Cryptographic hash algorithms supported.
  */
@@ -57,7 +80,7 @@ const char * Digest_method_sha256  = "sha256";
 const char * Digest_method_sha_256 = "sha-256";
 const char * Digest_method_sha_384 = "sha-384";
 const char * Digest_method_sha_512 = "sha-512";
- 
+
 /*
  * Integrity protection algorithms, used in conjunction with specific encryption algorithms.
  */


### PR DESCRIPTION
This commit lays down the plumbing to parametrize the names of the public-key and symmetric-key algorithms that will be used by the simple_app. Currently, these are hard-coded to 'Enc_method_rsa_2048' and 'Enc_method_aes_256_cbc_hmac_sha256', respectively.

This commit now supports `--public_key_alg` and `--symmetric_key_alg` flags that can be supplied to the `simple_app/example_app.exe` program.

An initial list of `char *Enc_public_key_algorithms[]` and `char *Enc_symmetric_key_algorithms[]` has been created in `src/certifier_algorithms.cc`. The idea is that we can run test-executions choosing pairs of these algorithms to drive the simple_app.

## High-level changes:

- Support --public_key_alg and --symmetric_key_alg flags which can be supplied [only] to the simple_app/example_app.exe program.

- An initial list of char *Enc_public_key_algorithms[] and
  char *Enc_symmetric_key_algorithms[] has been created in src/certifier_algorithms.cc

- run_example.sh:
  - Refactor methods implementing simple_app_python tests into their own functions as argument-parsing is different for C++  v/s Python apps. (New args added with this work are n/a for the Python simple_app.)

  - Add new test-method run_test-crypto_algorithms(), which will exercise the sub-steps needed to run simple_app with different  pairs of crypto algorithms.

- CI/test.sh, build.yml: Add test-simple_app-with-crypto_algorithms, which will invoke said test case. This invokes
   run_test-crypto_algorithms() named earlier.

   - Pulled-out testing of simple_app_python with 'warm-restart'  functionality into its own test-case invocation. 
   -   Adds test-simple_app_python-with-warm-restart().

- Cleaned-up some dependency of 'setup' step for simple_apps to reduce CI test run-times.